### PR TITLE
add `executeTakeFirstRow(...)` & `executeTakeFirstRowOrThrow(...)` @ `RawBuilder`.

### DIFF
--- a/src/query-builder/no-result-error.ts
+++ b/src/query-builder/no-result-error.ts
@@ -1,14 +1,15 @@
 import { QueryNode } from '../operation-node/query-node.js'
+import { RawNode } from '../operation-node/raw-node.js'
 
-export type NoResultErrorConstructor = new (node: QueryNode) => Error
+export type NoResultErrorConstructor = new (node: QueryNode | RawNode) => Error
 
 export class NoResultError extends Error {
   /**
    * The operation node tree of the query that was executed.
    */
-  readonly node: QueryNode
+  readonly node: QueryNode | RawNode
 
-  constructor(node: QueryNode) {
+  constructor(node: QueryNode | RawNode) {
     super('no result')
     this.node = node
   }

--- a/test/node/src/execute.test.ts
+++ b/test/node/src/execute.test.ts
@@ -1,4 +1,4 @@
-import { NoResultError, QueryNode } from '../../../'
+import { NoResultError, QueryNode, RawNode } from '../../../'
 
 import {
   BUILT_IN_DIALECTS,
@@ -72,9 +72,9 @@ for (const dialect of BUILT_IN_DIALECTS) {
 
       it('should throw a custom error if no result is found and a custom error is provided', async () => {
         class MyNotFoundError extends Error {
-          node: QueryNode
+          node: QueryNode | RawNode
 
-          constructor(node: QueryNode) {
+          constructor(node: QueryNode | RawNode) {
             super('custom error')
             this.node = node
           }

--- a/test/node/src/raw-query.test.ts
+++ b/test/node/src/raw-query.test.ts
@@ -1,4 +1,4 @@
-import { sql } from '../../../'
+import { NoResultError, QueryNode, RawNode, sql } from '../../../'
 
 import {
   BUILT_IN_DIALECTS,
@@ -30,76 +30,159 @@ for (const dialect of BUILT_IN_DIALECTS) {
       await destroyTest(ctx)
     })
 
-    it('should run a raw select query', async () => {
-      const gender = 'male'
+    describe('execute', () => {
+      it('should run a raw select query', async () => {
+        const gender = 'male'
 
-      const result = await sql<{
-        first_name: string
-      }>`select first_name from person where gender = ${gender} order by first_name asc, last_name asc`.execute(
-        ctx.db
-      )
-
-      expect(result.insertId).to.equal(undefined)
-      expect(result.numUpdatedOrDeletedRows).to.equal(undefined)
-      expect(result.rows).to.eql([
-        { first_name: 'Arnold' },
-        { first_name: 'Sylvester' },
-      ])
-    })
-
-    it('should run a raw update query', async () => {
-      const newFirstName = 'Updated'
-      const gender = 'male'
-
-      const result =
-        await sql`update person set first_name = ${newFirstName} where gender = ${gender}`.execute(
+        const result = await sql<{
+          first_name: string
+        }>`select first_name from person where gender = ${gender} order by first_name asc, last_name asc`.execute(
           ctx.db
         )
 
-      expect(result.numUpdatedOrDeletedRows).to.equal(2n)
-      expect(result.rows).to.eql([])
-    })
-
-    it('should run a raw delete query', async () => {
-      const gender = 'male'
-
-      const result =
-        await sql`delete from person where gender = ${gender}`.execute(ctx.db)
-
-      expect(result.numUpdatedOrDeletedRows).to.equal(2n)
-      expect(result.rows).to.eql([])
-    })
-
-    if (dialect === 'postgres') {
-      it('should run a raw insert query', async () => {
-        const firstName = 'New'
-        const lastName = 'Personsson'
-        const gender = 'other'
-
-        const result =
-          await sql`insert into person (first_name, last_name, gender) values (${firstName}, ${lastName}, ${gender}) returning first_name, last_name`.execute(
-            ctx.db
-          )
-
         expect(result.insertId).to.equal(undefined)
+        expect(result.numUpdatedOrDeletedRows).to.equal(undefined)
         expect(result.rows).to.eql([
-          { first_name: 'New', last_name: 'Personsson' },
+          { first_name: 'Arnold' },
+          { first_name: 'Sylvester' },
         ])
       })
-    } else {
-      it('should run a raw insert query', async () => {
-        const firstName = 'New'
-        const lastName = 'Personsson'
-        const gender = 'other'
+
+      it('should run a raw update query', async () => {
+        const newFirstName = 'Updated'
+        const gender = 'male'
 
         const result =
-          await sql`insert into person (first_name, last_name, gender) values (${firstName}, ${lastName}, ${gender})`.execute(
+          await sql`update person set first_name = ${newFirstName} where gender = ${gender}`.execute(
             ctx.db
           )
 
-        expect(result.insertId! > 0n).to.be.equal(true)
+        expect(result.numUpdatedOrDeletedRows).to.equal(2n)
         expect(result.rows).to.eql([])
       })
-    }
+
+      it('should run a raw delete query', async () => {
+        const gender = 'male'
+
+        const result =
+          await sql`delete from person where gender = ${gender}`.execute(ctx.db)
+
+        expect(result.numUpdatedOrDeletedRows).to.equal(2n)
+        expect(result.rows).to.eql([])
+      })
+
+      if (dialect === 'postgres') {
+        it('should run a raw insert query', async () => {
+          const firstName = 'New'
+          const lastName = 'Personsson'
+          const gender = 'other'
+
+          const result =
+            await sql`insert into person (first_name, last_name, gender) values (${firstName}, ${lastName}, ${gender}) returning first_name, last_name`.execute(
+              ctx.db
+            )
+
+          expect(result.insertId).to.equal(undefined)
+          expect(result.rows).to.eql([
+            { first_name: 'New', last_name: 'Personsson' },
+          ])
+        })
+      } else {
+        it('should run a raw insert query', async () => {
+          const firstName = 'New'
+          const lastName = 'Personsson'
+          const gender = 'other'
+
+          const result =
+            await sql`insert into person (first_name, last_name, gender) values (${firstName}, ${lastName}, ${gender})`.execute(
+              ctx.db
+            )
+
+          expect(result.insertId! > 0n).to.be.equal(true)
+          expect(result.rows).to.eql([])
+        })
+      }
+    })
+
+    describe('executeTakeFirstRow', () => {
+      it('should run a raw select query and return first row', async () => {
+        const gender = 'male'
+
+        const result = await sql<{
+          first_name: string
+        }>`select first_name from person where gender = ${gender} order by first_name asc, last_name asc`.executeTakeFirstRow(
+          ctx.db
+        )
+
+        expect(result).to.deep.equal({ first_name: 'Arnold' })
+      })
+
+      it('should run a raw select query and return undefined when no rows returned', async () => {
+        const gender = 'NO_SUCH_GENDER'
+
+        const result = await sql<{
+          first_name: string
+        }>`select first_name from person where gender = ${gender} order by first_name asc, last_name asc`.executeTakeFirstRow(
+          ctx.db
+        )
+
+        expect(result).to.be.undefined
+      })
+    })
+
+    describe('executeTakeFirstRowOrThrow', () => {
+      it('should run a raw select query and return first row', async () => {
+        const gender = 'male'
+
+        const result = await sql<{
+          first_name: string
+        }>`select first_name from person where gender = ${gender} order by first_name asc, last_name asc`.executeTakeFirstRowOrThrow(
+          ctx.db
+        )
+
+        expect(result).to.deep.equal({ first_name: 'Arnold' })
+      })
+
+      it('should run a raw select query and throw NoResultError when no rows returned', async () => {
+        const gender = 'NO_SUCH_GENDER'
+
+        try {
+          await sql<{
+            first_name: string
+          }>`select first_name from person where gender = ${gender} order by first_name asc, last_name asc`.executeTakeFirstRowOrThrow(
+            ctx.db
+          )
+        } catch (error) {
+          expect(error instanceof NoResultError).to.be.true
+        }
+      })
+
+      it('should run a raw select query and throw a custom error when no rows returned', async () => {
+        const gender = 'NO_SUCH_GENDER'
+        class MyNotFoundError extends Error {
+          node: QueryNode | RawNode
+
+          constructor(node: QueryNode | RawNode) {
+            super('custom error')
+            this.node = node
+          }
+        }
+
+        try {
+          await sql<{
+            first_name: string
+          }>`select first_name from person where gender = ${gender} order by first_name asc, last_name asc`.executeTakeFirstRowOrThrow(
+            ctx.db,
+            MyNotFoundError
+          )
+        } catch (error) {
+          expect(error instanceof MyNotFoundError).to.be.true
+
+          if (error instanceof MyNotFoundError) {
+            expect(error.node.kind).to.equal('RawNode')
+          }
+        }
+      })
+    })
   })
 }


### PR DESCRIPTION
closes #212.

- [x] implement.
- [x] unit tests.

small QoL improvement for anyone executing result set returning queries using `sql` template tag or `RawBuilder`.

I'm not 100% sure about the naming..

On one hand, `executeTakeFirst(...)` & `executeTakeFirstOrThrow(...)` do align with our query builders, so it'll feel like home for our consumers.

On the other, the lack of context in `RawBuilder.execute(...)` does not allow us to return `InsertResult`/`UpdateResult`/`DeleteResult` (unless we go for sql string compilation - which is probably something we don't want for kysely), so adding `Row` to these methods removes any false expectations a consumer might have.

---

This PR introduces a breaking change for anyone who's using `errorConstructor` arguments in `executeTakeFirstOrThrow(...)` - it's underlying node's type is now `QueryNode | RawNode`.

---

Maybe we should also have something like `executeTakeRows(...)` (returning `O[]`)?