### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ dist
 test/browser/bundle.js
 node_modules
 .vscode
+.idea
 demo.ts


### PR DESCRIPTION
This is for preventing `.idea` directory from being committed accidentally, just like `.vscode`.