### PR TITLE
fix: filter out internal cockroachdb schemas in postgres introspector

### DIFF
--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -73,6 +73,8 @@ export class PostgresIntrospector implements DatabaseIntrospector {
       ])
       .where('ns.nspname', '!~', '^pg_')
       .where('ns.nspname', '!=', 'information_schema')
+      // Filter out internal cockroachdb schema
+      .where('ns.nspname', '!=', 'crdb_internal')
       // No system columns
       .where('a.attnum', '>=', 0)
       .where('a.attisdropped', '!=', true)


### PR DESCRIPTION
closes #1458

It seems mikro-orm does something similar: https://github.com/mikro-orm/mikro-orm/blob/master/packages/postgresql/src/PostgreSqlSchemaHelper.ts#L71