### PR TITLE
Allow to have additional properties for KyselyPlugin.

### DIFF
--- a/src/plugin/kysely-plugin.ts
+++ b/src/plugin/kysely-plugin.ts
@@ -43,6 +43,8 @@ export interface KyselyPlugin {
   transformResult(
     args: PluginTransformResultArgs
   ): Promise<QueryResult<UnknownRow>>
+
+  [property: string | number | symbol]: any
 }
 
 export interface PluginTransformQueryArgs {


### PR DESCRIPTION
This change allow create plugin like this:

```ts
const plugin: KyselyPlugin = {
  data: new WeakMap<QueryId, SomeData>(),

  transformQuery(args: PluginTransformQueryArgs) {
    this.data.set(args.queryId, something);
    return args.node;
  },

  async transformResult(args: PluginTransformResultArgs) {
    const data = this.data.get(args.queryId);
    return args.result;
  },
};
```

For now, `data` property not allowed in `KyselyPlugin`.