### PR TITLE
pass `queryId` to `executeQuery` to allow easy async comms between connections & plugins

### DIFF
--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -174,8 +174,8 @@ class MysqlConnection implements DatabaseConnection {
 
   async *streamQuery<O>(
     compiledQuery: CompiledQuery,
-    queryId: QueryId,
-    chunkSize: number
+    chunkSize: number,
+    queryId: QueryId
   ): AsyncIterableIterator<QueryResult<O>> {
     const stream = this.#rawConnection
       .query(compiledQuery.sql, compiledQuery.parameters)

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -133,8 +133,8 @@ class PostgresConnection implements DatabaseConnection {
 
   async *streamQuery<O>(
     compiledQuery: CompiledQuery,
-    queryId: QueryId,
-    chunkSize: number
+    chunkSize: number,
+    queryId: QueryId
   ): AsyncIterableIterator<QueryResult<O>> {
     if (!this.#options.cursor) {
       throw new Error(

--- a/src/dialect/sqlite/sqlite-driver.ts
+++ b/src/dialect/sqlite/sqlite-driver.ts
@@ -5,6 +5,7 @@ import {
 import { Driver } from '../../driver/driver.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
 import { freeze, isFunction } from '../../util/object-utils.js'
+import { createQueryId, QueryId } from '../../util/query-id.js'
 import { SqliteDatabase, SqliteDialectConfig } from './sqlite-dialect-config.js'
 
 export class SqliteDriver implements Driver {
@@ -38,15 +39,18 @@ export class SqliteDriver implements Driver {
   }
 
   async beginTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw('begin'))
+    await connection.executeQuery(CompiledQuery.raw('begin'), createQueryId())
   }
 
   async commitTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw('commit'))
+    await connection.executeQuery(CompiledQuery.raw('commit'), createQueryId())
   }
 
   async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw('rollback'))
+    await connection.executeQuery(
+      CompiledQuery.raw('rollback'),
+      createQueryId()
+    )
   }
 
   async releaseConnection(): Promise<void> {
@@ -65,7 +69,10 @@ class SqliteConnection implements DatabaseConnection {
     this.#db = db
   }
 
-  executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
+  executeQuery<O>(
+    compiledQuery: CompiledQuery,
+    queryId: QueryId
+  ): Promise<QueryResult<O>> {
     const { sql, parameters } = compiledQuery
     const stmt = this.#db.prepare(sql)
 

--- a/src/driver/database-connection.ts
+++ b/src/driver/database-connection.ts
@@ -1,4 +1,5 @@
 import { CompiledQuery } from '../query-compiler/compiled-query.js'
+import { QueryId } from '../util/query-id.js'
 
 /**
  * A single connection to the database engine.
@@ -6,9 +7,13 @@ import { CompiledQuery } from '../query-compiler/compiled-query.js'
  * These are created by an instance of {@link Driver}.
  */
 export interface DatabaseConnection {
-  executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>>
+  executeQuery<R>(
+    compiledQuery: CompiledQuery,
+    queryId: QueryId
+  ): Promise<QueryResult<R>>
   streamQuery<R>(
     compiledQuery: CompiledQuery,
+    queryId: QueryId,
     chunkSize?: number
   ): AsyncIterableIterator<QueryResult<R>>
 }

--- a/src/driver/database-connection.ts
+++ b/src/driver/database-connection.ts
@@ -13,8 +13,8 @@ export interface DatabaseConnection {
   ): Promise<QueryResult<R>>
   streamQuery<R>(
     compiledQuery: CompiledQuery,
-    queryId: QueryId,
-    chunkSize?: number
+    chunkSize: number | undefined,
+    queryId: QueryId
   ): AsyncIterableIterator<QueryResult<R>>
 }
 

--- a/src/driver/runtime-driver.ts
+++ b/src/driver/runtime-driver.ts
@@ -98,12 +98,13 @@ export class RuntimeDriver implements Driver {
     const executeQuery = connection.executeQuery
 
     connection.executeQuery = async (
-      compiledQuery
+      compiledQuery,
+      queryId
     ): Promise<QueryResult<any>> => {
       const startTime = performanceNow()
 
       try {
-        return await executeQuery.call(connection, compiledQuery)
+        return await executeQuery.call(connection, compiledQuery, queryId)
       } catch (error) {
         this.#logError(error)
         throw error

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ export * from './util/column-type.js'
 export * from './util/compilable.js'
 export * from './util/explainable.js'
 export * from './util/log.js'
-export { QueryId } from './util/query-id'
+export { QueryId } from './util/query-id.js'
 export {
   AnyColumn,
   UnknownRow,

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,7 @@ export * from './util/column-type.js'
 export * from './util/compilable.js'
 export * from './util/explainable.js'
 export * from './util/log.js'
+export { QueryId } from './util/query-id'
 export {
   AnyColumn,
   UnknownRow,

--- a/src/query-executor/query-executor-base.ts
+++ b/src/query-executor/query-executor-base.ts
@@ -64,7 +64,7 @@ export abstract class QueryExecutorBase implements QueryExecutor {
     queryId: QueryId
   ): Promise<QueryResult<R>> {
     return await this.provideConnection(async (connection) => {
-      const result = await connection.executeQuery(compiledQuery)
+      const result = await connection.executeQuery(compiledQuery, queryId)
       return this.#transformResult(result, queryId)
     })
   }
@@ -89,6 +89,7 @@ export abstract class QueryExecutorBase implements QueryExecutor {
     try {
       for await (const result of connection.streamQuery(
         compiledQuery,
+        queryId,
         chunkSize
       )) {
         yield await this.#transformResult(result, queryId)

--- a/src/query-executor/query-executor-base.ts
+++ b/src/query-executor/query-executor-base.ts
@@ -89,8 +89,8 @@ export abstract class QueryExecutorBase implements QueryExecutor {
     try {
       for await (const result of connection.streamQuery(
         compiledQuery,
-        queryId,
-        chunkSize
+        chunkSize,
+        queryId
       )) {
         yield await this.#transformResult(result, queryId)
       }


### PR DESCRIPTION
Currently the only components enjoying comms by `queryId` are plugins between their `transformX` methods and compilers. Seems a bit odd that `connection.executeQuery` was left behind.

While playing around with casting results to js land types in some data api implementation, I couldn't communicate some elements from a query response to a plugin's `transformResult` method (connection and plugin belong to the same package so it's fine). This restriction forced me to implement an overly complex hack that leaks. Having queryId in the connection could allow an easy, garbage collectable, WeakMap flow.

---

Wanted flow that's currently impossible:

connection:

```ts
//...

executeQuery(compiledQuery, queryId) {
  const result = ...

  someWeakMap.set(queryId, result.someUncommonFieldInSomeJsonWeWontStandardize)

  return {
    rows: result.rows
  }
}

// ...
```

plugin:

```ts
transformResult(args) {
  const someUncommonFieldInSomeJsonWeWontStandardize = someWeakMap.get(args.queryId)

  // do stuff..
}
```