### PR TITLE
add `deleteFrom([t1, t2, ...])` overload.

### DIFF
--- a/src/operation-node/delete-query-node.ts
+++ b/src/operation-node/delete-query-node.ts
@@ -32,10 +32,10 @@ export const DeleteQueryNode = freeze({
     return node.kind === 'DeleteQueryNode'
   },
 
-  create(fromItem: OperationNode, withNode?: WithNode): DeleteQueryNode {
+  create(fromItems: OperationNode[], withNode?: WithNode): DeleteQueryNode {
     return freeze({
       kind: 'DeleteQueryNode',
-      from: FromNode.create([fromItem]),
+      from: FromNode.create(fromItems),
       ...(withNode && { with: withNode }),
     })
   },

--- a/src/parser/table-parser.ts
+++ b/src/parser/table-parser.ts
@@ -22,6 +22,10 @@ export type TableReference<DB> =
   | AnyTable<DB>
   | AliasedExpression<any, any>
 
+export type TableReferenceOrList<DB> =
+  | TableReference<DB>
+  | ReadonlyArray<TableReference<DB>>
+
 export type From<DB, TE> = {
   [C in
     | keyof DB

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -289,15 +289,19 @@ export class QueryCreator<DB> {
    * ```ts
    * const result = await db
    *   .deleteFrom(['person', 'pet'])
+   *   .using('person')
+   *   .innerJoin('pet', 'pet.owner_id', '=', 'person.id')
    *   .where('person.id', '=', 1)
-   *   .orWhere('pet.owner_id', '=', 1)
    *   .executeTakeFirst()
    * ```
    *
    * The generated SQL (MySQL):
    *
    * ```sql
-   * delete from `person`, `pet` where `person`.`id` = ? or `pet`.`owner_id` = ?
+   * delete from `person`, `pet`
+   * using `person`
+   * inner join `pet` on `pet`.`owner_id` = `person`.`id`
+   * where `person`.`id` = ?
    * ```
    */
   deleteFrom<TR extends TableReference<DB>>(

--- a/src/query-creator.ts
+++ b/src/query-creator.ts
@@ -15,6 +15,7 @@ import {
   TableExpressionOrList,
   FromTables,
   TableReference,
+  TableReferenceOrList,
 } from './parser/table-parser.js'
 import { QueryExecutor } from './query-executor/query-executor.js'
 import {
@@ -266,6 +267,8 @@ export class QueryCreator<DB> {
    *
    * ### Examples
    *
+   * Deleting person with id 1:
+   *
    * ```ts
    * const result = await db
    *   .deleteFrom('person')
@@ -274,15 +277,43 @@ export class QueryCreator<DB> {
    *
    * console.log(result.numDeletedRows)
    * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * delete from "person" where "person"."id" = $1
+   * ```
+   *
+   * Some databases such as MySQL support deleting from multiple tables:
+   *
+   * ```ts
+   * const result = await db
+   *   .deleteFrom(['person', 'pet'])
+   *   .where('person.id', '=', 1)
+   *   .orWhere('pet.owner_id', '=', 1)
+   *   .executeTakeFirst()
+   * ```
+   *
+   * The generated SQL (MySQL):
+   *
+   * ```sql
+   * delete from `person`, `pet` where `person`.`id` = ? or `pet`.`owner_id` = ?
+   * ```
    */
   deleteFrom<TR extends TableReference<DB>>(
+    tables: TR[]
+  ): DeleteQueryBuilder<From<DB, TR>, FromTables<DB, never, TR>, DeleteResult>
+
+  deleteFrom<TR extends TableReference<DB>>(
     table: TR
-  ): DeleteQueryBuilder<From<DB, TR>, FromTables<DB, never, TR>, DeleteResult> {
+  ): DeleteQueryBuilder<From<DB, TR>, FromTables<DB, never, TR>, DeleteResult>
+
+  deleteFrom(tables: TableReferenceOrList<DB>): any {
     return new DeleteQueryBuilder({
       queryId: createQueryId(),
       executor: this.#props.executor,
       queryNode: DeleteQueryNode.create(
-        parseTableExpression(table),
+        parseTableExpressionOrList(tables),
         this.#props.withNode
       ),
     })

--- a/test/node/src/delete.test.ts
+++ b/test/node/src/delete.test.ts
@@ -416,6 +416,186 @@ for (const dialect of BUILT_IN_DIALECTS) {
 
         await query.execute()
       })
+
+      it('should delete from t1, t2 using t1 left join t2', async () => {
+        const query = ctx.db
+          .deleteFrom(['person', 'pet'])
+          .using('person')
+          .leftJoin('pet', 'pet.owner_id', 'person.id')
+          .where('person.id', '=', 911)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: [
+              'delete from `person`, `pet`',
+              'using `person`',
+              'left join `pet` on `pet`.`owner_id` = `person`.`id`',
+              'where `person`.`id` = ?',
+            ],
+            parameters: [911],
+          },
+          sqlite: NOT_SUPPORTED,
+        })
+
+        await query.execute()
+      })
+
+      it('should delete from t1, t2 using t1 inner join t2 inner join t3', async () => {
+        const query = ctx.db
+          .deleteFrom(['person', 'pet'])
+          .using('person')
+          .innerJoin('pet', 'pet.owner_id', 'person.id')
+          .innerJoin('toy', 'toy.pet_id', 'pet.id')
+          .where('toy.price', '=', 1000)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: [
+              'delete from `person`, `pet`',
+              'using `person`',
+              'inner join `pet` on `pet`.`owner_id` = `person`.`id`',
+              'inner join `toy` on `toy`.`pet_id` = `pet`.`id`',
+              'where `toy`.`price` = ?',
+            ],
+            parameters: [1000],
+          },
+          sqlite: NOT_SUPPORTED,
+        })
+
+        await query.execute()
+      })
+
+      it('should delete from t1, t2 using t1 inner join t2 left join t3', async () => {
+        const query = ctx.db
+          .deleteFrom(['person', 'pet'])
+          .using('person')
+          .innerJoin('pet', 'pet.owner_id', 'person.id')
+          .leftJoin('toy', 'toy.pet_id', 'pet.id')
+          .where('toy.price', '=', 1000)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: [
+              'delete from `person`, `pet`',
+              'using `person`',
+              'inner join `pet` on `pet`.`owner_id` = `person`.`id`',
+              'left join `toy` on `toy`.`pet_id` = `pet`.`id`',
+              'where `toy`.`price` = ?',
+            ],
+            parameters: [1000],
+          },
+          sqlite: NOT_SUPPORTED,
+        })
+
+        await query.execute()
+      })
+
+      it('should delete from t1, t2 using t1 left join t2 left join t3', async () => {
+        const query = ctx.db
+          .deleteFrom(['person', 'pet'])
+          .using('person')
+          .leftJoin('pet', 'pet.owner_id', 'person.id')
+          .leftJoin('toy', 'toy.pet_id', 'pet.id')
+          .where('toy.price', '=', 1000)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: [
+              'delete from `person`, `pet`',
+              'using `person`',
+              'left join `pet` on `pet`.`owner_id` = `person`.`id`',
+              'left join `toy` on `toy`.`pet_id` = `pet`.`id`',
+              'where `toy`.`price` = ?',
+            ],
+            parameters: [1000],
+          },
+          sqlite: NOT_SUPPORTED,
+        })
+
+        await query.execute()
+      })
+
+      it('should delete from t1, t2, t3 using t1 inner join t2 inner join t3', async () => {
+        const query = ctx.db
+          .deleteFrom(['person', 'pet', 'toy'])
+          .using('person')
+          .innerJoin('pet', 'pet.owner_id', 'person.id')
+          .innerJoin('toy', 'toy.pet_id', 'pet.id')
+          .where('toy.price', '=', 1000)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: [
+              'delete from `person`, `pet`, `toy`',
+              'using `person`',
+              'inner join `pet` on `pet`.`owner_id` = `person`.`id`',
+              'inner join `toy` on `toy`.`pet_id` = `pet`.`id`',
+              'where `toy`.`price` = ?',
+            ],
+            parameters: [1000],
+          },
+          sqlite: NOT_SUPPORTED,
+        })
+
+        await query.execute()
+      })
+
+      it('should delete from t1, t2, t3 using t1 inner join t2 left join t3', async () => {
+        const query = ctx.db
+          .deleteFrom(['person', 'pet', 'toy'])
+          .using('person')
+          .innerJoin('pet', 'pet.owner_id', 'person.id')
+          .leftJoin('toy', 'toy.pet_id', 'pet.id')
+          .where('toy.price', '=', 1000)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: [
+              'delete from `person`, `pet`, `toy`',
+              'using `person`',
+              'inner join `pet` on `pet`.`owner_id` = `person`.`id`',
+              'left join `toy` on `toy`.`pet_id` = `pet`.`id`',
+              'where `toy`.`price` = ?',
+            ],
+            parameters: [1000],
+          },
+          sqlite: NOT_SUPPORTED,
+        })
+
+        await query.execute()
+      })
+
+      it('should delete from t1, t2, t3 using t1 left join t2 left join t3', async () => {
+        const query = ctx.db
+          .deleteFrom(['person', 'pet', 'toy'])
+          .using('person')
+          .leftJoin('pet', 'pet.owner_id', 'person.id')
+          .leftJoin('toy', 'toy.pet_id', 'pet.id')
+          .where('toy.price', '=', 1000)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: [
+              'delete from `person`, `pet`, `toy`',
+              'using `person`',
+              'left join `pet` on `pet`.`owner_id` = `person`.`id`',
+              'left join `toy` on `toy`.`pet_id` = `pet`.`id`',
+              'where `toy`.`price` = ?',
+            ],
+            parameters: [1000],
+          },
+          sqlite: NOT_SUPPORTED,
+        })
+
+        await query.execute()
+      })
     }
   })
 }

