### PR TITLE
adding `between` & `not between` operators.

### DIFF
--- a/scripts/check-esm-imports.js
+++ b/scripts/check-esm-imports.js
@@ -40,11 +40,11 @@ function readLines(filePath) {
 }
 
 function isLocalImport(row) {
-  return row.includes("from '.") || row.includes('from ".')
+  return row.match(/from ['"]\./)
 }
 
 function isDotJsImport(row) {
-  return row.endsWith(".js'")
+  return row.match(/.js['"][\n\t\s]*$/)
 }
 
 checkDir(path.join(__dirname, '..', 'src'))

--- a/src/operation-node/operator-node.ts
+++ b/src/operation-node/operator-node.ts
@@ -39,6 +39,8 @@ export const OPERATORS = [
   '@@@',
   '!!',
   '<->',
+  'between',
+  'not between'
 ] as const
 
 export type Operator = ArrayItemType<typeof OPERATORS>

--- a/test/node/src/execute.test.ts
+++ b/test/node/src/execute.test.ts
@@ -28,6 +28,7 @@ for (const dialect of BUILT_IN_DIALECTS) {
             { name: 'Catto 1', species: 'cat' },
             { name: 'Catto 2', species: 'cat' },
           ],
+          age: 17,
         },
         {
           first_name: 'Arnold',
@@ -37,12 +38,14 @@ for (const dialect of BUILT_IN_DIALECTS) {
             { name: 'Doggo 1', species: 'dog' },
             { name: 'Doggo 2', species: 'dog' },
           ],
+          age: 45,
         },
         {
           first_name: 'Sylvester',
           last_name: 'Stallone',
           gender: 'male',
           pets: [{ name: 'Hammo 1', species: 'hamster' }],
+          age: 12,
         },
       ])
     })

--- a/test/node/src/having.test.ts
+++ b/test/node/src/having.test.ts
@@ -29,6 +29,7 @@ for (const dialect of BUILT_IN_DIALECTS) {
             { name: 'Catto 1', species: 'cat' },
             { name: 'Catto 2', species: 'cat' },
           ],
+          age: 17,
         },
         {
           first_name: 'Arnold',
@@ -38,12 +39,14 @@ for (const dialect of BUILT_IN_DIALECTS) {
             { name: 'Doggo 1', species: 'dog' },
             { name: 'Doggo 2', species: 'dog' },
           ],
+          age: 45,
         },
         {
           first_name: 'Sylvester',
           last_name: 'Stallone',
           gender: 'male',
           pets: [{ name: 'Hammo 1', species: 'hamster' }],
+          age: 12,
         },
       ])
     })

--- a/test/node/src/join.test.ts
+++ b/test/node/src/join.test.ts
@@ -33,18 +33,21 @@ for (const dialect of BUILT_IN_DIALECTS) {
               toys: [{ name: 'spool', price: 10 }],
             },
           ],
+          age: 17,
         },
         {
           first_name: 'Arnold',
           last_name: 'Schwarzenegger',
           gender: 'male',
           pets: [{ name: 'Doggo', species: 'dog' }],
+          age: 45,
         },
         {
           first_name: 'Sylvester',
           last_name: 'Stallone',
           gender: 'male',
           pets: [{ name: 'Hammo', species: 'hamster' }],
+          age: 12,
         },
       ])
     })

--- a/test/node/src/select.test.ts
+++ b/test/node/src/select.test.ts
@@ -33,18 +33,21 @@ for (const dialect of BUILT_IN_DIALECTS) {
               toys: [{ name: 'spool', price: 10 }],
             },
           ],
