### PR TITLE
docs: fix typo concate -> concat

### DIFF
--- a/src/raw-builder/sql.ts
+++ b/src/raw-builder/sql.ts
@@ -300,7 +300,7 @@ export interface Sql {
  * from "person"
  * where birthdate between $1 and $2
  * and "nicknames" @> ARRAY[$3, $4, $5, $6, $7, $8, $9, $10]
- * order by concate(first_name, ' ', last_name)
+ * order by concat(first_name, ' ', last_name)
  * ```
  *
  * SQL snippets can be executed by calling the `execute` method and passing a `Kysely`


### PR DESCRIPTION
I didn't change it in docs/modules.html, I assume it gets generated automatically...somewhere. When I ran docs:build around 200 files changed so that didn't see mright either