### PR TITLE
Add sqld dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ for [3rd party dialects](https://koskimas.github.io/kysely/interfaces/Dialect.ht
  - [SingleStore Data API](https://github.com/igalklebanov/kysely-singlestore)
  - [D1](https://github.com/aidenwallis/kysely-d1)
  - [SurrealDB](https://github.com/igalklebanov/kysely-surrealdb)
+ - [sqld](https://github.com/libsql/kysely-libsql)
 
 # Minimal example
 


### PR DESCRIPTION
This PR adds a link to the libsql/sqld dialect for Kysely that connects to [sqld](https://github.com/libsql/sqld) over [a WebSocket](https://github.com/libsql/hrana-client-ts).