### PR TITLE
Fix issue with esbuild class transform

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -94,16 +94,16 @@ export class Kysely<DB> extends QueryCreator<DB> {
       )
 
       superProps = { executor, parseContext }
-      props = freeze({
+      props = {
         config: args,
         executor,
         dialect,
         driver: runtimeDriver,
         parseContext,
-      })
+      }
     }
     super(superProps);
-    this.#props = props;
+    this.#props = freeze(props);
   }
 
   /**

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -70,9 +70,10 @@ export class Kysely<DB> extends QueryCreator<DB> {
   constructor(args: KyselyConfig)
   constructor(args: KyselyProps)
   constructor(args: KyselyConfig | KyselyProps) {
+    let _super, _props;
     if (isKyselyProps(args)) {
-      super({ executor: args.executor, parseContext: args.parseContext })
-      this.#props = freeze({ ...args })
+      _super = { executor: args.executor, parseContext: args.parseContext }
+      _props = freeze({ ...args })
     } else {
       const dialect = args.dialect
 
@@ -91,9 +92,8 @@ export class Kysely<DB> extends QueryCreator<DB> {
         args.plugins ?? []
       )
 
-      super({ executor, parseContext })
-
-      this.#props = freeze({
+      _super = { executor, parseContext }
+      _props = freeze({
         config: args,
         executor,
         dialect,
@@ -101,6 +101,8 @@ export class Kysely<DB> extends QueryCreator<DB> {
         parseContext,
       })
     }
+    super(_super);
+    this.#props = _props;
   }
 
   /**

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -3,7 +3,7 @@ import { SchemaModule } from './schema/schema.js'
 import { DynamicModule } from './dynamic/dynamic.js'
 import { DefaultConnectionProvider } from './driver/default-connection-provider.js'
 import { QueryExecutor } from './query-executor/query-executor.js'
-import { QueryCreator } from './query-creator.js'
+import { QueryCreator, QueryCreatorProps } from './query-creator.js'
 import { KyselyPlugin } from './plugin/kysely-plugin.js'
 import { DefaultQueryExecutor } from './query-executor/default-query-executor.js'
 import { DatabaseIntrospector } from './dialect/database-introspector.js'
@@ -70,10 +70,11 @@ export class Kysely<DB> extends QueryCreator<DB> {
   constructor(args: KyselyConfig)
   constructor(args: KyselyProps)
   constructor(args: KyselyConfig | KyselyProps) {
-    let _super, _props;
+    let superProps: QueryCreatorProps;
+    let props: KyselyProps;
     if (isKyselyProps(args)) {
-      _super = { executor: args.executor, parseContext: args.parseContext }
-      _props = freeze({ ...args })
+      superProps = { executor: args.executor, parseContext: args.parseContext }
+      props = { ...args }
     } else {
       const dialect = args.dialect
 
@@ -92,8 +93,8 @@ export class Kysely<DB> extends QueryCreator<DB> {
         args.plugins ?? []
       )
 
-      _super = { executor, parseContext }
-      _props = freeze({
+      superProps = { executor, parseContext }
+      props = freeze({
         config: args,
         executor,
         dialect,
@@ -101,8 +102,8 @@ export class Kysely<DB> extends QueryCreator<DB> {
         parseContext,
       })
     }
-    super(_super);
-    this.#props = _props;
+    super(superProps);
+    this.#props = props;
   }
 
   /**


### PR DESCRIPTION
If you set `this.#props` and call `super()` in both `if` blocks, when using esbuild it will transform them and put the `this` call first causing runtime failure.