### PR TITLE
feat(alter-table): support multiple column operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export * from './schema/foreign-key-constraint-builder.js'
 export * from './schema/alter-table-builder.js'
 export * from './schema/create-view-builder.js'
 export * from './schema/drop-view-builder.js'
+export * from './schema/alter-column-builder.js'
 
 export * from './dynamic/dynamic.js'
 

--- a/src/operation-node/alter-table-node.ts
+++ b/src/operation-node/alter-table-node.ts
@@ -10,18 +10,24 @@ import { AddConstraintNode } from './add-constraint-node.js'
 import { DropConstraintNode } from './drop-constraint-node.js'
 import { ModifyColumnNode } from './modify-column-node.js'
 
-export type AlterTableNodeProps = Omit<AlterTableNode, 'kind' | 'table'>
+export type AlterTableNodeTableProps = Pick<
+  AlterTableNode,
+  'renameTo' | 'setSchema' | 'addConstraint' | 'dropConstraint'
+>
+
+export type AlterTableColumnAlterationNode =
+  | RenameColumnNode
+  | AddColumnNode
+  | DropColumnNode
+  | AlterColumnNode
+  | ModifyColumnNode
 
 export interface AlterTableNode extends OperationNode {
   readonly kind: 'AlterTableNode'
   readonly table: TableNode
   readonly renameTo?: TableNode
   readonly setSchema?: IdentifierNode
-  readonly renameColumn?: RenameColumnNode
-  readonly addColumn?: AddColumnNode
-  readonly dropColumn?: DropColumnNode
-  readonly alterColumn?: AlterColumnNode
-  readonly modifyColumn?: ModifyColumnNode
+  readonly columnAlterations?: ReadonlyArray<AlterTableColumnAlterationNode>
   readonly addConstraint?: AddConstraintNode
   readonly dropConstraint?: DropConstraintNode
 }
@@ -41,10 +47,25 @@ export const AlterTableNode = freeze({
     })
   },
 
-  cloneWith(node: AlterTableNode, props: AlterTableNodeProps): AlterTableNode {
+  cloneWithTableProps(
+    node: AlterTableNode,
+    props: AlterTableNodeTableProps
+  ): AlterTableNode {
     return freeze({
       ...node,
       ...props,
+    })
+  },
+
+  cloneWithColumnAlteration(
+    node: AlterTableNode,
+    columnAlteration: AlterTableColumnAlterationNode
+  ): AlterTableNode {
+    return freeze({
+      ...node,
+      columnAlterations: node.columnAlterations
+        ? [...node.columnAlterations, columnAlteration]
+        : [columnAlteration],
     })
   },
 })

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -667,11 +667,7 @@ export class OperationNodeTransformer {
       table: this.transformNode(node.table),
       renameTo: this.transformNode(node.renameTo),
       setSchema: this.transformNode(node.setSchema),
-      renameColumn: this.transformNode(node.renameColumn),
-      addColumn: this.transformNode(node.addColumn),
-      dropColumn: this.transformNode(node.dropColumn),
-      alterColumn: this.transformNode(node.alterColumn),
-      modifyColumn: this.transformNode(node.modifyColumn),
+      columnAlterations: this.transformNodeList(node.columnAlterations),
       addConstraint: this.transformNode(node.addConstraint),
       dropConstraint: this.transformNode(node.dropConstraint),
     })

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -951,24 +951,8 @@ export class DefaultQueryCompiler
       this.visitNode(node.dropConstraint)
     }
 
-    if (node.renameColumn) {
-      this.visitNode(node.renameColumn)
-    }
-
-    if (node.addColumn) {
-      this.visitNode(node.addColumn)
-    }
-
-    if (node.dropColumn) {
-      this.visitNode(node.dropColumn)
-    }
-
-    if (node.alterColumn) {
-      this.visitNode(node.alterColumn)
-    }
-
-    if (node.modifyColumn) {
-      this.visitNode(node.modifyColumn)
+    if (node.columnAlterations) {
+      this.compileList(node.columnAlterations)
     }
   }
 

