### PR TITLE
add `Kysely.executeQuery`.

### DIFF
--- a/recipes/splitting-build-compile-and-execute-code.md
+++ b/recipes/splitting-build-compile-and-execute-code.md
@@ -86,17 +86,13 @@ The `CompiledQuery` object returned by `.compile()` can be executed
 via "hot" Kysely instances (real drivers in use):
 
 ```ts
-import { randomUUID } from 'node:crypto'
-
 const compiledQuery = db
   .selectFrom('person')
   .select('first_name')
   .where('id', '=', id)
   .compile()
 
-const results = await db.getExecutor().executeQuery(compiledQuery, {
-  queryId: randomUUID(),
-})
+const results = await db.executeQuery(compiledQuery)
 ```
 
 The `QueryResult` object returned by `.executeQuery()` contains the query results' 

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -20,6 +20,10 @@ import { preventAwait } from './util/prevent-await.js'
 import { FunctionModule } from './query-builder/function-module.js'
 import { Log, LogConfig } from './util/log.js'
 import { QueryExecutorProvider } from './query-executor/query-executor-provider.js'
+import { QueryResult } from './driver/database-connection.js'
+import { CompiledQuery } from './query-compiler/compiled-query.js'
+import { createQueryId, QueryId } from './util/query-id.js'
+import { Compilable, isCompilable } from './util/compilable.js'
 
 /**
  * The main Kysely class.
@@ -319,6 +323,20 @@ export class Kysely<DB>
    */
   getExecutor(): QueryExecutor {
     return this.#props.executor
+  }
+
+  /**
+   * Executes a given compiled query or query builder.
+   *
+   * See {@link https://github.com/koskimas/kysely/blob/master/recipes/splitting-build-compile-and-execute-code.md#execute-compiled-queries splitting build, compile and execute code recipe} for more information.
+   */
+  executeQuery<R>(
+    query: CompiledQuery<R> | Compilable<R>,
+    queryId: QueryId = createQueryId()
+  ): Promise<QueryResult<R>> {
+    const compiledQuery = isCompilable(query) ? query.compile() : query
+
+    return this.getExecutor().executeQuery(compiledQuery, queryId)
   }
 }
 

--- a/src/query-executor/query-executor.ts
+++ b/src/query-executor/query-executor.ts
@@ -35,14 +35,17 @@ export interface QueryExecutor extends ConnectionProvider {
    * the output of {@link transformQuery} into this method but you can
    * compile any query using this method.
    */
-  compileQuery(node: RootOperationNode, queryId: QueryId): CompiledQuery
+  compileQuery<R = unknown>(
+    node: RootOperationNode,
+    queryId: QueryId
+  ): CompiledQuery<R>
 
   /**
    * Executes a compiled query and runs the result through all plugins'
    * `transformResult` method.
    */
   executeQuery<R>(
-    compiledQuery: CompiledQuery,
+    compiledQuery: CompiledQuery<R>,
     queryId: QueryId
   ): Promise<QueryResult<R>>
 
@@ -52,7 +55,7 @@ export interface QueryExecutor extends ConnectionProvider {
    * at once.
    */
   stream<R>(
-    compiledQuery: CompiledQuery,
+    compiledQuery: CompiledQuery<R>,
     /**
      * How many rows should be pulled from the database at once. Supported
      * only by the postgres driver.

--- a/src/util/compilable.ts
+++ b/src/util/compilable.ts
@@ -1,5 +1,10 @@
 import { CompiledQuery } from '../query-compiler/compiled-query.js'
+import { isFunction, isObject } from './object-utils.js'
 
 export interface Compilable<O = unknown> {
   compile(): CompiledQuery<O>
+}
+
+export function isCompilable(value: unknown): value is Compilable {
+  return isObject(value) && isFunction(value.compile)
 }


### PR DESCRIPTION
This PR introduces a shortcut for `Kysely.getExecutor().executeQuery(compiledQuery, queryId)`.

When splitting build, compile and execute code, consumers no longer have to:

- access Kysely's internal `.getExecutor()` method.
- provide a queryId - which is internal.

Additionally: 
- consumer can pass a query builder, it's get compiled under the hood.
- QueryResult gets the correct R type from compiled query when using QueryExecutor's execute query.