### PR TITLE
operation-node-transformer fixed:

### DIFF
--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -350,6 +350,8 @@ export class OperationNodeTransformer {
       where: this.transformNode(node.where),
       returning: this.transformNode(node.returning),
       with: this.transformNode(node.with),
+      orderBy:  this.transformNode(node.orderBy),
+      limit: this.transformNode(node.limit),
     }
   }
 
@@ -619,6 +621,7 @@ export class OperationNodeTransformer {
     return {
       kind: 'CreateSchemaNode',
       schema: this.transformNode(node.schema),
+      ifNotExists: node.ifNotExists,
     }
   }
 

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -1060,6 +1060,108 @@ for (const dialect of BUILT_IN_DIALECTS) {
       })
     })
 
+    describe('create schema', () => {
+      if (dialect === 'postgres' || dialect === 'mysql') {
+        beforeEach(cleanup)
+        afterEach(cleanup)
+
+        it('should create a schema', async () => {
+          const builder = ctx.db.schema
+            .createSchema('pets')
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `create schema "pets"`,
+              parameters: [],
+            },
+            mysql: {
+              sql: "create schema `pets`",
+              parameters: [],
+            },
+            sqlite: NOT_SUPPORTED
+          })
+
+          await builder.execute()
+        })
+
+        it('should create a schema if not exists', async () => {
+          const builder = ctx.db.schema
+            .createSchema('pets')
+            .ifNotExists()
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `create schema if not exists "pets"`,
+              parameters: [],
+            },
+            mysql: {
+              sql: "create schema if not exists `pets`",
+              parameters: [],
+            },
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
+      }
+
+      async function cleanup() {
+        await ctx.db.schema.dropSchema('pets').ifExists().execute()
+      }
+    })
+
+    describe('drop schema', () => {
+      if (dialect === 'postgres' || dialect === 'mysql') {
+        beforeEach(cleanup)
+        afterEach(cleanup)
+
+        it('should create a schema', async () => {
+          await ctx.db.schema.createSchema('pets').execute();
+
+          const builder = ctx.db.schema
+            .dropSchema('pets')
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `drop schema "pets"`,
+              parameters: [],
+            },
+            mysql: {
+              sql: "drop schema `pets`",
+              parameters: [],
+            },
+            sqlite: NOT_SUPPORTED
+          })
+
+          await builder.execute()
+        })
+
+        it('should drop a schema if exists', async () => {
+          const builder = ctx.db.schema
+            .dropSchema('pets')
+            .ifExists()
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `drop schema if exists "pets"`,
+              parameters: [],
+            },
+            mysql: {
+              sql: "drop schema if exists `pets`",
+              parameters: [],
+            },
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
+      }
+
+      async function cleanup() {
+        await ctx.db.schema.dropSchema('pets').ifExists().execute()
+      }
+    })
+
     describe('alter table', () => {
       beforeEach(async () => {
         await ctx.db.schema


### PR DESCRIPTION
I was facing a bug when I was using createScheme. I miss the "if not exists" part of compiled query even I use ifNotExists method of CreateSchemaBuilder.

Then I do following fixes: 

- added copy of ifNotExists property in transformCreateSchema
- added copy of orderBy and limit properties in transformDeleteQuery (because of `TEST_TRANSFORMER=1 npm run test` fails)

I've added create/drop schema tests too to prevent regression of this bug in future. Have to be tested with `TEST_TRANSFORMER` environment variable set of course.

Correct me if I'm wrong, SQLLite doesn't support schemas as other DBs do, right? I omit schema tests for it.