### PR TITLE
add `filter` clause support at `AggregateFunctionBuilder`.

### DIFF
--- a/src/operation-node/aggregate-function-node.ts
+++ b/src/operation-node/aggregate-function-node.ts
@@ -50,7 +50,11 @@ export const AggregateFunctionNode = freeze({
     return freeze({
       ...aggregateFunctionNode,
       filter: aggregateFunctionNode.filter
-        ? WhereNode.cloneWithFilter(aggregateFunctionNode.filter, 'And', filter)
+        ? WhereNode.cloneWithOperation(
+            aggregateFunctionNode.filter,
+            'And',
+            filter
+          )
         : WhereNode.create(filter),
     })
   },
@@ -62,7 +66,11 @@ export const AggregateFunctionNode = freeze({
     return freeze({
       ...aggregateFunctionNode,
       filter: aggregateFunctionNode.filter
-        ? WhereNode.cloneWithFilter(aggregateFunctionNode.filter, 'Or', filter)
+        ? WhereNode.cloneWithOperation(
+            aggregateFunctionNode.filter,
+            'Or',
+            filter
+          )
         : WhereNode.create(filter),
     })
   },

--- a/src/operation-node/aggregate-function-node.ts
+++ b/src/operation-node/aggregate-function-node.ts
@@ -2,6 +2,7 @@ import { freeze } from '../util/object-utils.js'
 import { OperationNode } from './operation-node.js'
 import { OverNode } from './over-node.js'
 import { SimpleReferenceExpressionNode } from './simple-reference-expression-node.js'
+import { WhereNode } from './where-node.js'
 
 type AggregateFunction = 'avg' | 'count' | 'max' | 'min' | 'sum'
 
@@ -10,6 +11,7 @@ export interface AggregateFunctionNode extends OperationNode {
   readonly func: AggregateFunction
   readonly column: SimpleReferenceExpressionNode
   readonly distinct?: boolean
+  readonly filter?: WhereNode
   readonly over?: OverNode
 }
 
@@ -38,6 +40,30 @@ export const AggregateFunctionNode = freeze({
     return freeze({
       ...aggregateFunctionNode,
       distinct: true,
+    })
+  },
+
+  cloneWithFilter(
+    aggregateFunctionNode: AggregateFunctionNode,
+    filter: OperationNode
+  ): AggregateFunctionNode {
+    return freeze({
+      ...aggregateFunctionNode,
+      filter: aggregateFunctionNode.filter
+        ? WhereNode.cloneWithFilter(aggregateFunctionNode.filter, 'And', filter)
+        : WhereNode.create(filter),
+    })
+  },
+
+  cloneWithOrFilter(
+    aggregateFunctionNode: AggregateFunctionNode,
+    filter: OperationNode
+  ): AggregateFunctionNode {
+    return freeze({
+      ...aggregateFunctionNode,
+      filter: aggregateFunctionNode.filter
+        ? WhereNode.cloneWithFilter(aggregateFunctionNode.filter, 'Or', filter)
+        : WhereNode.create(filter),
     })
   },
 

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -825,6 +825,7 @@ export class OperationNodeTransformer {
       kind: 'AggregateFunctionNode',
       column: this.transformNode(node.column),
       distinct: node.distinct,
+      filter: this.transformNode(node.filter),
       func: node.func,
       over: this.transformNode(node.over),
     })

--- a/src/query-builder/aggregate-function-builder.ts
+++ b/src/query-builder/aggregate-function-builder.ts
@@ -94,16 +94,18 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   /**
    * // TODO: ...
    */
-  filter<RE extends ReferenceExpression<DB, TB>>(
+  filterWhere<RE extends ReferenceExpression<DB, TB>>(
     lhs: RE,
     op: FilterOperator,
     rhs: FilterValueExpressionOrList<DB, TB, RE>
   ): AggregateFunctionBuilder<DB, TB, O>
 
-  filter(grouper: WhereGrouper<DB, TB>): AggregateFunctionBuilder<DB, TB, O>
-  filter(expression: Expression<any>): AggregateFunctionBuilder<DB, TB, O>
+  filterWhere(
+    grouper: WhereGrouper<DB, TB>
+  ): AggregateFunctionBuilder<DB, TB, O>
+  filterWhere(expression: Expression<any>): AggregateFunctionBuilder<DB, TB, O>
 
-  filter(...args: any[]): any {
+  filterWhere(...args: any[]): any {
     return new AggregateFunctionBuilder({
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
@@ -116,7 +118,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   /**
    * TODO: ...
    */
-  filterExists(
+  filterWhereExists(
     arg: ExistsExpression<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O> {
     return new AggregateFunctionBuilder({
@@ -131,7 +133,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   /**
    * TODO: ...
    */
-  filterNotExists(
+  filterWhereNotExists(
     arg: ExistsExpression<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O> {
     return new AggregateFunctionBuilder({
@@ -146,7 +148,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   /**
    * TODO: ...
    */
-  filterRef(
+  filterWhereRef(
     lhs: ReferenceExpression<DB, TB>,
     op: FilterOperator,
     rhs: ReferenceExpression<DB, TB>
@@ -163,16 +165,20 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   /**
    * TODO: ...
    */
-  orFilter<RE extends ReferenceExpression<DB, TB>>(
+  orFilterWhere<RE extends ReferenceExpression<DB, TB>>(
     lhs: RE,
     op: FilterOperator,
     rhs: FilterValueExpressionOrList<DB, TB, RE>
   ): AggregateFunctionBuilder<DB, TB, O>
 
-  orFilter(grouper: WhereGrouper<DB, TB>): AggregateFunctionBuilder<DB, TB, O>
-  orFilter(expression: Expression<any>): AggregateFunctionBuilder<DB, TB, O>
+  orFilterWhere(
+    grouper: WhereGrouper<DB, TB>
+  ): AggregateFunctionBuilder<DB, TB, O>
+  orFilterWhere(
+    expression: Expression<any>
+  ): AggregateFunctionBuilder<DB, TB, O>
 
-  orFilter(...args: any[]): any {
+  orFilterWhere(...args: any[]): any {
     return new AggregateFunctionBuilder({
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
@@ -185,7 +191,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   /**
    * TODO: ...
    */
-  orFilterExists(
+  orFilterWhereExists(
     arg: ExistsExpression<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O> {
     return new AggregateFunctionBuilder({
@@ -200,7 +206,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   /**
    * TODO: ...
    */
-  orFilterNotExists(
+  orFilterWhereNotExists(
     arg: ExistsExpression<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O> {
     return new AggregateFunctionBuilder({
@@ -215,7 +221,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   /**
    * TODO: ...
    */
-  orFilterRef(
+  orFilterWhereRef(
     lhs: ReferenceExpression<DB, TB>,
     op: FilterOperator,
     rhs: ReferenceExpression<DB, TB>

--- a/src/query-builder/aggregate-function-builder.ts
+++ b/src/query-builder/aggregate-function-builder.ts
@@ -6,17 +6,19 @@ import { preventAwait } from '../util/prevent-await.js'
 import { OverBuilder } from './over-builder.js'
 import { createOverBuilder } from '../parser/parse-utils.js'
 import { AliasedExpression, Expression } from '../expression/expression.js'
+import { ReferenceExpression } from '../parser/reference-parser.js'
+import { ComparisonOperator } from '../operation-node/operator-node.js'
+import {
+  OperandValueExpressionOrList,
+  parseReferentialFilter,
+  parseWhere,
+  WhereGrouper,
+} from '../parser/binary-operation-parser.js'
 import {
   ExistsExpression,
-  FilterOperator,
-  FilterValueExpressionOrList,
-  parseExistFilter,
-  parseNotExistFilter,
-  parseReferenceFilter,
-  parseWhereFilter,
-  WhereGrouper,
-} from '../parser/filter-parser.js'
-import { ReferenceExpression } from '../parser/reference-parser.js'
+  parseExists,
+  parseNotExists,
+} from '../parser/unary-operation-parser.js'
 
 export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   implements Expression<O>
@@ -96,8 +98,8 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    */
   filterWhere<RE extends ReferenceExpression<DB, TB>>(
     lhs: RE,
-    op: FilterOperator,
-    rhs: FilterValueExpressionOrList<DB, TB, RE>
+    op: ComparisonOperator,
+    rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): AggregateFunctionBuilder<DB, TB, O>
 
   filterWhere(
@@ -110,7 +112,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
         this.#props.aggregateFunctionNode,
-        parseWhereFilter(args)
+        parseWhere(args)
       ),
     })
   }
@@ -125,7 +127,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
         this.#props.aggregateFunctionNode,
-        parseExistFilter(arg)
+        parseExists(arg)
       ),
     })
   }
@@ -140,7 +142,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
         this.#props.aggregateFunctionNode,
-        parseNotExistFilter(arg)
+        parseNotExists(arg)
       ),
     })
   }
@@ -150,14 +152,14 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    */
   filterWhereRef(
     lhs: ReferenceExpression<DB, TB>,
-    op: FilterOperator,
+    op: ComparisonOperator,
     rhs: ReferenceExpression<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O> {
     return new AggregateFunctionBuilder({
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
         this.#props.aggregateFunctionNode,
-        parseReferenceFilter(lhs, op, rhs)
+        parseReferentialFilter(lhs, op, rhs)
       ),
     })
   }
@@ -167,8 +169,8 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    */
   orFilterWhere<RE extends ReferenceExpression<DB, TB>>(
     lhs: RE,
-    op: FilterOperator,
-    rhs: FilterValueExpressionOrList<DB, TB, RE>
+    op: ComparisonOperator,
+    rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): AggregateFunctionBuilder<DB, TB, O>
 
   orFilterWhere(
@@ -183,7 +185,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
         this.#props.aggregateFunctionNode,
-        parseWhereFilter(args)
+        parseWhere(args)
       ),
     })
   }
@@ -198,7 +200,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
         this.#props.aggregateFunctionNode,
-        parseExistFilter(arg)
+        parseExists(arg)
       ),
     })
   }
@@ -213,7 +215,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
         this.#props.aggregateFunctionNode,
-        parseNotExistFilter(arg)
+        parseNotExists(arg)
       ),
     })
   }
@@ -223,14 +225,14 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    */
   orFilterWhereRef(
     lhs: ReferenceExpression<DB, TB>,
-    op: FilterOperator,
+    op: ComparisonOperator,
     rhs: ReferenceExpression<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O> {
     return new AggregateFunctionBuilder({
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
         this.#props.aggregateFunctionNode,
-        parseReferenceFilter(lhs, op, rhs)
+        parseReferentialFilter(lhs, op, rhs)
       ),
     })
   }

--- a/src/query-builder/aggregate-function-builder.ts
+++ b/src/query-builder/aggregate-function-builder.ts
@@ -66,13 +66,15 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * Adds a distinct clause inside the function.
+   * Adds a `distinct` clause inside the function.
+   *
+   * ### Examples
    *
    * ```ts
    * const result = await db
    *   .selectFrom('person')
-   *   .select(
-   *     eb => eb.fn.count<number>('first_name').distinct().as('first_name_count')
+   *   .select((eb) =>
+   *     eb.fn.count<number>('first_name').distinct().as('first_name_count')
    *   )
    *   .executeTakeFirstOrThrow()
    * ```
@@ -94,7 +96,48 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * // TODO: ...
+   * Adds a `filter` clause with a nested `where` clause after the function.
+   *
+   * Similar to {@link WhereInterface}'s `where` method.
+   *
+   * Also see {@link orFilterWhere}, {@link filterWhereExists} and {@link filterWhereRef}.
+   *
+   * ### Examples
+   *
+   * Count by gender:
+   *
+   * ```ts
+   * const result = await db
+   *   .selectFrom('person')
+   *   .select([
+   *     (eb) =>
+   *       eb.fn
+   *         .count<number>('id')
+   *         .filterWhere('gender', '=', 'female')
+   *         .as('female_count'),
+   *     (eb) =>
+   *       eb.fn
+   *         .count<number>('id')
+   *         .filterWhere('gender', '=', 'male')
+   *         .as('male_count'),
+   *     (eb) =>
+   *       eb.fn
+   *         .count<number>('id')
+   *         .filterWhere('gender', '=', 'other')
+   *         .as('other_count'),
+   *   ])
+   *   .executeTakeFirstOrThrow()
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * select
+   *   count("id") filter(where "gender" = $1) as "female_count",
+   *   count("id") filter(where "gender" = $2) as "male_count",
+   *   count("id") filter(where "gender" = $3) as "other_count"
+   * from "person"
+   * ```
    */
   filterWhere<RE extends ReferenceExpression<DB, TB>>(
     lhs: RE,
@@ -119,7 +162,44 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * TODO: ...
+   * Adds a `filter` clause with a nested `where exists` clause after the function.
+   *
+   * Similar to {@link WhereInterface}'s `whereExists` method.
+   *
+   * ### Examples
+   *
+   * Count pet owners versus general public:
+   *
+   * ```ts
+   * const result = await db
+   *   .selectFrom('person')
+   *   .select([
+   *     (eb) =>
+   *       eb.fn
+   *         .count<number>('person.id')
+   *         .filterWhereExists((qb) =>
+   *           qb
+   *             .selectFrom('pet')
+   *             .select('pet.id')
+   *             .whereRef('pet.owner_id', '=', 'person.id')
+   *         )
+   *         .as('pet_owner_count'),
+   *     (eb) => eb.fn.count<number>('person.id').as('total_count'),
+   *   ])
+   *   .executeTakeFirstOrThrow()
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * select count("person"."id") filter(where exists (
+   *   select "pet"."id"
+   *   from "pet"
+   *   where "pet"."owner_id" = "person"."id"
+   * )) as "pet_ower_count",
+   *   count("person"."id") as "total_count"
+   * from "person"
+   * ```
    */
   filterWhereExists(
     arg: ExistsExpression<DB, TB>
@@ -134,7 +214,8 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * TODO: ...
+   * Just like {@link filterWhereExists} but creates a `not exists` clause inside
+   * the `filter` clause.
    */
   filterWhereNotExists(
     arg: ExistsExpression<DB, TB>
@@ -149,7 +230,37 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * TODO: ...
+   * Adds a `filter` clause with a nested `where` clause after the function, where
+   * both sides of the operator are references to columns.
+   *
+   * Similar to {@link WhereInterface}'s `whereRef` method.
+   *
+   * ### Examples
+   *
+   * Count people with same first and last names versus general public:
+   *
+   * ```ts
+   * const result = await db
+   *   .selectFrom('person')
+   *   .select([
+   *     (eb) =>
+   *       eb.fn
+   *         .count<number>('id')
+   *         .filterWhereRef('first_name', '=', 'last_name')
+   *         .as('repeat_name_count'),
+   *     (eb) => eb.fn.count<number>('id').as('total_count'),
+   *   ])
+   *   .executeTakeFirstOrThrow()
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * select
+   *   count("id") filter(where "first_name" = "last_name") as "repeat_name_count",
+   *   count("id") as "total_count"
+   * from "person"
+   * ```
    */
   filterWhereRef(
     lhs: ReferenceExpression<DB, TB>,
@@ -166,7 +277,39 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * TODO: ...
+   * Adds a `filter` clause with a nested `or where` clause after the function.
+   * Otherwise works just like {@link filterWhere}.
+   *
+   * Similar to {@link WhereInterface}'s `orWhere` method.
+   *
+   * ### Examples
+   *
+   * For some reason you're tasked with counting adults (18+) or people called
+   * "Bob" versus general public:
+   *
+   * ```ts
+   * const result = await db
+   *   .selectFrom('person')
+   *   .select([
+   *     (eb) =>
+   *       eb.fn
+   *         .count<number>('id')
+   *         .filterWhere('age', '>=', '18')
+   *         .orFilterWhere('first_name', '=', 'Bob')
+   *         .as('adult_or_bob_count'),
+   *     (eb) => eb.fn.count<number>('id').as('total_count'),
+   *   ])
+   *   .executeTakeFirstOrThrow()
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * select
+   *   count("id") filter(where "age" >= $1 or "first_name" = $2) as "adult_or_bob_count",
+   *   count("id") as "total_count"
+   * from "person"
+   * ```
    */
   orFilterWhere<RE extends ReferenceExpression<DB, TB>>(
     lhs: RE,
@@ -193,7 +336,10 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * TODO: ...
+   * Just like {@link filterWhereExists} but creates an `or exists` clause inside
+   * the `filter` clause.
+   *
+   * Similar to {@link WhereInterface}'s `orWhereExists` method.
    */
   orFilterWhereExists(
     arg: ExistsExpression<DB, TB>
@@ -208,7 +354,10 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * TODO: ...
+   * Just like {@link filterWhereExists} but creates an `or not exists` clause inside
+   * the `filter` clause.
+   *
+   * Similar to {@link WhereInterface}'s `orWhereNotExists` method.
    */
   orFilterWhereNotExists(
     arg: ExistsExpression<DB, TB>
@@ -223,7 +372,12 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * TODO: ...
+   * Adds an `or where` clause inside the `filter` clause. Otherwise works just
+   * like {@link filterWhereRef}.
+   *
+   * Also see {@link orFilterWhere} and {@link filterWhere}.
+   *
+   * Similar to {@link WhereInterface}'s `orWhereRef` method.
    */
   orFilterWhereRef(
     lhs: ReferenceExpression<DB, TB>,
@@ -240,7 +394,9 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   }
 
   /**
-   * Adds an over clause (window functions) after the function.
+   * Adds an `over` clause (window functions) after the function.
+   *
+   * ### Examples
    *
    * ```ts
    * const result = await db

--- a/src/query-builder/aggregate-function-builder.ts
+++ b/src/query-builder/aggregate-function-builder.ts
@@ -7,8 +7,8 @@ import { OverBuilder } from './over-builder.js'
 import { createOverBuilder } from '../parser/parse-utils.js'
 import { AliasedExpression, Expression } from '../expression/expression.js'
 import { ReferenceExpression } from '../parser/reference-parser.js'
-import { ComparisonOperator } from '../operation-node/operator-node.js'
 import {
+  ComparisonOperatorExpression,
   OperandValueExpressionOrList,
   parseReferentialFilter,
   parseWhere,
@@ -98,13 +98,14 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    */
   filterWhere<RE extends ReferenceExpression<DB, TB>>(
     lhs: RE,
-    op: ComparisonOperator,
+    op: ComparisonOperatorExpression,
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): AggregateFunctionBuilder<DB, TB, O>
 
   filterWhere(
     grouper: WhereGrouper<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O>
+
   filterWhere(expression: Expression<any>): AggregateFunctionBuilder<DB, TB, O>
 
   filterWhere(...args: any[]): any {
@@ -152,7 +153,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    */
   filterWhereRef(
     lhs: ReferenceExpression<DB, TB>,
-    op: ComparisonOperator,
+    op: ComparisonOperatorExpression,
     rhs: ReferenceExpression<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O> {
     return new AggregateFunctionBuilder({
@@ -169,13 +170,14 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    */
   orFilterWhere<RE extends ReferenceExpression<DB, TB>>(
     lhs: RE,
-    op: ComparisonOperator,
+    op: ComparisonOperatorExpression,
     rhs: OperandValueExpressionOrList<DB, TB, RE>
   ): AggregateFunctionBuilder<DB, TB, O>
 
   orFilterWhere(
     grouper: WhereGrouper<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O>
+
   orFilterWhere(
     expression: Expression<any>
   ): AggregateFunctionBuilder<DB, TB, O>
@@ -225,7 +227,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    */
   orFilterWhereRef(
     lhs: ReferenceExpression<DB, TB>,
-    op: ComparisonOperator,
+    op: ComparisonOperatorExpression,
     rhs: ReferenceExpression<DB, TB>
   ): AggregateFunctionBuilder<DB, TB, O> {
     return new AggregateFunctionBuilder({

--- a/src/query-builder/aggregate-function-builder.ts
+++ b/src/query-builder/aggregate-function-builder.ts
@@ -6,6 +6,17 @@ import { preventAwait } from '../util/prevent-await.js'
 import { OverBuilder } from './over-builder.js'
 import { createOverBuilder } from '../parser/parse-utils.js'
 import { AliasedExpression, Expression } from '../expression/expression.js'
+import {
+  ExistsExpression,
+  FilterOperator,
+  FilterValueExpressionOrList,
+  parseExistFilter,
+  parseNotExistFilter,
+  parseReferenceFilter,
+  parseWhereFilter,
+  WhereGrouper,
+} from '../parser/filter-parser.js'
+import { ReferenceExpression } from '../parser/reference-parser.js'
 
 export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
   implements Expression<O>
@@ -76,6 +87,144 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
       ...this.#props,
       aggregateFunctionNode: AggregateFunctionNode.cloneWithDistinct(
         this.#props.aggregateFunctionNode
+      ),
+    })
+  }
+
+  /**
+   * // TODO: ...
+   */
+  filter<RE extends ReferenceExpression<DB, TB>>(
+    lhs: RE,
+    op: FilterOperator,
+    rhs: FilterValueExpressionOrList<DB, TB, RE>
+  ): AggregateFunctionBuilder<DB, TB, O>
+
+  filter(grouper: WhereGrouper<DB, TB>): AggregateFunctionBuilder<DB, TB, O>
+  filter(expression: Expression<any>): AggregateFunctionBuilder<DB, TB, O>
+
+  filter(...args: any[]): any {
+    return new AggregateFunctionBuilder({
+      ...this.#props,
+      aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
+        this.#props.aggregateFunctionNode,
+        parseWhereFilter(args)
+      ),
+    })
+  }
+
+  /**
+   * TODO: ...
+   */
+  filterExists(
+    arg: ExistsExpression<DB, TB>
+  ): AggregateFunctionBuilder<DB, TB, O> {
+    return new AggregateFunctionBuilder({
+      ...this.#props,
+      aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
+        this.#props.aggregateFunctionNode,
+        parseExistFilter(arg)
+      ),
+    })
+  }
+
+  /**
+   * TODO: ...
+   */
+  filterNotExists(
+    arg: ExistsExpression<DB, TB>
+  ): AggregateFunctionBuilder<DB, TB, O> {
+    return new AggregateFunctionBuilder({
+      ...this.#props,
+      aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
+        this.#props.aggregateFunctionNode,
+        parseNotExistFilter(arg)
+      ),
+    })
+  }
+
+  /**
+   * TODO: ...
+   */
+  filterRef(
+    lhs: ReferenceExpression<DB, TB>,
+    op: FilterOperator,
+    rhs: ReferenceExpression<DB, TB>
+  ): AggregateFunctionBuilder<DB, TB, O> {
+    return new AggregateFunctionBuilder({
+      ...this.#props,
+      aggregateFunctionNode: AggregateFunctionNode.cloneWithFilter(
+        this.#props.aggregateFunctionNode,
+        parseReferenceFilter(lhs, op, rhs)
+      ),
+    })
+  }
+
+  /**
+   * TODO: ...
+   */
+  orFilter<RE extends ReferenceExpression<DB, TB>>(
+    lhs: RE,
+    op: FilterOperator,
+    rhs: FilterValueExpressionOrList<DB, TB, RE>
+  ): AggregateFunctionBuilder<DB, TB, O>
+
+  orFilter(grouper: WhereGrouper<DB, TB>): AggregateFunctionBuilder<DB, TB, O>
+  orFilter(expression: Expression<any>): AggregateFunctionBuilder<DB, TB, O>
+
+  orFilter(...args: any[]): any {
+    return new AggregateFunctionBuilder({
+      ...this.#props,
+      aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
+        this.#props.aggregateFunctionNode,
+        parseWhereFilter(args)
+      ),
+    })
+  }
+
+  /**
+   * TODO: ...
+   */
+  orFilterExists(
+    arg: ExistsExpression<DB, TB>
+  ): AggregateFunctionBuilder<DB, TB, O> {
+    return new AggregateFunctionBuilder({
+      ...this.#props,
+      aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
+        this.#props.aggregateFunctionNode,
+        parseExistFilter(arg)
+      ),
+    })
+  }
+
+  /**
+   * TODO: ...
+   */
+  orFilterNotExists(
+    arg: ExistsExpression<DB, TB>
+  ): AggregateFunctionBuilder<DB, TB, O> {
+    return new AggregateFunctionBuilder({
+      ...this.#props,
+      aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
+        this.#props.aggregateFunctionNode,
+        parseNotExistFilter(arg)
+      ),
+    })
+  }
+
+  /**
+   * TODO: ...
+   */
+  orFilterRef(
+    lhs: ReferenceExpression<DB, TB>,
+    op: FilterOperator,
+    rhs: ReferenceExpression<DB, TB>
+  ): AggregateFunctionBuilder<DB, TB, O> {
+    return new AggregateFunctionBuilder({
+      ...this.#props,
+      aggregateFunctionNode: AggregateFunctionNode.cloneWithOrFilter(
+        this.#props.aggregateFunctionNode,
+        parseReferenceFilter(lhs, op, rhs)
       ),
     })
   }

--- a/src/query-builder/where-interface.ts
+++ b/src/query-builder/where-interface.ts
@@ -208,7 +208,7 @@ export interface WhereInterface<DB, TB extends keyof DB> {
    *
    * The normal `where` method treats the right hand side argument as a
    * value by default. `whereRef` treats it as a column reference. This method is
-   * expecially useful with joins and correclated subqueries.
+   * expecially useful with joins and correlated subqueries.
    *
    * ### Examples
    *
@@ -411,12 +411,12 @@ export interface WhereInterface<DB, TB extends keyof DB> {
   whereNotExists(arg: ExistsExpression<DB, TB>): WhereInterface<DB, TB>
 
   /**
-   * Just like {@link whereExists} but creates a `or exists` clause.
+   * Just like {@link whereExists} but creates an `or exists` clause.
    */
   orWhereExists(arg: ExistsExpression<DB, TB>): WhereInterface<DB, TB>
 
   /**
-   * Just like {@link whereExists} but creates a `or not exists` clause.
+   * Just like {@link whereExists} but creates an `or not exists` clause.
    */
   orWhereNotExists(arg: ExistsExpression<DB, TB>): WhereInterface<DB, TB>
 }

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1200,6 +1200,12 @@ export class DefaultQueryCompiler
     this.visitNode(node.column)
     this.append(')')
 
+    if (node.filter) {
+      this.append(' filter(')
+      this.visitNode(node.filter)
+      this.append(')')
+    }
+
     if (node.over) {
       this.append(' ')
       this.visitNode(node.over)

--- a/test/node/src/aggregate-function.test.ts
+++ b/test/node/src/aggregate-function.test.ts
@@ -365,11 +365,11 @@ for (const dialect of BUILT_IN_DIALECTS) {
               .selectFrom('person')
               .select([
                 func('person.id')
-                  .filter('person.gender', '=', 'female')
+                  .filterWhere('person.gender', '=', 'female')
                   .as(funcName),
                 (eb) =>
                   getFuncFromExpressionBuilder(eb, funcName)('person.id')
-                    .filter('person.gender', '=', 'female')
+                    .filterWhere('person.gender', '=', 'female')
                     .as(`another_${funcName}`),
               ])
 
@@ -403,13 +403,13 @@ for (const dialect of BUILT_IN_DIALECTS) {
               .selectFrom('person')
               .select([
                 func('person.id')
-                  .filter('person.gender', '=', 'female')
-                  .filter('person.middle_name', 'is not', null)
+                  .filterWhere('person.gender', '=', 'female')
+                  .filterWhere('person.middle_name', 'is not', null)
                   .as(funcName),
                 (eb) =>
                   getFuncFromExpressionBuilder(eb, funcName)('person.id')
-                    .filter('person.gender', '=', 'female')
-                    .filter('person.middle_name', 'is not', null)
+                    .filterWhere('person.gender', '=', 'female')
+                    .filterWhere('person.middle_name', 'is not', null)
                     .as(`another_${funcName}`),
               ])
 
@@ -443,13 +443,13 @@ for (const dialect of BUILT_IN_DIALECTS) {
               .selectFrom('person')
               .select([
                 func('person.id')
-                  .filter('person.gender', '=', 'female')
-                  .orFilter('person.middle_name', 'is not', null)
+                  .filterWhere('person.gender', '=', 'female')
+                  .orFilterWhere('person.middle_name', 'is not', null)
                   .as(funcName),
                 (eb) =>
                   getFuncFromExpressionBuilder(eb, funcName)('person.id')
-                    .filter('person.gender', '=', 'female')
-                    .orFilter('person.middle_name', 'is not', null)
+                    .filterWhere('person.gender', '=', 'female')
+                    .orFilterWhere('person.middle_name', 'is not', null)
                     .as(`another_${funcName}`),
               ])
 
@@ -483,12 +483,12 @@ for (const dialect of BUILT_IN_DIALECTS) {
               .selectFrom('person')
               .select([
                 func('person.id')
-                  .filter('person.gender', '=', 'female')
+                  .filterWhere('person.gender', '=', 'female')
                   .over()
                   .as(funcName),
                 (eb) =>
                   getFuncFromExpressionBuilder(eb, funcName)('person.id')
-                    .filter('person.gender', '=', 'female')
+                    .filterWhere('person.gender', '=', 'female')
                     .over()
                     .as(`another_${funcName}`),
               ])

--- a/test/node/src/aggregate-function.test.ts
+++ b/test/node/src/aggregate-function.test.ts
@@ -16,7 +16,7 @@ import {
 const funcNames = ['avg', 'count', 'max', 'min', 'sum'] as const
 
 for (const dialect of BUILT_IN_DIALECTS) {
-  describe.only(`${dialect}: aggregate functions`, () => {
+  describe(`${dialect}: aggregate functions`, () => {
     let ctx: TestContext
 
     before(async function () {

--- a/test/node/src/aggregate-function.test.ts
+++ b/test/node/src/aggregate-function.test.ts
@@ -8,6 +8,7 @@ import {
   Database,
   destroyTest,
   initTest,
+  NOT_SUPPORTED,
   TestContext,
   testSql,
 } from './test-setup.js'
@@ -15,7 +16,7 @@ import {
 const funcNames = ['avg', 'count', 'max', 'min', 'sum'] as const
 
 for (const dialect of BUILT_IN_DIALECTS) {
-  describe(`${dialect}: aggregate functions`, () => {
+  describe.only(`${dialect}: aggregate functions`, () => {
     let ctx: TestContext
 
     before(async function () {
@@ -357,6 +358,166 @@ for (const dialect of BUILT_IN_DIALECTS) {
             },
           })
         })
+
+        if (dialect === 'postgres' || dialect === 'sqlite') {
+          it(`should execute a query with ${funcName}(...) filter(where ...) in select clause`, async () => {
+            const query = ctx.db
+              .selectFrom('person')
+              .select([
+                func('person.id')
+                  .filter('person.gender', '=', 'female')
+                  .as(funcName),
+                (eb) =>
+                  getFuncFromExpressionBuilder(eb, funcName)('person.id')
+                    .filter('person.gender', '=', 'female')
+                    .as(`another_${funcName}`),
+              ])
+
+            testSql(query, dialect, {
+              postgres: {
+                sql: [
+                  `select`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = $1) as "${funcName}",`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = $2) as "another_${funcName}"`,
+                  `from "person"`,
+                ],
+                parameters: ['female', 'female'],
+              },
+              mysql: NOT_SUPPORTED,
+              sqlite: {
+                sql: [
+                  `select`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = ?) as "${funcName}",`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = ?) as "another_${funcName}"`,
+                  `from "person"`,
+                ],
+                parameters: ['female', 'female'],
+              },
+            })
+
+            await query.execute()
+          })
+
+          it(`should execute a query with ${funcName}(...) filter(where ... and ...) in select clause`, async () => {
+            const query = ctx.db
+              .selectFrom('person')
+              .select([
+                func('person.id')
+                  .filter('person.gender', '=', 'female')
+                  .filter('person.middle_name', 'is not', null)
+                  .as(funcName),
+                (eb) =>
+                  getFuncFromExpressionBuilder(eb, funcName)('person.id')
+                    .filter('person.gender', '=', 'female')
+                    .filter('person.middle_name', 'is not', null)
+                    .as(`another_${funcName}`),
+              ])
+
+            testSql(query, dialect, {
+              postgres: {
+                sql: [
+                  `select`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = $1 and "person"."middle_name" is not null) as "${funcName}",`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = $2 and "person"."middle_name" is not null) as "another_${funcName}"`,
+                  `from "person"`,
+                ],
+                parameters: ['female', 'female'],
+              },
+              mysql: NOT_SUPPORTED,
+              sqlite: {
+                sql: [
+                  `select`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = ? and "person"."middle_name" is not null) as "${funcName}",`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = ? and "person"."middle_name" is not null) as "another_${funcName}"`,
+                  `from "person"`,
+                ],
+                parameters: ['female', 'female'],
+              },
+            })
+
+            await query.execute()
+          })
+
+          it(`should execute a query with ${funcName}(...) filter(where ... or ...) in select clause`, async () => {
+            const query = ctx.db
+              .selectFrom('person')
+              .select([
+                func('person.id')
+                  .filter('person.gender', '=', 'female')
+                  .orFilter('person.middle_name', 'is not', null)
+                  .as(funcName),
+                (eb) =>
+                  getFuncFromExpressionBuilder(eb, funcName)('person.id')
+                    .filter('person.gender', '=', 'female')
+                    .orFilter('person.middle_name', 'is not', null)
+                    .as(`another_${funcName}`),
+              ])
+
+            testSql(query, dialect, {
+              postgres: {
+                sql: [
+                  `select`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = $1 or "person"."middle_name" is not null) as "${funcName}",`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = $2 or "person"."middle_name" is not null) as "another_${funcName}"`,
+                  `from "person"`,
+                ],
+                parameters: ['female', 'female'],
+              },
+              mysql: NOT_SUPPORTED,
+              sqlite: {
+                sql: [
+                  `select`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = ? or "person"."middle_name" is not null) as "${funcName}",`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = ? or "person"."middle_name" is not null) as "another_${funcName}"`,
+                  `from "person"`,
+                ],
+                parameters: ['female', 'female'],
+              },
+            })
+
+            await query.execute()
+          })
+
+          it(`should execute a query with ${funcName}(...) filter(where ...) over() in select clause`, async () => {
+            const query = ctx.db
+              .selectFrom('person')
+              .select([
+                func('person.id')
+                  .filter('person.gender', '=', 'female')
+                  .over()
+                  .as(funcName),
+                (eb) =>
+                  getFuncFromExpressionBuilder(eb, funcName)('person.id')
+                    .filter('person.gender', '=', 'female')
+                    .over()
+                    .as(`another_${funcName}`),
+              ])
+
+            testSql(query, dialect, {
+              postgres: {
+                sql: [
+                  `select`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = $1) over() as "${funcName}",`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = $2) over() as "another_${funcName}"`,
+                  `from "person"`,
+                ],
+                parameters: ['female', 'female'],
+              },
+              mysql: NOT_SUPPORTED,
+              sqlite: {
+                sql: [
+                  `select`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = ?) over() as "${funcName}",`,
+                  `${funcName}("person"."id") filter(where "person"."gender" = ?) over() as "another_${funcName}"`,
+                  `from "person"`,
+                ],
+                parameters: ['female', 'female'],
+              },
+            })
+
+            await query.execute()
+          })
+        }
       })
     }
   })

--- a/test/node/src/postgres-json.test.ts
+++ b/test/node/src/postgres-json.test.ts
@@ -1,6 +1,12 @@
 import { Generated, Kysely, RawBuilder, sql } from '../../../'
 
-import { destroyTest, initTest, TestContext, expect } from './test-setup.js'
+import {
+  destroyTest,
+  initTest,
+  TestContext,
+  expect,
+  Database,
+} from './test-setup.js'
 
 interface JsonTable {
   id: Generated<number>
@@ -14,7 +20,7 @@ interface JsonTable {
 
 describe(`postgres json tests`, () => {
   let ctx: TestContext
-  let db: Kysely<{ json_table: JsonTable }>
+  let db: Kysely<Database & { json_table: JsonTable }>
 
   before(async function () {
     ctx = await initTest(this, 'postgres')


### PR DESCRIPTION
brought up by @thelinuxlich on discord.

Postgres [[1]](https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-AGGREGATES) [[2]](https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS) & [SQLite](https://www.sqlite.org/windowfunctions.html#the_filter_clause) support `filter` clause when using aggregate functions, with syntax as follows:
```
aggregate_function(...) [filter(where ...)] [over(...)]
```

Its a simple alternative to using `case...when...then...end` inside the aggregate function.

This PR adds `filterWhere`, `filterWhereExists`, `filterWhereNotExists`, `filterWhereRef`, `orFilterWhere`, `orFilterWhereExists`, `orFilterWhereNotExists` & `orFiltereWhereRef` to `AggregateFunctionBuilder`.

---

- [x] implement.
- [x] unit tests.
- [x] typings tests.
- [x] ts docs.

---

Some things to consider..

- since `where` is nested in `filter`, maybe its more intuitive and future-proof to make a `FilterBuilder` that implements `WhereInterface`, and make `filter` accept a `FilterBuilderCallback` instead of acting as the `where` itself?
- ~maybe we should rename `filter` to `filterWhere` to not hide `where` from caller?~ went with it, feels more aligned with Kysely's API philosophy.
- since `filter` clause is a thing, maybe we should rename the existing `FilterNode`, parsers, etc and introduce a new `FilterNode`?