--- a/src/schema/alter-column-builder.ts
+++ b/src/schema/alter-column-builder.ts
@@ -1,0 +1,83 @@
+import { AlterColumnNode } from '../operation-node/alter-column-node.js'
+import {
+  ColumnDataType,
+  DataTypeNode,
+} from '../operation-node/data-type-node.js'
+import { OperationNode } from '../operation-node/operation-node.js'
+import { OperationNodeSource } from '../operation-node/operation-node-source.js'
+import {
+  DefaultValueExpression,
+  parseDefaultValueExpression,
+} from '../parser/default-value-parser.js'
+
+export class AlterColumnBuilder {
+  protected readonly alterColumnNode: AlterColumnNode
+
+  constructor(alterColumnNode: AlterColumnNode) {
+    this.alterColumnNode = alterColumnNode
+  }
+
+  setDataType(dataType: ColumnDataType): AlteredColumnBuilder {
+    return new AlteredColumnBuilder(
+      AlterColumnNode.cloneWith(this.alterColumnNode, {
+        dataType: DataTypeNode.create(dataType),
+      })
+    )
+  }
+
+  setDefault(value: DefaultValueExpression): AlteredColumnBuilder {
+    return new AlteredColumnBuilder(
+      AlterColumnNode.cloneWith(this.alterColumnNode, {
+        setDefault: parseDefaultValueExpression(value),
+      })
+    )
+  }
+
+  dropDefault(): AlteredColumnBuilder {
+    return new AlteredColumnBuilder(
+      AlterColumnNode.cloneWith(this.alterColumnNode, {
+        dropDefault: true,
+      })
+    )
+  }
+
+  setNotNull(): AlteredColumnBuilder {
+    return new AlteredColumnBuilder(
+      AlterColumnNode.cloneWith(this.alterColumnNode, {
+        setNotNull: true,
+      })
+    )
+  }
+
+  dropNotNull(): AlteredColumnBuilder {
+    return new AlteredColumnBuilder(
+      AlterColumnNode.cloneWith(this.alterColumnNode, {
+        dropNotNull: true,
+      })
+    )
+  }
+}
+
+/**
+ * Allows us to force consumers to do something, anything, when altering a column.
+ *
+ * Basically, deny the following:
+ *
+ * ```ts
+ * db.schema.alterTable('person').alterColumn('age', (ac) => ac)
+ * ```
+ *
+ * Which would now throw a compilation error, instead of a runtime error.
+ */
+export class AlteredColumnBuilder
+  extends AlterColumnBuilder
+  implements OperationNodeSource
+{
+  toOperationNode(): AlterColumnNode {
+    return this.alterColumnNode
+  }
+}
+
+export type AlterColumnBuilderCallback = (
+  builder: AlterColumnBuilder
+) => AlteredColumnBuilder

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -210,7 +210,7 @@ export class SchemaModule {
     return new AlterTableBuilder({
       queryId: createQueryId(),
       executor: this.#executor,
-      alterTableNode: AlterTableNode.create(table),
+      node: AlterTableNode.create(table),
     })
   }
 

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -1541,6 +1541,109 @@ for (const dialect of BUILT_IN_DIALECTS) {
           .execute()
       })
 
