### PR TITLE
fix `FunctionModule.max` & `FunctionModule.min` autocompletion.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -179,12 +179,13 @@ export * from './util/compilable.js'
 export * from './util/explainable.js'
 export * from './util/log.js'
 export {
-  AnyColumn,
-  AnyColumnWithTable,
   AnyAliasedColumn,
   AnyAliasedColumnWithTable,
-  UnknownRow,
+  AnyColumn,
+  AnyColumnWithTable,
   AnySelectQueryBuilder,
+  Equals,
+  UnknownRow,
 } from './util/type-utils.js'
 export * from './util/infer-result.js'
 

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -152,3 +152,11 @@ export type Nullable<T> = { [P in keyof T]: T[P] | null }
  * // { name: string, age: number, species?: 'cat' | 'dog' }
  */
 export type MergePartial<T1, T2> = T1 & Partial<Omit<T2, keyof T1>>
+
+export type IsNever<T> = [T] extends [never] ? true : false
+
+export type Equals<T, U> = (<G>() => G extends T ? 1 : 2) extends <
+  G
+>() => G extends U ? 1 : 2
+  ? true
+  : false

--- a/test/typings/shared.d.ts
+++ b/test/typings/shared.d.ts
@@ -36,9 +36,3 @@ export interface Person {
   // update.
   modified_at: ColumnType<Date, never, never>
 }
-
-export type Equals<T, U> = (<G>() => G extends T ? 1 : 2) extends <
-  G
->() => G extends U ? 1 : 2
-  ? true
-  : false

--- a/test/typings/test-d/function-module.test-d.ts
+++ b/test/typings/test-d/function-module.test-d.ts
@@ -74,11 +74,7 @@ async function testSelectWithCustomGenerics(db: Kysely<Database>) {
     .select(avg<number | null>('age').as('nullable_avg_age'))
     .select(count<number>('age').as('total_people'))
     .select(max<number | null, 'age'>('age').as('nullable_max_age'))
-    .select(max<string, 'age'>('age').as('lying_max_age'))
-    .select(max<string | null, 'age'>('age').as('nullable_lying_max_age'))
     .select(min<number | null, 'age'>('age').as('nullable_min_age'))
-    .select(min<bigint, 'age'>('age').as('lying_min_age'))
-    .select(min<bigint | null, 'age'>('age').as('nullable_lying_min_age'))
     .select(sum<number>('age').as('total_age'))
     .select(sum<number | null>('age').as('nullable_total_age'))
     .executeTakeFirstOrThrow()
@@ -91,16 +87,8 @@ async function testSelectWithCustomGenerics(db: Kysely<Database>) {
   expectNotAssignable<string | bigint | null>(result.total_people)
   expectAssignable<number | null>(result.nullable_max_age)
   expectNotAssignable<string | bigint>(result.nullable_max_age)
-  expectAssignable<number>(result.lying_max_age)
-  expectNotAssignable<string | bigint | null>(result.lying_max_age)
-  expectAssignable<number | null>(result.nullable_lying_max_age)
-  expectNotAssignable<string | bigint>(result.nullable_lying_max_age)
   expectAssignable<number | null>(result.nullable_min_age)
   expectNotAssignable<string | bigint>(result.nullable_min_age)
-  expectAssignable<number>(result.lying_min_age)
-  expectNotAssignable<string | bigint | null>(result.lying_min_age)
-  expectAssignable<number | null>(result.nullable_lying_min_age)
-  expectNotAssignable<string | bigint>(result.nullable_lying_min_age)
   expectAssignable<number>(result.total_age)
   expectNotAssignable<string | bigint | null>(result.total_age)
   expectAssignable<number | null>(result.nullable_total_age)
@@ -109,14 +97,50 @@ async function testSelectWithCustomGenerics(db: Kysely<Database>) {
   expectError(
     db
       .selectFrom('person')
-      .select(max<number>('age').as('max_no_reference_generic'))
+      .select(max<string>('age').as('max_lie_return_type'))
       .executeTakeFirstOrThrow()
   )
 
   expectError(
     db
       .selectFrom('person')
-      .select(min<number>('age').as('min_no_reference_generic'))
+      .select(max<string, 'age'>('age').as('another_max_lie_return_type'))
+      .executeTakeFirstOrThrow()
+  )
+
+  expectError(
+    db
+      .selectFrom('person')
+      .select(
+        max<number | null>('age').as(
+          'max_explicit_return_type_but_no_string_ref'
+        )
+      )
+      .executeTakeFirstOrThrow()
+  )
+
+  expectError(
+    db
+      .selectFrom('person')
+      .select(min<string>('age').as('min_lie_return_type'))
+      .executeTakeFirstOrThrow()
+  )
+
+  expectError(
+    db
+      .selectFrom('person')
+      .select(min<string, 'age'>('age').as('another_min_lie_return_type'))
+      .executeTakeFirstOrThrow()
+  )
+
+  expectError(
+    db
+      .selectFrom('person')
+      .select(
+        min<number | null>('age').as(
+          'min_explicit_return_type_but_no_string_ref'
+        )
+      )
       .executeTakeFirstOrThrow()
   )
 }

--- a/test/typings/test-d/infer-result.test-d.ts
+++ b/test/typings/test-d/infer-result.test-d.ts
@@ -2,13 +2,14 @@ import { expectType } from 'tsd'
 
 import {
   DeleteResult,
+  Equals,
   InferResult,
   InsertResult,
   Kysely,
   Selectable,
   UpdateResult,
 } from '..'
-import { Database, Equals, Person, Pet } from '../shared'
+import { Database, Person, Pet } from '../shared'
 
 function testInferResultSelectQuery(db: Kysely<Database>) {
   const query0 = db.selectFrom('person').selectAll()


### PR DESCRIPTION
closes #221.

Tested autocompletion manually, seems to work now - except for when providing output type in generic - this is a wide typescript issue with partial generics inference and defaults.