### PR TITLE
Run CI in Node 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         deno-version: [1.17.x]
 
     steps:


### PR DESCRIPTION
Node 18 is now the "current" Node version. Add it to CI version matrix.