### PR TITLE
add compiled query and timing to error logs

### DIFF
--- a/src/driver/runtime-driver.ts
+++ b/src/driver/runtime-driver.ts
@@ -105,7 +105,7 @@ export class RuntimeDriver implements Driver {
       try {
         return await executeQuery.call(connection, compiledQuery)
       } catch (error) {
-        this.#logError(error)
+        this.#logError(error, compiledQuery, startTime)
         throw error
       } finally {
         this.#logQuery(compiledQuery, startTime)
@@ -113,10 +113,16 @@ export class RuntimeDriver implements Driver {
     }
   }
 
-  #logError(error: unknown): void {
+  #logError(
+    error: unknown,
+    compiledQuery: CompiledQuery,
+    startTime: number
+  ): void {
     this.#log.error(() => ({
       level: 'error',
       error,
+      query: compiledQuery,
+      queryDurationMillis: this.#calculateDurationMillis(startTime),
     }))
   }
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -15,6 +15,8 @@ export interface QueryLogEvent {
 export interface ErrorLogEvent {
   readonly level: 'error'
   readonly error: unknown
+  readonly query: CompiledQuery
+  readonly queryDurationMillis: number
 }
 
 export type LogEvent = QueryLogEvent | ErrorLogEvent


### PR DESCRIPTION
This PR is a follow up to [this issue](https://github.com/koskimas/kysely/issues/342).

The change makes it possible to log the compiled query along with its timing in case of error logs. As the issue mentioned, this makes it easier to debug failing queries.

closes #342