### PR TITLE
Coerce file migration from esModuleInterop default prop.

### DIFF
--- a/src/migration/file-migration-provider.ts
+++ b/src/migration/file-migration-provider.ts
@@ -33,12 +33,14 @@ export class FileMigrationProvider implements MigrationProvider {
         (fileName.endsWith('.js') || fileName.endsWith('.ts') || fileName.endsWith('.mjs')) &&
         !fileName.endsWith('.d.ts')
       ) {
-        const migration = await import(
+        let migration = await import(
           /* webpackIgnore: true */ this.#props.path.join(
             this.#props.migrationFolder,
             fileName
           )
         )
+        // Coerce an esModuleInterop export's `default` prop...
+        migration = migration?.default ?? migration
 
         if (isMigration(migration)) {
           migrations[fileName.substring(0, fileName.length - 3)] = migration

--- a/src/migration/file-migration-provider.ts
+++ b/src/migration/file-migration-provider.ts
@@ -33,17 +33,18 @@ export class FileMigrationProvider implements MigrationProvider {
         (fileName.endsWith('.js') || fileName.endsWith('.ts') || fileName.endsWith('.mjs')) &&
         !fileName.endsWith('.d.ts')
       ) {
-        let migration = await import(
+        const migration = await import(
           /* webpackIgnore: true */ this.#props.path.join(
             this.#props.migrationFolder,
             fileName
           )
         )
-        // Coerce an esModuleInterop export's `default` prop...
-        migration = migration?.default ?? migration
-
-        if (isMigration(migration)) {
-          migrations[fileName.substring(0, fileName.length - 3)] = migration
+        const migrationKey = fileName.substring(0, fileName.length - 3);
+        // Handle esModuleInterop export's `default` prop...
+        if (isMigration(migration?.default)) {
+          migrations[migrationKey] = migration.default;
+        } else if (isMigration(migration)) {
+          migrations[migrationKey] = migration
         }
       }
     }


### PR DESCRIPTION
Add a check for a `default` prop when dynamically importing file migrations.

The `FileMigrationProvider` wasn't working in my project which is compiled to `commonjs` and has `esModuleInterop` enabled. So, I edited my local Kysely dependency to add some logging around the imported migration. I saw that the imports where wrapped like this: `{ default: { up: Function, down: Function } }`, so I changed the code to coerce the value from the default property like this:

```js
let migration = await Promise.resolve().then(() => require(
/* webpackIgnore: true */ this.#props.path.join(this.#props.migrationFolder, fileName)));
migration = migration?.default ?? migration;
```

All existing tests have passed for me. I did not write any new tests surrounding this change because I didn't think it was warranted, but if it's required for acceptance please let me know. Thanks!

(I was on the fence about the one comment line that I added. Do you think it's self explanatory?)