### PR TITLE
Add `call` to create/alter table statement builder

### DIFF
--- a/src/schema/alter-table-builder.ts
+++ b/src/schema/alter-table-builder.ts
@@ -208,6 +208,15 @@ export class AlterTableBuilder {
       }),
     })
   }
+
+  /**
+   * Calls the given function passing `this` as the only argument.
+   *
+   * See {@link CreateTableBuilder.call}
+   */
+  call<T>(func: (qb: this) => T): T {
+    return func(this)
+  }
 }
 
 export interface AlterTableBuilderProps {

--- a/src/schema/create-table-builder.ts
+++ b/src/schema/create-table-builder.ts
@@ -355,6 +355,42 @@ export class CreateTableBuilder<TB extends string, C extends string = never>
     })
   }
 
+  /**
+   * Calls the given function passing `this` as the only argument.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * db.schema
+   *   .createTable('test')
+   *   .call((builder) => builder.addColumn('id', 'integer'))
+   *   .execute()
+   * ```
+   *
+   * ```ts
+   * const addDefaultColumns = <T extends string, C extends string = never>(
+   *   builder: CreateTableBuilder<T, C>
+   * ) => {
+   *   return builder
+   *     .addColumn('id', 'integer', (col) => col.notNull())
+   *     .addColumn('created_at', 'date', (col) =>
+   *       col.notNull().defaultTo(sql`now()`)
+   *     )
+   *     .addColumn('updated_at', 'date', (col) =>
+   *       col.notNull().defaultTo(sql`now()`)
+   *     )
+   * }
+   *
+   * db.schema
+   *   .createTable('test')
+   *   .call(addDefaultColumns)
+   *   .execute()
+   * ```
+   */
+  call<T>(func: (qb: this) => T): T {
+    return func(this)
+  }
+
   toOperationNode(): CreateTableNode {
     return this.#props.executor.transformQuery(
       this.#props.createTableNode,

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -786,6 +786,46 @@ for (const dialect of BUILT_IN_DIALECTS) {
           await builder.execute()
         })
       }
+
+      it('should create a table calling query builder functions', async () => {
+        const builder = ctx.db.schema
+          .createTable('test')
+          .addColumn('id', 'integer', (col) => col.notNull())
+          .call((builder) =>
+            builder.addColumn('call_me', 'varchar(10)', (col) =>
+              col.defaultTo('maybe')
+            )
+          )
+
+        testSql(builder, dialect, {
+          postgres: {
+            sql: [
+              'create table "test"',
+              '("id" integer not null,',
+              `"call_me" varchar(10) default 'maybe')`,
+            ],
+            parameters: [],
+          },
+          mysql: {
+            sql: [
+              'create table `test`',
+              '(`id` integer not null,',
+              "`call_me` varchar(10) default 'maybe')",
+            ],
+            parameters: [],
+          },
+          sqlite: {
+            sql: [
+              'create table "test"',
+              '("id" integer not null,',
+              `"call_me" varchar(10) default 'maybe')`,
+            ],
+            parameters: [],
+          },
+        })
+
+        await builder.execute()
+      })
     })
 
     describe('drop table', () => {
@@ -2106,6 +2146,31 @@ for (const dialect of BUILT_IN_DIALECTS) {
           })
         })
       }
+
+      it('should alter a table calling query builder functions', async () => {
+        const builder = ctx.db.schema
+          .alterTable('test')
+          .call((builder) =>
+            builder.addColumn('abc', 'integer', (col) => col.defaultTo('42'))
+          )
+
+        testSql(builder, dialect, {
+          postgres: {
+            sql: [`alter table "test" add column "abc" integer default '42'`],
+            parameters: [],
+          },
+          mysql: {
+            sql: ["alter table `test` add column `abc` integer default '42'"],
+            parameters: [],
+          },
+          sqlite: {
+            sql: [`alter table "test" add column "abc" integer default '42'`],
+            parameters: [],
+          },
+        })
+
+        await builder.execute()
+      })
     })
 
     async function dropTestTables(): Promise<void> {


### PR DESCRIPTION
This is a copy of the approach used on the query builders (e.g. [`SelectQueryBuilder`](https://github.com/koskimas/kysely/blob/9c9acc6a4dbaf90b178397d3ceafdc22d3cb2b46/src/query-builder/select-query-builder.ts#L1471-L1495)), applied to the builders used for creating and altering tables. This addition should make it easier to write reusable functions that operate on those builders!