### PR TITLE
Add match to allowed comparison operators

### DIFF
--- a/src/operation-node/operator-node.ts
+++ b/src/operation-node/operator-node.ts
@@ -16,6 +16,7 @@ export const COMPARISON_OPERATORS = [
   'is not',
   'like',
   'not like',
+  'match',
   'ilike',
   'not ilike',
   '@>',


### PR DESCRIPTION
Fixes https://github.com/koskimas/kysely/issues/279

In sqlite, a query like ```SELECT * 
FROM posts 
WHERE posts MATCH 'text' 
ORDER BY rank;``` is a valid query