--- a/test/node/src/delete.test.ts
+++ b/test/node/src/delete.test.ts
@@ -392,6 +392,30 @@ for (const dialect of BUILT_IN_DIALECTS) {
 
         await query.execute()
       })
+
+      it('should delete from t1, t2 using t1 inner join t2', async () => {
+        const query = ctx.db
+          .deleteFrom(['person', 'pet'])
+          .using('person')
+          .innerJoin('pet', 'pet.owner_id', 'person.id')
+          .where('person.id', '=', 911)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: [
+              'delete from `person`, `pet`',
+              'using `person`',
+              'inner join `pet` on `pet`.`owner_id` = `person`.`id`',
+              'where `person`.`id` = ?',
+            ],
+            parameters: [911],
+          },
+          sqlite: NOT_SUPPORTED,
+        })
+
+        await query.execute()
+      })
     }
   })
 }

--- a/test/typings/test-d/delete-query-builder.test-d.ts
+++ b/test/typings/test-d/delete-query-builder.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 import { Kysely, DeleteResult } from '..'
 import { Database } from '../shared'
 
@@ -54,4 +54,29 @@ async function testDelete(db: Kysely<Database>) {
     .where('person.id', '=', 1)
     .executeTakeFirstOrThrow()
   expectType<DeleteResult>(r7)
+
+  expectError(db.deleteFrom('NO_SUCH_TABLE'))
+  expectError(db.deleteFrom('pet').where('NO_SUCH_COLUMN', '=', '1'))
+  expectError(db.deleteFrom('pet').whereRef('owner_id', '=', 'NO_SUCH_COLUMN'))
+  expectError(db.deleteFrom(['pet', 'NO_SUCH_TABLE']))
+  expectError(db.deleteFrom('pet').using('NO_SUCH_TABLE'))
+  expectError(db.deleteFrom('pet').using(['pet', 'NO_SUCH_TABLE']))
+  expectError(
+    db.deleteFrom('pet').using('pet').innerJoin('NO_SUCH_TABLE', 'pet.id', 'b')
+  )
+  expectError(
+    db
+      .deleteFrom('pet')
+      .using('pet')
+      .innerJoin('person', 'NO_SUCH_COLUMN', 'pet.owner_id')
+  )
+  expectError(
+    db.deleteFrom('pet').using('pet').leftJoin('NO_SUCH_TABLE', 'pet.id', 'b')
+  )
+  expectError(
+    db
+      .deleteFrom('pet')
+      .using('pet')
+      .leftJoin('person', 'NO_SUCH_COLUMN', 'pet.owner_id')
+  )
 }

