### PR TITLE
fix bigint `n` notation not buildable in some targets.

### DIFF
--- a/src/dialect/postgres/postgres-adapter.ts
+++ b/src/dialect/postgres/postgres-adapter.ts
@@ -3,7 +3,7 @@ import { sql } from '../../raw-builder/sql.js'
 import { DialectAdapterBase } from '../dialect-adapter-base.js'
 
 // Random id for our transaction lock.
-const LOCK_ID = 3853314791062309107n
+const LOCK_ID = BigInt('3853314791062309107')
 
 export class PostgresAdapter extends DialectAdapterBase {
   get supportsTransactionalDdl(): boolean {


### PR DESCRIPTION
fixes #142.

> The following is truthy in chrome, node 16.x, node 14.x, deno 1.26.x:
>
>```ts
> BigInt('3853314791062309107') === 3853314791062309107n
> ```
>
> And most importantly, astro dev starts successfully after patching this in.