### PR TITLE
Fix potential security issue

### DIFF
--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -373,7 +373,13 @@ export class DefaultQueryCompiler
   }
 
   protected compileUnwrappedIdentifier(node: IdentifierNode): void {
-    this.append(node.identifier)
+    this.append(this.getSanitizedIdentifier(node.identifier))
+  }
+
+  protected getSanitizedIdentifier = (identifier: string): string => {
+    return identifier
+      .replace(this.getLeftIdentifierWrapper(), '')
+      .replace(this.getRightIdentifierWrapper(), '')
   }
 
   protected override visitFilter(node: FilterNode): void {

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -373,13 +373,27 @@ export class DefaultQueryCompiler
   }
 
   protected compileUnwrappedIdentifier(node: IdentifierNode): void {
-    this.append(this.getSanitizedIdentifier(node.identifier))
+    this.append(this.sanitizeIdentifier(node.identifier))
   }
 
-  protected getSanitizedIdentifier = (identifier: string): string => {
-    return identifier
-      .replace(this.getLeftIdentifierWrapper(), '')
-      .replace(this.getRightIdentifierWrapper(), '')
+  protected sanitizeIdentifier = (identifier: string): string => {
+    const leftWrapper = this.getLeftIdentifierWrapper()
+    const rightWrapper = this.getRightIdentifierWrapper()
+
+    let sanitizedIdentifier = identifier
+      .split('')
+      .map((char) => {
+        if (char === leftWrapper) {
+          return `${leftWrapper}${leftWrapper}`
+        } else if (char === rightWrapper) {
+          return `${rightWrapper}${rightWrapper}`
+        }
+
+        return char
+      })
+      .join('')
+
+    return sanitizedIdentifier
   }
 
   protected override visitFilter(node: FilterNode): void {


### PR DESCRIPTION
# Fix Potential Security issues

  

First of all this vulnerability is not completely due to Kysely itself but rather with the way the user of this library might use it.

This fix might seem unnecessary because the vulnerability is not exploitable if Kysely and typescript are used in a safe manner.
But since this fix is really minor, I don't see no disadvantages in making it.

I believe code speaks better so I leave here a scenario in which this vulnerability might be exploited (due to sloppiness of the programmer that might use this library) to prove how easily it could happen and why this fix is important as it eliminates a potential security issue

  

## The scenario:

  

Imagine we have a table like this

  

```ts

interface  UserTable = {

id: number;

email: string;

interests: string | null;

authorization:  'full'  |  'restrict'

}

```

  

and we have 2 users like

  

```ts

[

{

id: 1,

email: 'admin@example.com',

interests: null,

role: 'full',

},

{

id: 2,

email: 'malicioius@example.com',

interests: 'Reading',

role: 'restrict',

},

];

```

  

And we have in our app an endpoint like this

`/users/:id PUT`

for users to update their data so the request body would be like this

  

```ts

interface  UpdateUserRequest {

email?: string:

interests?: string;

}

```

  

And in our service class we have some function like this

to update the user. This function is called passing the request body as an argument

  

```ts

async updateUser(user: UpdateUserRequest){
/* Just to be extra safe let's delete the user role property since the user
shouldn't be able to modify his role
*/
delete user.authorization;

await  this.repository.updateUser(authorization);
}

```
So we delete the authorization property to make sure the user doesn't try to change it's authorization level.

Our repository method to update the user looks like this
```ts

class UserRepository {

	async  updateUser(user: Updateable<UserTable>) {
		await database
			.updateTable('user')
			.set(user)
			.where('id', '=', user.id);
	}

}

```

  

Do you see the problem the problem?

  

## The exploit

  

A malicious user could sent a request like this

  

```json
{
	"authorization` = 'full' where email = 'malicious@example.com' -- ": null,

	"interests": "Swimming"
}
```

  

And then it would have full authorization

  

## The vulnerability

  

So yes it is a SQL injection vulnerability.

The issue is that although using prepared statements protects against SQL Injection in row values it doesn't protect against SQL injection in column and table names.

The mistake from the programmer in our scenario is the way the values of the user object used by the repository is constructed using the spread operator. 
 But this fix will prevent this for happening even if the user makes this mistake

### Vulnerable methods

  

I was able to exploit this vulnerability in `update`, `insert` and `selectFrom` methods using a `mysql` dialect but all the methods that accepts identifiers for columns and tables are potentially vulnerable as well as all dialects.

With `selectFrom` statements is more tricky since the programmer would have to give the user control over the fields that should be queried in a particular endpoint but is still worth fixing.

## The fix
So fixing this is pretty straight forward we just need to sanitize the identifiers passed to the query when we compile it.
In this particular case sanitizing is just removing the backticks (`) in case of mysql or double quotes (") in case of postgres and sqlite.
```diff
protected compileUnwrappedIdentifier(node: IdentifierNode): void {
+   this.append(this.getSanitizedIdentifier(node.identifier))
+ }

+ protected getSanitizedIdentifier = (identifier: string) : string => {
+    return identifier.replace(this.getLeftIdentifierWrapper(), '')
+   				  .replace(this.getRightIdentifierWrapper(), '')
  }
```
