### PR TITLE
adding `db.schema.createTable(name).modifyFront(modifier)` & `db.schema.createTable(name).modifyEnd(modifier)`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kysely",
-  "version": "0.19.10",
+  "version": "0.19.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kysely",
-      "version": "0.19.10",
+      "version": "0.19.11",
       "license": "MIT",
       "devDependencies": {
         "@types/better-sqlite3": "^7.5.0",

--- a/src/operation-node/create-table-node.ts
+++ b/src/operation-node/create-table-node.ts
@@ -4,13 +4,19 @@ import { TableNode } from './table-node.js'
 import { ConstraintNode } from './constraint-node.js'
 import { ColumnDefinitionNode } from './column-definition-node.js'
 import { ArrayItemType } from '../util/type-utils.js'
+import { RawNode } from './raw-node.js'
 
 export const ON_COMMIT_ACTIONS = ['preserve rows', 'delete rows', 'drop']
 export type OnCommitAction = ArrayItemType<typeof ON_COMMIT_ACTIONS>
 
 export type CreateTableNodeParams = Omit<
   CreateTableNode,
-  'kind' | 'table' | 'columns' | 'constraints'
+  | 'kind'
+  | 'table'
+  | 'columns'
+  | 'constraints'
+  | 'frontModifiers'
+  | 'endModifiers'
 >
 
 export interface CreateTableNode extends OperationNode {
@@ -21,6 +27,8 @@ export interface CreateTableNode extends OperationNode {
   readonly temporary?: boolean
   readonly ifNotExists?: boolean
   readonly onCommit?: OnCommitAction
+  readonly frontModifiers?: ReadonlyArray<RawNode>
+  readonly endModifiers?: ReadonlyArray<RawNode>
 }
 
 /**
@@ -58,6 +66,30 @@ export const CreateTableNode = freeze({
       constraints: createTable.constraints
         ? freeze([...createTable.constraints, constraint])
         : freeze([constraint]),
+    })
+  },
+
+  cloneWithFrontModifier(
+    createTable: CreateTableNode,
+    modifier: RawNode
+  ): CreateTableNode {
+    return freeze({
+      ...createTable,
+      frontModifiers: createTable.frontModifiers
+        ? freeze([...createTable.frontModifiers, modifier])
+        : freeze([modifier]),
+    })
+  },
+
+  cloneWithEndModifier(
+    createTable: CreateTableNode,
+    modifier: RawNode
+  ): CreateTableNode {
+    return freeze({
+      ...createTable,
+      endModifiers: createTable.endModifiers
+        ? freeze([...createTable.endModifiers, modifier])
+        : freeze([modifier]),
     })
   },
 

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -390,6 +390,8 @@ export class OperationNodeTransformer {
       temporary: node.temporary,
       ifNotExists: node.ifNotExists,
       onCommit: node.onCommit,
+      frontModifiers: node.frontModifiers,
+      endModifiers: node.endModifiers,
     })
   }
 

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -390,8 +390,8 @@ export class OperationNodeTransformer {
       temporary: node.temporary,
       ifNotExists: node.ifNotExists,
       onCommit: node.onCommit,
-      frontModifiers: node.frontModifiers,
-      endModifiers: node.endModifiers,
+      frontModifiers: this.transformNodeList(node.frontModifiers),
+      endModifiers: this.transformNodeList(node.endModifiers),
     })
   }
 

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -480,6 +480,11 @@ export class DefaultQueryCompiler
   protected override visitCreateTable(node: CreateTableNode): void {
     this.append('create ')
 
+    if (node.frontModifiers) {
+      this.compileList(node.frontModifiers, ' ')
+      this.append(' ')
+    }
+
     if (node.temporary) {
       this.append('temporary ')
     }
@@ -498,6 +503,11 @@ export class DefaultQueryCompiler
     if (node.onCommit) {
       this.append(' on commit ')
       this.append(node.onCommit)
+    }
+
+    if (node.endModifiers) {
+      this.append(' ')
+      this.compileList(node.endModifiers, ' ')
     }
   }
 


### PR DESCRIPTION
`CREATE TABLE` statement exists in all 3 base dialects ([postgres](https://www.postgresql.org/docs/current/sql-createtable.html), [mysql](https://dev.mysql.com/doc/refman/8.0/en/create-table.html), [sqlite](https://www.sqlite.org/lang_createtable.html)) and their variants (cockroachdb, planetscale, singlestore). Kysely supports compiling such queries using `SchemaModule` (`db.schema.createTable(name)...`).

Dialects and their variants provide abilities to choose table type/scope and configure your table beyond the defaults (e.g. engine, collation, compression, partitioning, etc.). You do this between `CREATE` & `TABLE` keywords and after column, constraint and index scope. Kysely supports some common use cases like temporary tables (`db.schema.createTable(name).temporary()`), and on commit. There's a lot of dialect-specific stuff here and it probably won't be beneficial to implement most of it in Kysely as functions. Some will probably end up as functions in Kysely, but it'll take time.

Consumers who need more configurability when creating tables are blocked from using `SchemaModule`. E.g. in singlestore (a "MySQL variant", formerly memSQL), table storage types are at the core of the product. You choose between a columnstore table and an in-memory rowstore table right after the `CREATE` keyword. E.g. you'd like to partition your table by region.

----

tldr

This PR adds the ability to: 
- inject custom SQL right after the `CREATE` keyword, and before `TABLE` keyword using:

```typescript
import { sql } from 'kysely'

db.schema
    .createTable('my_table')
    .modifyFront(sql`global temporary`)
    .addColumn('id', 'integer', col => col.primaryKey())
```

```sql
create global temporary table "my_table" (
    "id" integer primary key
)
```

- inject custom SQL right at the end of `CREATE ... TABLE ( ... ) ...` statements using:

```typescript
import { sql } from 'kysely'

db.schema
    .createTable('my_table')
    .addColumn('id', 'integer', col => col.primaryKey())
    .modifyEnd(sql`collate utf8_unicode_ci`)
```

```sql
create table `my_table` (
  `id` integer primary key
) collate utf8_unicode_ci
```