### PR TITLE
add binded sql to kysely instance

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -20,6 +20,7 @@ import { preventAwait } from './util/prevent-await.js'
 import { FunctionBuilder } from './query-builder/function-builder.js'
 import { Log, LogConfig } from './util/log.js'
 import { QueryExecutorProvider } from './query-executor/query-executor-provider.js'
+import { getSqlInstance, Sql } from './raw-builder/sql.js'
 
 /**
  * The main Kysely class.
@@ -66,9 +67,9 @@ import { QueryExecutorProvider } from './query-executor/query-executor-provider.
  */
 export class Kysely<DB>
   extends QueryCreator<DB>
-  implements QueryExecutorProvider
-{
+  implements QueryExecutorProvider {
   readonly #props: KyselyProps
+  readonly #sql: Sql<true>
 
   constructor(args: KyselyConfig)
   constructor(args: KyselyProps)
@@ -108,6 +109,11 @@ export class Kysely<DB>
 
     super(superProps)
     this.#props = freeze(props)
+    this.#sql = getSqlInstance(this.getExecutor())
+  }
+
+  get sql() {
+    return this.#sql;
   }
 
   /**
@@ -450,7 +456,7 @@ export class ConnectionBuilder<DB> {
   }
 }
 
-interface ConnectionBuilderProps extends KyselyProps {}
+interface ConnectionBuilderProps extends KyselyProps { }
 
 preventAwait(
   ConnectionBuilder,

--- a/test/node/src/raw-query.test.ts
+++ b/test/node/src/raw-query.test.ts
@@ -103,5 +103,13 @@ for (const dialect of BUILT_IN_DIALECTS) {
         expect(result.rows).to.eql([])
       })
     }
+
+    it('should allow using binded instance', async () => {
+      const result = await ctx.db.sql<{ result: string }>`select 'foo' result`.execute()
+
+      expect(result.insertId).to.equal(undefined)
+      expect(result.numUpdatedOrDeletedRows).to.equal(undefined)
+      expect(result.rows).to.eql([{ result: 'foo' }])
+    })
   })
 }

--- a/test/typings/index.test-d.ts
+++ b/test/typings/index.test-d.ts
@@ -693,8 +693,8 @@ async function testReturning(db: Kysely<Database>) {
 
   expectType<
     | {
-        id: number
-      }
+      id: number
+    }
     | undefined
   >(r1)
 
@@ -1049,4 +1049,15 @@ async function testGenericSelect<T extends keyof Database>(
 
 async function testGenericUpdate(db: Kysely<Database>, table: 'pet' | 'movie') {
   await db.updateTable(table).set({ id: '123' }).execute()
+}
+
+async function testSql(db: Kysely<Database>) {
+  // Allow calling execute without providing executor on binded instance
+  db.sql`select 1`.execute()
+
+  // Doesn't allow passing executor on binded instance
+  expectError(db.sql`select 1`.execute(db.getExecutor()))
+
+  // Requires executor on non-binded instance
+  expectError(sql`select 1`.execute())
 }


### PR DESCRIPTION
Basically a convenience property to not have to import `sql` separately nor specifying any argument on `execute` method.

Please let me know if there's a way to get rid of the cast in

```ts
// src/raw-builder/raw-builder.ts [line 34]
this.#executor = executor as (B extends true ? QueryExecutor : undefined)
```

and the redundant type guard on 

```ts
// src/raw-builder/raw-builder.ts [line 133]
if (executor === undefined) {
  throw new Error('Unreachable code')
}
```