### PR TITLE
add `.where` & `.orWhere` @ `CreateIndexBuilder`.

### DIFF
--- a/src/operation-node/create-index-node.ts
+++ b/src/operation-node/create-index-node.ts
@@ -3,6 +3,7 @@ import { IdentifierNode } from './identifier-node.js'
 import { OperationNode } from './operation-node.js'
 import { RawNode } from './raw-node.js'
 import { TableNode } from './table-node.js'
+import { WhereNode } from './where-node.js'
 
 export type CreateIndexNodeProps = Omit<CreateIndexNode, 'kind' | 'name'>
 export type IndexType = 'btree' | 'hash' | 'gist' | 'gin'
@@ -20,6 +21,7 @@ export interface CreateIndexNode extends OperationNode {
   //               This would then be of type `IndexTypeNode | RawNode`.
   readonly using?: RawNode
   readonly ifNotExists?: boolean
+  readonly where?: WhereNode
 }
 
 /**

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -531,6 +531,7 @@ export class OperationNodeTransformer {
       unique: node.unique,
       using: this.transformNode(node.using),
       ifNotExists: node.ifNotExists,
+      where: this.transformNode(node.where),
     })
   }
 

--- a/src/operation-node/query-node.ts
+++ b/src/operation-node/query-node.ts
@@ -11,19 +11,15 @@ import { OperationNode } from './operation-node.js'
 
 export type QueryNode =
   | SelectQueryNode
-  | DeleteQueryNode
   | InsertQueryNode
   | UpdateQueryNode
-
-export type MutatingQueryNode =
   | DeleteQueryNode
-  | InsertQueryNode
-  | UpdateQueryNode
 
-export type FilterableQueryNode =
-  | SelectQueryNode
-  | DeleteQueryNode
-  | UpdateQueryNode
+export type HasJoins = { joins?: ReadonlyArray<JoinNode> }
+
+export type HasWhere = { where?: WhereNode }
+
+export type HasReturning = { returning?: ReturningNode }
 
 /**
  * @internal
@@ -31,17 +27,14 @@ export type FilterableQueryNode =
 export const QueryNode = freeze({
   is(node: OperationNode): node is QueryNode {
     return (
-      DeleteQueryNode.is(node) ||
+      SelectQueryNode.is(node) ||
       InsertQueryNode.is(node) ||
       UpdateQueryNode.is(node) ||
-      SelectQueryNode.is(node)
+      DeleteQueryNode.is(node)
     )
   },
 
-  cloneWithWhere<T extends FilterableQueryNode>(
-    node: T,
-    operation: OperationNode
-  ): T {
+  cloneWithWhere<T extends HasWhere>(node: T, operation: OperationNode): T {
     return freeze({
       ...node,
       where: node.where
@@ -50,10 +43,7 @@ export const QueryNode = freeze({
     })
   },
 
-  cloneWithOrWhere<T extends FilterableQueryNode>(
-    node: T,
-    operation: OperationNode
-  ): T {
+  cloneWithOrWhere<T extends HasWhere>(node: T, operation: OperationNode): T {
     return freeze({
       ...node,
       where: node.where
@@ -62,14 +52,14 @@ export const QueryNode = freeze({
     })
   },
 
-  cloneWithJoin<T extends FilterableQueryNode>(node: T, join: JoinNode): T {
+  cloneWithJoin<T extends HasJoins>(node: T, join: JoinNode): T {
     return freeze({
       ...node,
       joins: node.joins ? freeze([...node.joins, join]) : freeze([join]),
     })
   },
 
-  cloneWithReturning<T extends MutatingQueryNode>(
+  cloneWithReturning<T extends HasReturning>(
     node: T,
     selections: ReadonlyArray<SelectionNode>
   ): T {
@@ -81,7 +71,7 @@ export const QueryNode = freeze({
     })
   },
 
-  cloneWithoutWhere<T extends FilterableQueryNode>(node: T): T {
+  cloneWithoutWhere<T extends HasWhere>(node: T): T {
     return freeze({
       ...node,
       where: undefined,

--- a/src/parser/binary-operation-parser.ts
+++ b/src/parser/binary-operation-parser.ts
@@ -32,6 +32,7 @@ import { HavingInterface } from '../query-builder/having-interface.js'
 import { createJoinBuilder, createSelectQueryBuilder } from './parse-utils.js'
 import { OperationNode } from '../operation-node/operation-node.js'
 import { Expression } from '../expression/expression.js'
+import { sql } from '../raw-builder/sql.js'
 
 export type OperandValueExpression<
   DB,
@@ -98,6 +99,14 @@ export function parseFilterExpression(
   }
 
   throw createFilterExpressionError(type, args)
+}
+
+export function parseWhereWithParametersAsLiterals(args: any[]): OperationNode {
+  if (args.length === 3) {
+    args = [args[0], args[1], sql.literal(args[2])]
+  }
+
+  return parseWhere(args)
 }
 
 function parseFilter(

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -796,6 +796,11 @@ export class DefaultQueryCompiler
       this.visitNode(node.expression)
       this.append(')')
     }
+
+    if (node.where) {
+      this.append(' ')
+      this.visitNode(node.where)
+    }
   }
 
   protected override visitDropIndex(node: DropIndexNode): void {

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -137,7 +137,7 @@ export class CreateIndexBuilder<C = never>
   }
 
   where(
-    lhs: C | DynamicReferenceBuilder<any> | Expression<any>,
+    lhs: C | Expression<any>,
     op: ComparisonOperatorExpression,
     rhs: unknown
   ): CreateIndexBuilder<C>
@@ -157,7 +157,7 @@ export class CreateIndexBuilder<C = never>
   }
 
   orWhere(
-    lhs: C | DynamicReferenceBuilder<any> | Expression<any>,
+    lhs: C | Expression<any>,
     op: ComparisonOperatorExpression,
     rhs: unknown
   ): CreateIndexBuilder<C>

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -16,7 +16,7 @@ import { freeze } from '../util/object-utils.js'
 import { Expression } from '../expression/expression.js'
 import {
   ComparisonOperatorExpression,
-  parseWhereWithParametersAsLiterals,
+  parseWhereWithImmediateParameters,
 } from '../parser/binary-operation-parser.js'
 import { QueryNode } from '../operation-node/query-node.js'
 
@@ -181,7 +181,7 @@ export class CreateIndexBuilder<C = never>
       ...this.#props,
       node: QueryNode.cloneWithWhere(
         this.#props.node as any,
-        parseWhereWithParametersAsLiterals(args)
+        parseWhereWithImmediateParameters(args)
       ),
     })
   }
@@ -223,7 +223,7 @@ export class CreateIndexBuilder<C = never>
       ...this.#props,
       node: QueryNode.cloneWithOrWhere(
         this.#props.node as any,
-        parseWhereWithParametersAsLiterals(args)
+        parseWhereWithImmediateParameters(args)
       ),
     })
   }

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -180,7 +180,7 @@ export class CreateIndexBuilder<C = never>
     return new CreateIndexBuilder({
       ...this.#props,
       node: QueryNode.cloneWithWhere(
-        this.#props.node as any,
+        this.#props.node,
         parseWhereWithImmediateParameters(args)
       ),
     })

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -16,7 +16,7 @@ import { freeze } from '../util/object-utils.js'
 import { Expression } from '../expression/expression.js'
 import {
   ComparisonOperatorExpression,
-  parseWhere,
+  parseWhereWithParametersAsLiterals,
 } from '../parser/binary-operation-parser.js'
 import { DynamicReferenceBuilder } from '../dynamic/dynamic-reference-builder.js'
 import { QueryNode } from '../operation-node/query-node.js'
@@ -149,7 +149,10 @@ export class CreateIndexBuilder<C = never>
   where(...args: any[]): any {
     return new CreateIndexBuilder({
       ...this.#props,
-      node: QueryNode.cloneWithWhere(this.#props.node as any, parseWhere(args)),
+      node: QueryNode.cloneWithWhere(
+        this.#props.node as any,
+        parseWhereWithParametersAsLiterals(args)
+      ),
     })
   }
 
@@ -168,7 +171,7 @@ export class CreateIndexBuilder<C = never>
       ...this.#props,
       node: QueryNode.cloneWithOrWhere(
         this.#props.node as any,
-        parseWhere(args)
+        parseWhereWithParametersAsLiterals(args)
       ),
     })
   }
@@ -214,7 +217,7 @@ export interface CreateIndexBuilderProps {
 // WhereInterface but without database schema type definition generics, just available column names.
 export interface CreateIndexWhereInterface<C> {
   where(
-    lhs: C | DynamicReferenceBuilder<any> | Expression<any>,
+    lhs: C | Expression<any>,
     op: ComparisonOperatorExpression,
     rhs: unknown
   ): CreateIndexBuilder<C>
@@ -224,7 +227,7 @@ export interface CreateIndexWhereInterface<C> {
   where(expression: Expression<any>): CreateIndexBuilder<C>
 
   orWhere(
-    lhs: C | DynamicReferenceBuilder<any> | Expression<any>,
+    lhs: C | Expression<any>,
     op: ComparisonOperatorExpression,
     rhs: unknown
   ): CreateIndexBuilder<C>

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -915,6 +915,7 @@ for (const dialect of DIALECTS) {
           .addColumn('id', 'bigint', (col) => col.primaryKey())
           .addColumn('first_name', 'varchar(255)')
           .addColumn('last_name', 'varchar(255)')
+          .addColumn('age', 'integer')
           .execute()
       })
 
@@ -1071,6 +1072,31 @@ for (const dialect of DIALECTS) {
 
         await builder.execute()
       })
+
+      if (dialect !== 'mysql') {
+        it('should create a partial index', async () => {
+          const builder = ctx.db.schema
+            .createIndex('test_partial_index')
+            .on('test')
+            .columns(['first_name', 'last_name'])
+            .where('first_name', '=', 'Igal')
+            .orWhere('age', '>=', 18)
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `create index "test_partial_index" on "test" ("first_name", "last_name") where "first_name" = 'Igal' or "age" >= 18`,
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            sqlite: {
+              sql: `create index "test_partial_index" on "test" ("first_name", "last_name") where "first_name" = 'Igal' or "age" >= 18`,
+              parameters: [],
+            },
+          })
+
+          await builder.execute()
+        })
+      }
     })
 
     describe('drop index', () => {

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -1080,7 +1080,7 @@ for (const dialect of DIALECTS) {
             .on('test')
             .columns(['first_name', 'last_name'])
             .where('first_name', '=', 'Igal')
-            .orWhere('age', '>=', 18)
+            .orWhere(sql.ref('age'), '>=', 18)
 
           testSql(builder, dialect, {
             postgres: {


### PR DESCRIPTION
closes #302.

Adds the ability to create partial indexes in postgres / sqlite.

- only columns known in compile-time (used in `.column`/`.columns`) provide autocompletion,
unknown columns require `sql` template tag to be referred to.
- parameter types are unknown.
- parameters are not allowed (engine throws), so they're turned to literals before parsing.