### PR TITLE
adding fractional seconds precision to `db.schema.createTable(name).addColumn(...)`.

### DIFF
--- a/src/operation-node/data-type-node.ts
+++ b/src/operation-node/data-type-node.ts
@@ -22,10 +22,15 @@ export type ColumnDataType =
   | 'binary'
   | 'date'
   | 'datetime'
+  | `datetime(${number})`
   | 'time'
+  | `time(${number})`
   | 'timetz'
+  | `timetz(${number})`
   | 'timestamp'
+  | `timestamp(${number})`
   | 'timestamptz'
+  | `timestamptz(${number})`
   | 'serial'
   | 'bigserial'
   | 'uuid'

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -66,6 +66,11 @@ for (const dialect of BUILT_IN_DIALECTS) {
                 .stored()
                 .notNull()
             )
+            .addColumn('t', 'time(6)')
+            .addColumn('u', 'timestamp(6)', (col) =>
+              col.notNull().defaultTo(sql`current_timestamp`)
+            )
+            .addColumn('v', 'timestamptz(6)')
 
           testSql(builder, dialect, {
             postgres: {
@@ -89,7 +94,10 @@ for (const dialect of BUILT_IN_DIALECTS) {
                 '"p" int2,',
                 '"q" int4,',
                 '"r" int8,',
-                '"s" double precision generated always as (f + g) stored not null)',
+                '"s" double precision generated always as (f + g) stored not null,',
+                '"t" time(6),',
+                '"u" timestamp(6) default current_timestamp not null,',
+                '"v" timestamptz(6))',
               ],
               parameters: [],
             },
@@ -154,6 +162,11 @@ for (const dialect of BUILT_IN_DIALECTS) {
                 .stored()
                 .notNull()
             )
+            .addColumn('q', 'time(6)')
+            .addColumn('r', 'datetime(6)')
+            .addColumn('s', 'timestamp(6)', (col) =>
+              col.notNull().defaultTo(sql`current_timestamp(6)`)
+            )
 
           testSql(builder, dialect, {
             mysql: {
@@ -174,7 +187,10 @@ for (const dialect of BUILT_IN_DIALECTS) {
                 '`m` time,',
                 '`n` datetime,',
                 '`o` timestamp,',
-                '`p` double precision generated always as (e + f) stored not null)',
+                '`p` double precision generated always as (e + f) stored not null,',
+                '`q` time(6),',
+                '`r` datetime(6),',
+                '`s` timestamp(6) default current_timestamp(6) not null)',
               ],
               parameters: [],
             },


### PR DESCRIPTION
Fractional Seconds Precision (e.g. `timestamp(n)`) is supported in both [Postgresql](https://www.postgresql.org/docs/current/datatype-datetime.html) and [Mysql](https://dev.mysql.com/doc/refman/8.0/en/fractional-seconds.html) dialects, documented as optional *p* or *fsp* parameter.

Currently, kysely supports date and time data types, without stating *fsp*. Consumers are forced to use raw sql to achieve more accurate columns when creating tables using the schema module.

Database defaults and behavior on insert/update in case *fsp* is omitted are not good enough.

> A value of 0 signifies that there is no fractional part. If omitted, the default precision is 0. 
> 
> Inserting a TIME, DATE, or TIMESTAMP value with a fractional seconds part into a column of the same type but having fewer fractional digits results in **rounding**.  -mysql docs

Millisecond accuracy (at the very least) is crucial to some workflows (e.g. analytics, financial, event-driven systems).

----

tldr

This PR basically adds the ability to add date time columns as `data_type(fsp)`:
```typescript
`datetime(${number})` | `time(${number})` | `timetz(${number})` | `timestamp(${number})` | `timestamptz(${number})`
```