### PR TITLE
Add LIMIT clause when executeTakeFirst()

### DIFF
--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1336,7 +1336,7 @@ export class SelectQueryBuilder<DB, TB extends keyof DB, O>
    * the query returned no result.
    */
   async executeTakeFirst(): Promise<SingleResultType<O>> {
-    const [result] = await this.execute()
+    const [result] = await this.limit(1).execute()
     return result as SingleResultType<O>
   }
 


### PR DESCRIPTION
Hello to everyone developing Kysely!

I have one suggestion.

I am using `executeTakeFirst()` when trying to retrieve just one record. The current function still retrieves the desired record, but I wanted to add a LIMIT clause for performance reasons.