### PR TITLE
add `RawBuilder.compile`.

### DIFF
--- a/recipes/splitting-build-compile-and-execute-code.md
+++ b/recipes/splitting-build-compile-and-execute-code.md
@@ -59,6 +59,16 @@ for compilation.
 This output alone can be used with any database driver that understands the sql 
 dialect used (PostgreSQL in this example).
 
+Raw queries can be compiled as well:
+
+```ts
+import { Selectable, sql } from 'kysely'
+
+const compiledQuery = sql<Selectable<Person>>`select * from person where id = ${id}`.compile(db)
+
+console.log(compiledQuery) // { sql: 'select * from person where id = $1', parameters: [1], query: { ... } }
+```
+
 ## Infer result type
 
 Kysely supports inferring a (compiled) query's result type even when detached from 

--- a/test/node/src/raw-query.test.ts
+++ b/test/node/src/raw-query.test.ts
@@ -8,6 +8,7 @@ import {
   TestContext,
   expect,
   insertDefaultDataSet,
+  testSql,
 } from './test-setup.js'
 
 for (const dialect of BUILT_IN_DIALECTS) {
@@ -101,5 +102,26 @@ for (const dialect of BUILT_IN_DIALECTS) {
         expect(result.rows).to.eql([])
       })
     }
+
+    it('should compile a raw select query', async () => {
+      const gender = 'male'
+
+      const query = sql`select first_name from person where gender = ${gender} order by first_name asc, last_name asc`
+
+      testSql({ compile: () => query.compile(ctx.db) }, dialect, {
+        postgres: {
+          sql: 'select first_name from person where gender = $1 order by first_name asc, last_name asc',
+          parameters: [gender],
+        },
+        mysql: {
+          sql: 'select first_name from person where gender = ? order by first_name asc, last_name asc',
+          parameters: [gender],
+        },
+        sqlite: {
+          sql: 'select first_name from person where gender = ? order by first_name asc, last_name asc',
+          parameters: [gender],
+        },
+      })
+    })
   })
 }


### PR DESCRIPTION
This PR allows consumers to compile `RawBuilder`s and pass around their `CompiledQuery`s when splitting build, compile and execute code.