+          age: 17,
         },
         {
           first_name: 'Arnold',
           last_name: 'Schwarzenegger',
           gender: 'male',
           pets: [{ name: 'Doggo', species: 'dog' }],
+          age: 45,
         },
         {
           first_name: 'Sylvester',
           last_name: 'Stallone',
           gender: 'male',
           pets: [{ name: 'Hammo', species: 'hamster' }],
+          age: 12,
         },
       ])
     })

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -33,6 +33,7 @@ export interface Person {
   first_name: string | null
   last_name: string | null
   gender: 'male' | 'female' | 'other'
+  age: number | null
 }
 
 export interface Pet {
@@ -188,18 +189,21 @@ export async function insertDefaultDataSet(ctx: TestContext): Promise<void> {
       last_name: 'Aniston',
       gender: 'female',
       pets: [{ name: 'Catto', species: 'cat' }],
+      age: 17,
     },
     {
       first_name: 'Arnold',
       last_name: 'Schwarzenegger',
       gender: 'male',
       pets: [{ name: 'Doggo', species: 'dog' }],
+      age: 45,
     },
     {
       first_name: 'Sylvester',
       last_name: 'Stallone',
       gender: 'male',
       pets: [{ name: 'Hammo', species: 'hamster' }],
+      age: 12,
     },
   ])
 }
@@ -235,6 +239,7 @@ async function createDatabase(
     .addColumn('first_name', 'varchar(255)')
     .addColumn('last_name', 'varchar(255)')
     .addColumn('gender', 'varchar(50)', (col) => col.notNull())
+    .addColumn('age', 'integer')
     .execute()
 
   await createTableWithId(db.schema, dialect, 'pet')

--- a/test/node/src/where.test.ts
+++ b/test/node/src/where.test.ts
@@ -509,6 +509,45 @@ for (const dialect of BUILT_IN_DIALECTS) {
 
         await query.execute()
       })
+
+      it('a `where between` query', async () => {
+        const query = ctx.db
+          .selectFrom('person')
+          .selectAll()
+          .where('age', 'between', [0, 18])
+          .orderBy('first_name', 'desc')
+
+        testSql(query, dialect, {
+          postgres: {
+            sql: 'select * from "person" where "age" between $1 and $2 order by "first_name" desc',
+            parameters: [0, 18],
+          },
+          mysql: {
+            sql: 'select * from `person` where `age` between ? and ? order by `first_name` desc',
+            parameters: [0, 18],
+          },
+          sqlite: {
+            sql: 'select * from "person" where "age" between ? and ? order by "first_name" desc',
+            parameters: [0, 18],
+          },
+        })
+
+        const persons = await query.execute()
+        expect(persons).to.have.length(2)
+        expect(persons[0].first_name).to.equal('Sylvester')
+        expect(persons).to.containSubset([
+          {
+            first_name: 'Sylvester',
+            last_name: 'Stallone',
+            gender: 'male',
+          },
+          {
+            first_name: 'Jennifer',
+            last_name: 'Aniston',
+            gender: 'female',
+          },
+        ])
+      })
     })
 
     describe('orWhere', () => {


### PR DESCRIPTION
`BETWEEN ... AND ...` and `NOT BETWEEN ... AND ...` comparison operators exist in all three base dialects ([postgresql](https://www.postgresql.org/docs/current/functions-comparison.html#FUNCTIONS-COMPARISON-PRED-TABLE), [mysql](https://dev.mysql.com/doc/refman/8.0/en/comparison-operators.html#operator_between), [sqlite](https://sqlite.org/lang_expr.html#the_between_operator)).

Current implementation is not ideal as it forces consumers to either:

* Write `.where`/`.having` for `>=` and `<=` separately. 

   ```typescript
   db.selectFrom('person').where('age', '>=', 0).where('age', '<=', 18)
   ```

   This can be tedious and might force wrappers if you're, for example, constantly querying by date range. tldr not great DX.

* Write a raw query using `sql` component as follows:

   ```typescript
   db.selectFrom('person').where(sql`${sql.ref('age')} between ${0} and ${18}`)
   ```
  This can be complex to some consumers (we should shorten the learning curve), and makes the code less readable.

I believe a lot of people intuitively try to `where between` when picking up `kysely` and are surprised they don't have it in their autocomplete menu. Especially people coming from `knex`, where [this](http://knexjs.org/guide/query-builder.html#wherebetween) option exists.

---

tldr

This pull request basically adds the following:

```typescript
await db.selectFrom('person').where('age', 'between', [0, 18]).selectAll()
```

that compiles to something like:

```typescript
{
    sql: 'select * from `person` where `age` between ? and ?'
    parameters: [0, 18]
}
```