### PR TITLE
Add PlanetScale serverless driver dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ for [3rd party dialects](https://koskimas.github.io/kysely/interfaces/Dialect.ht
 ### 3rd party dialects:
 
  - [AWS Data API](https://github.com/serverless-stack/kysely-data-api)
+ - [PlanetScale Serverless Driver](https://github.com/depot/kysely-planetscale)
 
 # Minimal example
 


### PR DESCRIPTION
This PR adds a link to a dialect that uses [PlanetScale's serverless driver for JS](https://github.com/planetscale/database-js).