### PR TITLE
add `numInsertedOrUpdatedRows` to `InsertResult`.

### DIFF
--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -129,7 +129,7 @@ class MysqlConnection implements DatabaseConnection {
               ? BigInt(insertId)
               : undefined,
           numUpdatedOrDeletedRows:
-            affectedRows !== undefined && insertId !== null
+            affectedRows !== undefined && affectedRows !== null
               ? BigInt(affectedRows)
               : undefined,
           rows: [],

--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -121,6 +121,11 @@ class MysqlConnection implements DatabaseConnection {
       if (isOkPacket(result)) {
         const { insertId, affectedRows } = result
 
+        const numAffectedRows =
+          affectedRows !== undefined && affectedRows !== null
+            ? BigInt(affectedRows)
+            : undefined
+
         return {
           insertId:
             insertId !== undefined &&
@@ -128,10 +133,9 @@ class MysqlConnection implements DatabaseConnection {
             insertId.toString() !== '0'
               ? BigInt(insertId)
               : undefined,
-          numUpdatedOrDeletedRows:
-            affectedRows !== undefined && affectedRows !== null
-              ? BigInt(affectedRows)
-              : undefined,
+          // TODO: remove.
+          numUpdatedOrDeletedRows: numAffectedRows,
+          numAffectedRows,
           rows: [],
         }
       } else if (Array.isArray(result)) {

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -111,8 +111,12 @@ class PostgresConnection implements DatabaseConnection {
         result.command === 'UPDATE' ||
         result.command === 'DELETE'
       ) {
+        const numAffectedRows = BigInt(result.rowCount)
+
         return {
-          numUpdatedOrDeletedRows: BigInt(result.rowCount),
+          // TODO: remove.
+          numUpdatedOrDeletedRows: numAffectedRows,
+          numAffectedRows,
           rows: result.rows ?? [],
         }
       }

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -106,7 +106,11 @@ class PostgresConnection implements DatabaseConnection {
         ...compiledQuery.parameters,
       ])
 
-      if (result.command === 'UPDATE' || result.command === 'DELETE') {
+      if (
+        result.command === 'INSERT' ||
+        result.command === 'UPDATE' ||
+        result.command === 'DELETE'
+      ) {
         return {
           numUpdatedOrDeletedRows: BigInt(result.rowCount),
           rows: result.rows ?? [],

--- a/src/dialect/sqlite/sqlite-driver.ts
+++ b/src/dialect/sqlite/sqlite-driver.ts
@@ -76,11 +76,13 @@ class SqliteConnection implements DatabaseConnection {
     } else {
       const { changes, lastInsertRowid } = stmt.run(parameters)
 
+      const numAffectedRows =
+        changes !== undefined && changes !== null ? BigInt(changes) : undefined
+
       return Promise.resolve({
-        numUpdatedOrDeletedRows:
-          changes !== undefined && changes !== null
-            ? BigInt(changes)
-            : undefined,
+        // TODO: remove.
+        numUpdatedOrDeletedRows: numAffectedRows,
+        numAffectedRows,
         insertId:
           lastInsertRowid !== undefined && lastInsertRowid !== null
             ? BigInt(lastInsertRowid)

--- a/src/driver/database-connection.ts
+++ b/src/driver/database-connection.ts
@@ -15,10 +15,16 @@ export interface DatabaseConnection {
 
 export interface QueryResult<O> {
   /**
+   * @deprecated use {@link QueryResult.numAffectedRows} instead.
+   */
+  // TODO: remove.
+  readonly numUpdatedOrDeletedRows?: bigint
+
+  /**
    * This is defined for insert, update and delete queries and contains
    * the number of rows the query inserted/updated/deleted.
    */
-  readonly numUpdatedOrDeletedRows?: bigint
+  readonly numAffectedRows?: bigint
 
   /**
    * This is defined for insert queries on dialects that return

--- a/src/driver/database-connection.ts
+++ b/src/driver/database-connection.ts
@@ -15,8 +15,8 @@ export interface DatabaseConnection {
 
 export interface QueryResult<O> {
   /**
-   * This is defined for update and delete queries and contains
-   * the number of rows the query updated/deleted.
+   * This is defined for insert, update and delete queries and contains
+   * the number of rows the query inserted/updated/deleted.
    */
   readonly numUpdatedOrDeletedRows?: bigint
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,7 @@ export {
   UnknownRow,
 } from './util/type-utils.js'
 export * from './util/infer-result.js'
+export { logOnce } from './util/log-once.js'
 
 export {
   SelectExpression,

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -608,9 +608,14 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
 
     if (this.#props.executor.adapter.supportsReturning && query.returning) {
       return result.rows
-    } else {
-      return [new DeleteResult(result.numUpdatedOrDeletedRows!) as unknown as O]
     }
+
+    return [
+      new DeleteResult(
+        // TODO: remove numUpdatedOrDeletedRows.
+        (result.numAffectedRows ?? result.numUpdatedOrDeletedRows)!
+      ) as any,
+    ]
   }
 
   /**

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -653,7 +653,12 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
     if (this.#props.executor.adapter.supportsReturning && query.returning) {
       return result.rows
     } else {
-      return [new InsertResult(result.insertId) as unknown as O]
+      return [
+        new InsertResult(
+          result.insertId,
+          result.numUpdatedOrDeletedRows
+        ) as unknown as O,
+      ]
     }
   }
 

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -652,14 +652,15 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
 
     if (this.#props.executor.adapter.supportsReturning && query.returning) {
       return result.rows
-    } else {
-      return [
-        new InsertResult(
-          result.insertId,
-          result.numUpdatedOrDeletedRows
-        ) as unknown as O,
-      ]
     }
+
+    return [
+      new InsertResult(
+        result.insertId,
+        // TODO: remove numUpdatedOrDeletedRows.
+        result.numAffectedRows ?? result.numUpdatedOrDeletedRows
+      ) as any,
+    ]
   }
 
   /**

--- a/src/query-builder/insert-result.ts
+++ b/src/query-builder/insert-result.ts
@@ -20,14 +20,14 @@
  */
 export class InsertResult {
   readonly #insertId: bigint | undefined
-  readonly #numAffectedRows: bigint | undefined
+  readonly #numInsertedOrUpdatedRows: bigint | undefined
 
   constructor(
     insertId: bigint | undefined,
-    numAffectedRows: bigint | undefined
+    numInsertedOrUpdatedRows: bigint | undefined
   ) {
     this.#insertId = insertId
-    this.#numAffectedRows = numAffectedRows
+    this.#numInsertedOrUpdatedRows = numInsertedOrUpdatedRows
   }
 
   /**
@@ -40,7 +40,7 @@ export class InsertResult {
   /**
    * Affected rows count.
    */
-  get numAffectedRows(): bigint | undefined {
-    return this.#numAffectedRows
+  get numInsertedOrUpdatedRows(): bigint | undefined {
+    return this.#numInsertedOrUpdatedRows
   }
 }

--- a/src/query-builder/insert-result.ts
+++ b/src/query-builder/insert-result.ts
@@ -7,6 +7,9 @@
  * need to use {@link ReturningInterface.returning} or {@link ReturningInterface.returningAll}
  * to get out the inserted id.
  *
+ * {@link numInsertedOrUpdatedRows} holds the number of (actually) inserted rows.
+ * On MySQL, updated rows are counted twice when using `on duplicate key update`.
+ *
  * ### Examples
  *
  * ```ts

--- a/src/query-builder/insert-result.ts
+++ b/src/query-builder/insert-result.ts
@@ -20,9 +20,14 @@
  */
 export class InsertResult {
   readonly #insertId: bigint | undefined
+  readonly #numAffectedRows: bigint | undefined
 
-  constructor(insertId: bigint | undefined) {
+  constructor(
+    insertId: bigint | undefined,
+    numAffectedRows: bigint | undefined
+  ) {
     this.#insertId = insertId
+    this.#numAffectedRows = numAffectedRows
   }
 
   /**
@@ -30,5 +35,12 @@ export class InsertResult {
    */
   get insertId(): bigint | undefined {
     return this.#insertId
+  }
+
+  /**
+   * Affected rows count.
+   */
+  get numAffectedRows(): bigint | undefined {
+    return this.#numAffectedRows
   }
 }

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -704,9 +704,14 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
 
     if (this.#props.executor.adapter.supportsReturning && query.returning) {
       return result.rows
-    } else {
-      return [new UpdateResult(result.numUpdatedOrDeletedRows!) as unknown as O]
     }
+
+    return [
+      new UpdateResult(
+        // TODO: remove numUpdatedOrDeletedRows.
+        (result.numAffectedRows ?? result.numUpdatedOrDeletedRows)!
+      ) as any,
+    ]
   }
 
   /**

--- a/src/util/log-once.ts
+++ b/src/util/log-once.ts
@@ -1,10 +1,14 @@
-let ALREADY_LOGGED: Set<string>
+let LOGGED_MESSAGES: Set<string>
 
+/**
+ * Use for system-level logging, such as deprecation messages.
+ * Logs a message and ensures it won't be logged again.
+ */
 export function logOnce(message: string): void {
-  if (ALREADY_LOGGED?.has(message)) {
+  if (LOGGED_MESSAGES?.has(message)) {
     return
   }
 
-  ;(ALREADY_LOGGED ??= new Set()).add(message)
+  ;(LOGGED_MESSAGES ??= new Set()).add(message)
   console.log(message)
 }

--- a/src/util/log-once.ts
+++ b/src/util/log-once.ts
@@ -1,0 +1,10 @@
+let ALREADY_LOGGED: Set<string>
+
+export function logOnce(message: string): void {
+  if (ALREADY_LOGGED?.has(message)) {
+    return
+  }
+
+  ;(ALREADY_LOGGED ??= new Set()).add(message)
+  console.log(message)
+}

--- a/src/util/log-once.ts
+++ b/src/util/log-once.ts
@@ -1,14 +1,14 @@
-let LOGGED_MESSAGES: Set<string>
+const LOGGED_MESSAGES: Set<string> = new Set()
 
 /**
  * Use for system-level logging, such as deprecation messages.
  * Logs a message and ensures it won't be logged again.
  */
 export function logOnce(message: string): void {
-  if (LOGGED_MESSAGES?.has(message)) {
+  if (LOGGED_MESSAGES.has(message)) {
     return
   }
 
-  ;(LOGGED_MESSAGES ??= new Set()).add(message)
+  LOGGED_MESSAGES.add(message)
   console.log(message)
 }

--- a/test/node/src/delete.test.ts
+++ b/test/node/src/delete.test.ts
@@ -104,7 +104,10 @@ for (const dialect of BUILT_IN_DIALECTS) {
           sqlite: NOT_SUPPORTED,
         })
 
-        await query.execute()
+        const result = await query.executeTakeFirst()
+
+        expect(result).to.be.instanceOf(DeleteResult)
+        expect(result.numDeletedRows).to.equal(2n)
       })
     }
 

--- a/test/node/src/insert.test.ts
+++ b/test/node/src/insert.test.ts
@@ -584,7 +584,6 @@ for (const dialect of BUILT_IN_DIALECTS) {
         .limit(2)
         .execute()
 
-      expect(inserted).to.have.length(2)
       expect(inserted).to.containSubset([
         { first_name: 'Foo', last_name: 'Bar', gender: 'other' },
         { first_name: 'Baz', last_name: 'Spam', gender: 'other' },

--- a/test/node/src/log-once.test.ts
+++ b/test/node/src/log-once.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai'
+import { createSandbox, SinonSpy } from 'sinon'
+import { logOnce } from '../../..'
+
+describe('logOnce', () => {
+  let logSpy: SinonSpy
+  const sandbox = createSandbox()
+
+  before(() => {
+    logSpy = sandbox.spy(console, 'log')
+  })
+
+  it('should log each message once.', () => {
+    const message = 'Kysely is awesome!'
+    const message2 = 'Type-safety is everything!'
+
+    logOnce(message)
+    logOnce(message)
+    logOnce(message2)
+    logOnce(message2)
+    logOnce(message)
+
+    expect(logSpy.calledTwice).to.be.true
+    expect(logSpy.getCall(0).args[0]).to.equal(message)
+    expect(logSpy.getCall(1).args[0]).to.equal(message2)
+  })
+})


### PR DESCRIPTION
Also:

- Deprecate `QueryResult.numUpdatedOrDeletedRows` and add `QueryResult.numAffectedRows`.

---

- [x] add to `InsertResult`.
- [x] unit tests.
~~- [ ] typings tests.~~ tests for `InsertResult` already in place.

---

On MySQL, this field lets consumers know whether an `insert...on duplicate key update` query inserted OR updated some records. Real world scenario, publishing an event following the query, "entity {created | updated}".

> With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 1 if the row is inserted as a new row, 2 if an existing row is updated, and 0 if an existing row is set to its current values. If you specify the CLIENT_FOUND_ROWS flag to the mysql_real_connect() C API function when connecting to mysqld, the affected-rows value is 1 (not 0) if an existing row is set to its current values.
https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html

The field is also relevant to inserts in Postgres..

> The rowCount is populated from the command tag supplied by the PostgreSQL server. It's generally of the form: COMMAND [OID] [ROWS]. For DML commands (INSERT, UPDATE, etc), it reflects how many rows the server modified to process the command.
https://node-postgres.com/api/result

---

Things to consider:

Feels like `QueryResult`'s `numUpdatedOrDeletedRows` should be renamed to `numAffectedRows`, which is more readable, neutral and aligned with MySQL terminology.

~~Stopped myself from doing this change as it'll break 3rd party drivers.~~