### PR TITLE
`exactOptionalPropertyTypes` should no longer error when updating/inserting with undefined values in nullable columns.

### DIFF
--- a/src/parser/insert-values-parser.ts
+++ b/src/parser/insert-values-parser.ts
@@ -19,11 +19,9 @@ export type InsertObject<DB, TB extends keyof DB> = {
     InsertType<DB[TB][C]>
   >
 } & {
-  [C in NullableInsertKeys<DB[TB]>]?: ValueExpression<
-    DB,
-    TB,
-    InsertType<DB[TB][C]>
-  >
+  [C in NullableInsertKeys<DB[TB]>]?:
+    | ValueExpression<DB, TB, InsertType<DB[TB][C]>>
+    | undefined
 }
 
 export type InsertObjectOrList<DB, TB extends keyof DB> =

--- a/src/parser/update-set-parser.ts
+++ b/src/parser/update-set-parser.ts
@@ -4,7 +4,9 @@ import { UpdateKeys, UpdateType } from '../util/column-type.js'
 import { parseValueExpression, ValueExpression } from './value-parser.js'
 
 export type MutationObject<DB, TB extends keyof DB, TM extends keyof DB> = {
-  [C in UpdateKeys<DB[TM]>]?: ValueExpression<DB, TB, UpdateType<DB[TM][C]>>
+  [C in UpdateKeys<DB[TM]>]?:
+    | ValueExpression<DB, TB, UpdateType<DB[TM][C]>>
+    | undefined
 }
 
 export function parseUpdateObject(

--- a/test/typings/test-d/index.test-d.ts
+++ b/test/typings/test-d/index.test-d.ts
@@ -693,9 +693,24 @@ async function testInsert(db: Kysely<Database>) {
     db.insertInto('person').values({
       first_name: 'what',
       gender: 'male',
-      age: (eb) => eb.selectFrom('pet').select('pet.name')
+      age: (eb) => eb.selectFrom('pet').select('pet.name'),
     })
   )
+
+  // Nullable column as undefined
+  const insertObject: {
+    first_name: string
+    last_name: string | undefined
+    age: number
+    gender: 'male' | 'female' | 'other'
+  } = {
+    first_name: 'emily',
+    last_name: 'smith',
+    age: 25,
+    gender: 'female',
+  }
+
+  db.insertInto('person').values(insertObject)
 }
 
 async function testReturning(db: Kysely<Database>) {
@@ -789,6 +804,13 @@ async function testUpdate(db: Kysely<Database>) {
   expectError(db.updateTable('book').set({ id: 1, name: 'foo' }))
 
   db.updateTable('book').set({ name: 'bar' })
+
+  // Nullable column as undefined
+  const mutationObject: { last_name: string | undefined } = {
+    last_name: 'smith',
+  }
+
+  db.updateTable('person').set(mutationObject)
 }
 
 async function testDelete(db: Kysely<Database>) {

--- a/test/typings/tsconfig.json
+++ b/test/typings/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig-base.json",
   "include": ["./**/*"],
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "module": "CommonJS"
   }
 }


### PR DESCRIPTION
2nd attempt at closing #170 . #171 missed the mark, changing things deeper than needed.