### PR TITLE
fix no separator between default insert values.

### DIFF
--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -234,12 +234,12 @@ export class DefaultQueryCompiler
     nodes: ReadonlyArray<OperationNode>,
     separator = ', '
   ): void {
-    const lastNode = getLast(nodes)
+    const lastIndex = nodes.length - 1
 
-    for (const node of nodes) {
-      this.visitNode(node)
+    for (let i = 0; i <= lastIndex; i++) {
+      this.visitNode(nodes[i])
 
-      if (node !== lastNode) {
+      if (i < lastIndex) {
         this.append(separator)
       }
     }

--- a/test/node/src/insert.test.ts
+++ b/test/node/src/insert.test.ts
@@ -490,7 +490,7 @@ for (const dialect of BUILT_IN_DIALECTS) {
     }
 
     if (dialect === 'postgres' || dialect === 'sqlite') {
-      it.only('should insert multiple rows', async () => {
+      it('should insert multiple rows', async () => {
         const query = ctx.db
           .insertInto('person')
           .values([

--- a/test/node/src/insert.test.ts
+++ b/test/node/src/insert.test.ts
@@ -490,18 +490,20 @@ for (const dialect of BUILT_IN_DIALECTS) {
     }
 
     if (dialect === 'postgres' || dialect === 'sqlite') {
-      it('should insert multiple rows', async () => {
+      it.only('should insert multiple rows', async () => {
         const query = ctx.db
           .insertInto('person')
           .values([
             {
               first_name: 'Foo',
               // last_name is missing on purpose
+              // middle_name is missing on purpose
               gender: 'other',
             },
             {
               first_name: 'Baz',
               last_name: 'Spam',
+              middle_name: 'Bo',
               gender: 'other',
             },
           ])
@@ -509,13 +511,13 @@ for (const dialect of BUILT_IN_DIALECTS) {
 
         testSql(query, dialect, {
           postgres: {
-            sql: 'insert into "person" ("first_name", "gender", "last_name") values ($1, $2, default), ($3, $4, $5) returning *',
-            parameters: ['Foo', 'other', 'Baz', 'other', 'Spam'],
+            sql: 'insert into "person" ("first_name", "gender", "last_name", "middle_name") values ($1, $2, default, default), ($3, $4, $5, $6) returning *',
+            parameters: ['Foo', 'other', 'Baz', 'other', 'Spam', 'Bo'],
           },
           mysql: NOT_SUPPORTED,
           sqlite: {
-            sql: 'insert into "person" ("first_name", "gender", "last_name") values (?, ?, null), (?, ?, ?) returning *',
-            parameters: ['Foo', 'other', 'Baz', 'other', 'Spam'],
+            sql: 'insert into "person" ("first_name", "gender", "last_name", "middle_name") values (?, ?, null, null), (?, ?, ?, ?) returning *',
+            parameters: ['Foo', 'other', 'Baz', 'other', 'Spam', 'Bo'],
           },
         })
 

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -74,6 +74,13 @@ for (const dialect of BUILT_IN_DIALECTS) {
                 isAutoIncrementing: false,
                 hasDefaultValue: false,
               },
+              {
+                name: 'middle_name',
+                dataType: 'varchar',
+                isNullable: true,
+                isAutoIncrementing: false,
+                hasDefaultValue: false,
+              },
             ],
           },
           {
@@ -192,6 +199,13 @@ for (const dialect of BUILT_IN_DIALECTS) {
                 isAutoIncrementing: false,
                 hasDefaultValue: false,
               },
+              {
+                name: 'middle_name',
+                dataType: 'varchar',
+                isNullable: true,
+                isAutoIncrementing: false,
+                hasDefaultValue: false,
+              },
             ],
           },
           {
@@ -291,6 +305,13 @@ for (const dialect of BUILT_IN_DIALECTS) {
               },
               {
                 name: 'last_name',
+                dataType: 'varchar(255)',
+                isNullable: true,
+                isAutoIncrementing: false,
+                hasDefaultValue: false,
+              },
+              {
+                name: 'middle_name',
                 dataType: 'varchar(255)',
                 isNullable: true,
                 isAutoIncrementing: false,

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -245,6 +245,7 @@ async function createDatabase(
 
   await createTableWithId(db.schema, dialect, 'person')
     .addColumn('first_name', 'varchar(255)')
+    .addColumn('middle_name', 'varchar(255)')
     .addColumn('last_name', 'varchar(255)')
     .addColumn('gender', 'varchar(50)', (col) => col.notNull())
     .execute()


### PR DESCRIPTION
Currently, having more than 1 missing column value in `insertInto` value compiles to:

`("hello", "world", nullnull)`

instead of

`("hello", "world", null, null)`