+      describe('add column', () => {
+        it('should add a column', async () => {
+          const builder = ctx.db.schema
+            .alterTable('test')
+            .addColumn('bool_col', 'boolean', (cb) => cb.notNull())
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: 'alter table "test" add column "bool_col" boolean not null',
+              parameters: [],
+            },
+            mysql: {
+              sql: 'alter table `test` add column `bool_col` boolean not null',
+              parameters: [],
+            },
+            sqlite: {
+              sql: 'alter table "test" add column "bool_col" boolean not null',
+              parameters: [],
+            },
+          })
+
+          await builder.execute()
+
+          expect(await getColumnMeta('test.bool_col')).to.containSubset({
+            name: 'bool_col',
+            isNullable: false,
+            dataType:
+              dialect === 'postgres'
+                ? 'bool'
+                : dialect === 'sqlite'
+                ? 'boolean'
+                : 'tinyint',
+          })
+        })
+
+        if (dialect !== 'sqlite') {
+          it('should add a unique column', async () => {
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .addColumn('bool_col', 'boolean', (cb) => cb.notNull().unique())
+
+            testSql(builder, dialect, {
+              postgres: {
+                sql: 'alter table "test" add column "bool_col" boolean not null unique',
+                parameters: [],
+              },
+              mysql: {
+                sql: 'alter table `test` add column `bool_col` boolean not null unique',
+                parameters: [],
+              },
+              sqlite: {
+                sql: 'alter table "test" add column "bool_col" boolean not null unique',
+                parameters: [],
+              },
+            })
+
+            await builder.execute()
+
+            expect(await getColumnMeta('test.bool_col')).to.containSubset({
+              name: 'bool_col',
+              isNullable: false,
+              dataType: dialect === 'postgres' ? 'bool' : 'tinyint',
+            })
+          })
+
+          it('should add multiple columns', async () => {
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .addColumn('another_col', 'text')
+              .addColumn('yet_another_col', 'integer')
+
+            testSql(builder, dialect, {
+              postgres: {
+                sql: [
+                  'alter table "test"',
+                  'add column "another_col" text,',
+                  'add column "yet_another_col" integer',
+                ],
+                parameters: [],
+              },
+              mysql: {
+                sql: [
+                  'alter table `test`',
+                  'add column `another_col` text,',
+                  'add column `yet_another_col` integer',
+                ],
+                parameters: [],
+              },
+              sqlite: {
+                sql: [
+                  'alter table "test"',
+                  'add column "another_col" text,',
+                  'add column "yet_another_col" integer',
+                ],
+                parameters: [],
+              },
+            })
+
+            await builder.execute()
+          })
+        }
+      })
+
       if (dialect === 'mysql') {
         describe('modify column', () => {
           it('should set column data type', async () => {
@@ -1563,8 +1666,7 @@ for (const dialect of BUILT_IN_DIALECTS) {
           it('should add not null constraint for column', async () => {
             const builder = ctx.db.schema
               .alterTable('test')
-              .modifyColumn('varchar_col', 'varchar(255)')
-              .notNull()
+              .modifyColumn('varchar_col', 'varchar(255)', (cb) => cb.notNull())
 
             testSql(builder, dialect, {
               mysql: {
@@ -1579,14 +1681,9 @@ for (const dialect of BUILT_IN_DIALECTS) {
           })
 
           it('should drop not null constraint for column', async () => {
-            expect(
-              (await getColumnMeta('test.varchar_col')).isNullable
-            ).to.equal(true)
-
             await ctx.db.schema
               .alterTable('test')
-              .modifyColumn('varchar_col', 'varchar(255)')
-              .notNull()
+              .modifyColumn('varchar_col', 'varchar(255)', (cb) => cb.notNull())
               .execute()
 
             expect(
@@ -1612,6 +1709,28 @@ for (const dialect of BUILT_IN_DIALECTS) {
               (await getColumnMeta('test.varchar_col')).isNullable
             ).to.equal(true)
           })
+
+          it('should modify multiple columns', async () => {
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .modifyColumn('varchar_col', 'varchar(255)')
+              .modifyColumn('integer_col', 'bigint')
+
+            testSql(builder, dialect, {
+              mysql: {
+                sql: [
+                  'alter table `test`',
+                  'modify column `varchar_col` varchar(255),',
+                  'modify column `integer_col` bigint',
+                ],
+                parameters: [],
+              },
+              postgres: NOT_SUPPORTED,
+              sqlite: NOT_SUPPORTED,
+            })
+
+            await builder.execute()
+          })
         })
       }
 
@@ -1620,8 +1739,7 @@ for (const dialect of BUILT_IN_DIALECTS) {
           it('should set default value', async () => {
             const builder = ctx.db.schema
               .alterTable('test')
-              .alterColumn('varchar_col')
-              .setDefault('foo')
+              .alterColumn('varchar_col', (ac) => ac.setDefault('foo'))
 
             testSql(builder, dialect, {
               postgres: {
@@ -1639,16 +1757,16 @@ for (const dialect of BUILT_IN_DIALECTS) {
           })
 
           it('should drop default value', async () => {
+            const subject = 'varchar_col'
+
             await ctx.db.schema
               .alterTable('test')
-              .alterColumn('varchar_col')
-              .setDefault('foo')
+              .alterColumn(subject, (ac) => ac.setDefault('foo'))
               .execute()
 
             const builder = ctx.db.schema
               .alterTable('test')
-              .alterColumn('varchar_col')
-              .dropDefault()
+              .alterColumn(subject, (ac) => ac.dropDefault())
 
             testSql(builder, dialect, {
               postgres: {
@@ -1661,7 +1779,6 @@ for (const dialect of BUILT_IN_DIALECTS) {
               },
               sqlite: NOT_SUPPORTED,
             })
-
             await builder.execute()
           })
 
@@ -1669,8 +1786,7 @@ for (const dialect of BUILT_IN_DIALECTS) {
             it('should set column data type', async () => {
               const builder = ctx.db.schema
                 .alterTable('test')
-                .alterColumn('varchar_col')
-                .setDataType('text')
+                .alterColumn('varchar_col', (ac) => ac.setDataType('text'))
 
               testSql(builder, dialect, {
                 postgres: {
@@ -1690,8 +1806,7 @@ for (const dialect of BUILT_IN_DIALECTS) {
             it('should add not null constraint for column', async () => {
               const builder = ctx.db.schema
                 .alterTable('test')
-                .alterColumn('varchar_col')
-                .setNotNull()
+                .alterColumn('varchar_col', (ac) => ac.setNotNull())
 
               testSql(builder, dialect, {
                 postgres: {
@@ -1711,14 +1826,12 @@ for (const dialect of BUILT_IN_DIALECTS) {
             it('should drop not null constraint for column', async () => {
               await ctx.db.schema
                 .alterTable('test')
-                .alterColumn('varchar_col')
-                .setNotNull()
+                .alterColumn('varchar_col', (ac) => ac.setNotNull())
                 .execute()
 
               const builder = ctx.db.schema
                 .alterTable('test')
-                .alterColumn('varchar_col')
-                .dropNotNull()
+                .alterColumn('varchar_col', (ac) => ac.dropNotNull())
 
               testSql(builder, dialect, {
                 postgres: {
@@ -1735,6 +1848,35 @@ for (const dialect of BUILT_IN_DIALECTS) {
               await builder.execute()
             })
           }
+
+          it('should alter multiple columns', async () => {
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .alterColumn('varchar_col', (ac) => ac.setDefault('foo'))
+              .alterColumn('integer_col', (ac) => ac.setDefault(5))
+
+            testSql(builder, dialect, {
+              postgres: {
+                sql: [
+                  `alter table "test"`,
+                  `alter column "varchar_col" set default 'foo',`,
+                  `alter column "integer_col" set default 5`,
+                ],
+                parameters: [],
+              },
+              mysql: {
+                sql: [
+                  'alter table `test`',
+                  "alter column `varchar_col` set default 'foo',",
+                  'alter column `integer_col` set default 5',
+                ],
+                parameters: [],
+              },
+              sqlite: NOT_SUPPORTED,
+            })
+
+            await builder.execute()
+          })
         })
       }
 
@@ -1761,6 +1903,49 @@ for (const dialect of BUILT_IN_DIALECTS) {
 
           await builder.execute()
         })
+
+        if (dialect !== 'sqlite') {
+          it('should drop multiple columns', async () => {
+            await ctx.db.schema
+              .alterTable('test')
+              .addColumn('text_col', 'text')
+              .execute()
+
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .dropColumn('varchar_col')
+              .dropColumn('text_col')
+
+            testSql(builder, dialect, {
+              postgres: {
+                sql: [
+                  'alter table "test"',
+                  'drop column "varchar_col",',
+                  'drop column "text_col"',
+                ],
+                parameters: [],
+              },
+              mysql: {
+                sql: [
+                  'alter table `test`',
+                  'drop column `varchar_col`,',
+                  'drop column `text_col`',
+                ],
+                parameters: [],
+              },
+              sqlite: {
+                sql: [
+                  'alter table "test"',
+                  'drop column "varchar_col",',
+                  'drop column "text_col"',
+                ],
+                parameters: [],
+              },
+            })
+
+            await builder.execute()
+          })
+        }
       })
 
       describe('rename', () => {
@@ -1828,108 +2013,106 @@ for (const dialect of BUILT_IN_DIALECTS) {
 
           await builder.execute()
         })
-      })
 
-      describe('add column', () => {
-        it('should add a column', async () => {
-          const builder = ctx.db.schema
-            .alterTable('test')
-            .addColumn('bool_col', 'boolean')
-            .notNull()
-
-          testSql(builder, dialect, {
-            postgres: {
-              sql: 'alter table "test" add column "bool_col" boolean not null',
-              parameters: [],
-            },
-            mysql: {
-              sql: 'alter table `test` add column `bool_col` boolean not null',
-              parameters: [],
-            },
-            sqlite: {
-              sql: 'alter table "test" add column "bool_col" boolean not null',
-              parameters: [],
-            },
-          })
-
-          await builder.execute()
-
-          expect(await getColumnMeta('test.bool_col')).to.containSubset({
-            name: 'bool_col',
-            isNullable: false,
-            dataType:
-              dialect === 'postgres'
-                ? 'bool'
-                : dialect === 'sqlite'
-                ? 'boolean'
-                : 'tinyint',
-          })
-        })
-
-        it('should add a column using a callback', async () => {
-          const builder = ctx.db.schema
-            .alterTable('test')
-            .addColumn('bool_col', 'boolean', (col) => col.notNull())
-
-          testSql(builder, dialect, {
-            postgres: {
-              sql: 'alter table "test" add column "bool_col" boolean not null',
-              parameters: [],
-            },
-            mysql: {
-              sql: 'alter table `test` add column `bool_col` boolean not null',
-              parameters: [],
-            },
-            sqlite: {
-              sql: 'alter table "test" add column "bool_col" boolean not null',
-              parameters: [],
-            },
-          })
-
-          await builder.execute()
-
-          expect(await getColumnMeta('test.bool_col')).to.containSubset({
-            name: 'bool_col',
-            isNullable: false,
-            dataType:
-              dialect === 'postgres'
-                ? 'bool'
-                : dialect === 'sqlite'
-                ? 'boolean'
-                : 'tinyint',
-          })
-        })
-
-        if (dialect !== 'sqlite') {
-          it('should add a unique column', async () => {
+        if (dialect === 'mysql') {
+          it('should rename multiple columns', async () => {
             const builder = ctx.db.schema
               .alterTable('test')
-              .addColumn('bool_col', 'boolean')
-              .notNull()
-              .unique()
+              .renameColumn('varchar_col', 'text_col')
+              .renameColumn('integer_col', 'number_col')
 
             testSql(builder, dialect, {
               postgres: {
-                sql: 'alter table "test" add column "bool_col" boolean not null unique',
+                sql: [
+                  'alter table "test"',
+                  'rename column "varchar_col" to "text_col",',
+                  'rename column "integer_col" to "number_col"',
+                ],
                 parameters: [],
               },
               mysql: {
-                sql: 'alter table `test` add column `bool_col` boolean not null unique',
+                sql: [
+                  'alter table `test`',
+                  'rename column `varchar_col` to `text_col`,',
+                  'rename column `integer_col` to `number_col`',
+                ],
                 parameters: [],
               },
               sqlite: {
-                sql: 'alter table "test" add column "bool_col" boolean not null unique',
+                sql: [
+                  'alter table "test"',
+                  'rename column "varchar_col" to "text_col",',
+                  'rename column "integer_col" to "number_col"',
+                ],
                 parameters: [],
               },
             })
 
             await builder.execute()
+          })
+        }
+      })
 
-            expect(await getColumnMeta('test.bool_col')).to.containSubset({
-              name: 'bool_col',
-              isNullable: false,
-              dataType: dialect === 'postgres' ? 'bool' : 'tinyint',
+      describe('mixed column alterations', () => {
+        if (dialect === 'postgres') {
+          it('should alter multiple columns in various ways', async () => {
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .addColumn('another_varchar_col', 'varchar(255)')
+              .alterColumn('varchar_col', (ac) => ac.setDefault('foo'))
+              .dropColumn('integer_col')
+
+            testSql(builder, dialect, {
+              postgres: {
+                sql: [
+                  `alter table "test"`,
+                  `add column "another_varchar_col" varchar(255),`,
+                  `alter column "varchar_col" set default 'foo',`,
+                  `drop column "integer_col"`,
+                ],
+                parameters: [],
+              },
+              mysql: NOT_SUPPORTED,
+              sqlite: NOT_SUPPORTED,
             })
+
+            await builder.execute()
+          })
+        }
+
+        if (dialect === 'mysql') {
+          it('should alter multiple columns in various ways', async () => {
+            await ctx.db.schema
+              .alterTable('test')
+              .addColumn('rename_me', 'text')
+              .addColumn('modify_me', 'boolean')
+              .execute()
+
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .addColumn('another_varchar_col', 'varchar(255)')
+              .alterColumn('varchar_col', (ac) => ac.setDefault('foo'))
+              .dropColumn('integer_col')
+              .renameColumn('rename_me', 'text_col')
+              .modifyColumn('modify_me', 'bigint')
+
+            testSql(builder, dialect, {
+              postgres: NOT_SUPPORTED,
+              mysql: {
+                sql: [
+                  'alter table `test`',
+                  'add column `another_varchar_col` varchar(255),',
+                  "alter column `varchar_col` set default 'foo',",
+                  'drop column `integer_col`,',
+                  'rename column `rename_me` to `text_col`,',
+                  'modify column `modify_me` bigint',
+                ],
+                parameters: [],
+              },
+              sqlite: NOT_SUPPORTED,
+            })
+
+            await builder.execute()
           })
         }
       })


### PR DESCRIPTION
- feat(alter-table-node)!: allow multiple alter ops - allow multiple column alterations at `AlterTableNode`
- def-query-compiler: align /w  AlterTableNode
- operation-node-transformer align /w AlterTableNode
- add alter column builder
- remove usages of ColumnDefinitionBuilderInterface
- allow multiple col alterations@alter-table-builder
- rename schema alterTable prop
- added alter-column-builder to index
- added and fixed unit tests

co authored by @igalklebanov 
closes #217