--- a/test/typings/test-d/delete-query-builder.test-d.ts
+++ b/test/typings/test-d/delete-query-builder.test-d.ts
@@ -38,4 +38,20 @@ async function testDelete(db: Kysely<Database>) {
     .orWhere('toy.price', '=', 0)
     .executeTakeFirstOrThrow()
   expectType<DeleteResult>(r5)
+
+  const r6 = await db
+    .deleteFrom(['person', 'pet'])
+    .using('person')
+    .innerJoin('pet', 'pet.owner_id', 'person.id')
+    .where('person.id', '=', 1)
+    .executeTakeFirstOrThrow()
+  expectType<DeleteResult>(r6)
+
+  const r7 = await db
+    .deleteFrom(['person', 'pet'])
+    .using('person')
+    .leftJoin('pet', 'pet.owner_id', 'person.id')
+    .where('person.id', '=', 1)
+    .executeTakeFirstOrThrow()
+  expectType<DeleteResult>(r7)
 }


### PR DESCRIPTION
closes #269 .

- [x] implement.
- [x] document.
- [x] unit test.
- [x] typings test.

---

To consider:

Should we deny empty arrays as inputs at compile-time? (e.g. `QueryCreator.selectFrom`, `QueryCreator.deleteFrom`, `SelectQueryBuilder.groupBy`, etc.