### PR TITLE
Fix prettier glob pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:typings": "tsd test/typings",
     "test:esmimports": "node scripts/check-esm-imports.js",
     "test:esbuild": "esbuild --bundle --platform=node --external:pg-native dist/esm/index.js --outfile=/dev/null",
-    "prettier": "prettier --write src/**/*.ts test/**/*.ts",
+    "prettier": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run script:module-fixup && npm run script:copy-interface-doc",
     "build:esm": "tsc -p tsconfig.json && npm run script:add-deno-type-references",
     "build:cjs": "tsc -p tsconfig-cjs.json",

--- a/src/plugin/deduplicate-joins/deduplicate-joins-plugin.ts
+++ b/src/plugin/deduplicate-joins/deduplicate-joins-plugin.ts
@@ -10,7 +10,7 @@ import { DeduplicateJoinsTransformer } from './deduplicate-joins-transformer.js'
 
 /**
  * Plugin that removes duplicate joins from queries.
- * 
+ *
  * See [this recipe](https://github.com/koskimas/kysely/tree/master/recipes/deduplicate-joins.md)
  */
 export class DeduplicateJoinsPlugin implements KyselyPlugin {

--- a/test/node/src/with-schema.test.ts
+++ b/test/node/src/with-schema.test.ts
@@ -288,14 +288,14 @@ for (const dialect of ['postgres'] as const) {
           .createTable('foo')
           .addColumn('bar', 'integer', (col) => col.references('pets.id'))
 
-          testSql(query, dialect, {
-            postgres: {
-              sql: 'create table "mammals"."foo" ("bar" integer references "mammals"."pets" ("id"))',
-              parameters: [],
-            },
-            mysql: NOT_SUPPORTED,
-            sqlite: NOT_SUPPORTED,
-          })
+        testSql(query, dialect, {
+          postgres: {
+            sql: 'create table "mammals"."foo" ("bar" integer references "mammals"."pets" ("id"))',
+            parameters: [],
+          },
+          mysql: NOT_SUPPORTED,
+          sqlite: NOT_SUPPORTED,
+        })
       })
     })
 

--- a/test/typings/test-d/clear.test-d.ts
+++ b/test/typings/test-d/clear.test-d.ts
@@ -13,11 +13,11 @@ async function testClearSelect(db: Kysely<Database>) {
   expectType<{ id: number }>(r1)
 
   const r2 = await db
-      .selectFrom('person')
-      .selectAll()
-      .clearSelect()
-      .select('age')
-      .executeTakeFirstOrThrow()
+    .selectFrom('person')
+    .selectAll()
+    .clearSelect()
+    .select('age')
+    .executeTakeFirstOrThrow()
 
   expectType<{ age: number }>(r2)
 }


### PR DESCRIPTION
I found that some files are not formatted with `npm run prettier` = `prettier --write src/**/*.ts test/**/*.ts`. It is because shell parses glob patterns, not prettier parses them.


If glob pattern arguments are not quoted, the shell parses them and pass parsed strings to the  command. For easy understanding, I replace `prettier` command to `echo`.

```shell
$ echo test/**/*.ts
test/browser/main.ts
test/deno/cdn.test.ts
test/deno/local.test.ts
test/typings/index.d.ts
test/typings/shared.d.ts
```
(I inserted new line manually for readability) This is cause of the problem. I'm using `ubuntu 22.04` with `bash 5.1.16(1)-release`, my bash parses `test/**/*.ts` to a small part of the files. I don't know why.

When I quote the argument,

```shell
$ echo 'test/**/*.ts'
test/**/*.ts
```

It was passed to the command as-is. So back to kysely, if I change this line
https://github.com/koskimas/kysely/blob/71507c4102ca1ae86fa18940c53310aa6e15ac1b/package.json#L31
to `    "prettier": "prettier --write 'src/**/*.ts' 'test/**/*.ts'"`,
then finally all files in the project could be formatted.

I ran prettier again(a99b912), and found not formatted files. So I think this issue is not only relevant to me but also to other people.