### PR TITLE
feat(Introspect): add support for postgres & mysql foreign tables

### DIFF
--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -26,6 +26,11 @@ export interface DatabaseMetadataOptions {
    * such as the migration tables.
    */
   withInternalKyselyTables: boolean
+
+  /**
+   * If this is true, the metadata contains the foreign tables.
+   */
+  withForeignTables?: boolean
 }
 
 export interface SchemaMetadata {
@@ -43,6 +48,7 @@ export interface DatabaseMetadata {
 export interface TableMetadata {
   readonly name: string
   readonly isView: boolean
+  readonly isForeignTable: boolean
   readonly columns: ColumnMetadata[]
   readonly schema?: string
 }

--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -26,11 +26,6 @@ export interface DatabaseMetadataOptions {
    * such as the migration tables.
    */
   withInternalKyselyTables: boolean
-
-  /**
-   * If this is true, the metadata contains the foreign tables.
-   */
-  withForeignTables?: boolean
 }
 
 export interface SchemaMetadata {
@@ -48,7 +43,7 @@ export interface DatabaseMetadata {
 export interface TableMetadata {
   readonly name: string
   readonly isView: boolean
-  readonly isForeignTable: boolean
+  readonly isForeign: boolean
   readonly columns: ColumnMetadata[]
   readonly schema?: string
 }

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -142,6 +142,7 @@ export class MssqlIntrospector implements DatabaseIntrospector {
         tableDictionary[key] ||
         freeze({
           columns: [],
+          isForeign: false,
           isView: rawColumn.table_type === 'V ',
           name: rawColumn.table_name,
           schema: rawColumn.table_schema_name ?? undefined,

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -47,6 +47,7 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         'columns.TABLE_NAME',
         'columns.TABLE_SCHEMA',
         'tables.TABLE_TYPE',
+        'tables.ENGINE',
         'columns.IS_NULLABLE',
         'columns.DATA_TYPE',
         'columns.EXTRA',
@@ -83,7 +84,7 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         table = freeze({
           name: it.TABLE_NAME,
           isView: it.TABLE_TYPE === 'VIEW',
-          isForeignTable: false,
+          isForeign: it.ENGINE === 'FEDERATED',
           schema: it.TABLE_SCHEMA,
           columns: [],
         })
@@ -117,6 +118,7 @@ interface RawColumnMetadata {
   TABLE_NAME: string
   TABLE_SCHEMA: string
   TABLE_TYPE: string
+  ENGINE: string
   IS_NULLABLE: 'YES' | 'NO'
   DATA_TYPE: string
   EXTRA: string

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -83,6 +83,7 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         table = freeze({
           name: it.TABLE_NAME,
           isView: it.TABLE_TYPE === 'VIEW',
+          isForeignTable: false,
           schema: it.TABLE_SCHEMA,
           columns: [],
         })

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -31,10 +31,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
   }
 
   async getTables(
-    options: DatabaseMetadataOptions = {
-      withInternalKyselyTables: false,
-      withForeignTables: false,
-    },
+    options: DatabaseMetadataOptions = { withInternalKyselyTables: false },
   ): Promise<TableMetadata[]> {
     let query = this.#db
       // column
@@ -87,10 +84,6 @@ export class PostgresIntrospector implements DatabaseIntrospector {
       .orderBy('a.attnum')
       .$castTo<RawColumnMetadata>()
 
-    if (!options.withForeignTables) {
-      query = query.where('c.relkind', '!=', 'f')
-    }
-
     if (!options.withInternalKyselyTables) {
       query = query
         .where('c.relname', '!=', DEFAULT_MIGRATION_TABLE)
@@ -120,7 +113,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
         table = freeze({
           name: it.table,
           isView: it.table_type === 'v',
-          isForeignTable: it.table_type === 'f',
+          isForeign: it.table_type === 'f',
           schema: it.schema,
           columns: [],
         })

--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -135,7 +135,7 @@ export class SqliteIntrospector implements DatabaseIntrospector {
       return {
         name: name,
         isView: type === 'view',
-        isForeignTable: false,
+        isForeign: false,
         columns: columns.map((col) => ({
           name: col.name,
           dataType: col.type,

--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -135,6 +135,7 @@ export class SqliteIntrospector implements DatabaseIntrospector {
       return {
         name: name,
         isView: type === 'view',
+        isForeignTable: false,
         columns: columns.map((col) => ({
           name: col.name,
           dataType: col.type,

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -85,6 +85,7 @@ for (const dialect of DIALECTS) {
           expect(meta).to.eql([
             {
               name: 'person',
+              isForeign: false,
               isView: false,
               schema: 'public',
               columns: [
@@ -157,6 +158,7 @@ for (const dialect of DIALECTS) {
             {
               name: 'pet',
               isView: false,
+              isForeign: false,
               schema: 'public',
               columns: [
                 {
@@ -200,6 +202,7 @@ for (const dialect of DIALECTS) {
             {
               name: 'toy',
               isView: false,
+              isForeign: false,
               schema: 'public',
               columns: [
                 {
@@ -242,6 +245,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'toy_names',
+              isForeign: false,
               isView: true,
               schema: 'public',
               columns: [
@@ -258,6 +262,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'MixedCaseTable',
+              isForeign: false,
               isView: false,
               schema: 'some_schema',
               columns: [
@@ -274,6 +279,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'pet',
+              isForeign: false,
               isView: false,
               schema: 'some_schema',
               columns: [
@@ -299,6 +305,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'pet_partition',
+              isForeign: false,
               isView: false,
               schema: 'some_schema',
               columns: [
@@ -318,6 +325,7 @@ for (const dialect of DIALECTS) {
           expect(meta).to.eql([
             {
               name: 'person',
+              isForeign: false,
               isView: false,
               schema: 'kysely_test',
               columns: [
@@ -382,6 +390,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'pet',
+              isForeign: false,
               isView: false,
               schema: 'kysely_test',
               columns: [
@@ -421,6 +430,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'toy',
+              isForeign: false,
               isView: false,
               schema: 'kysely_test',
               columns: [
@@ -460,6 +470,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'toy_names',
+              isForeign: false,
               isView: true,
               schema: 'kysely_test',
               columns: [
@@ -477,6 +488,7 @@ for (const dialect of DIALECTS) {
         } else if (dialect === 'mssql') {
           expect(meta).to.eql([
             {
+              isForeign: false,
               isView: false,
               name: 'person',
               schema: 'dbo',
@@ -547,6 +559,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              isForeign: false,
               isView: false,
               name: 'pet',
               schema: 'dbo',
@@ -590,6 +603,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              isForeign: false,
               isView: false,
               name: 'toy',
               schema: 'dbo',
@@ -633,6 +647,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              isForeign: false,
               isView: true,
               name: 'toy_names',
               schema: 'dbo',
@@ -649,6 +664,7 @@ for (const dialect of DIALECTS) {
               ],
             },
             {
+              isForeign: false,
               isView: false,
               name: 'pet',
               schema: 'some_schema',
@@ -678,6 +694,7 @@ for (const dialect of DIALECTS) {
           expect(meta).to.eql([
             {
               name: 'person',
+              isForeign: false,
               isView: false,
               columns: [
                 {
@@ -741,6 +758,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'pet',
+              isForeign: false,
               isView: false,
               columns: [
                 {
@@ -779,6 +797,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'toy',
+              isForeign: false,
               isView: false,
               columns: [
                 {
@@ -817,6 +836,7 @@ for (const dialect of DIALECTS) {
             },
             {
               name: 'toy_names',
+              isForeign: false,
               isView: true,
               columns: [
                 {
@@ -856,6 +876,7 @@ for (const dialect of DIALECTS) {
 
             expect(testTable).to.eql({
               name: testTableName,
+              isForeign: false,
               isView: false,
               columns: [
                 {


### PR DESCRIPTION
Hey 👋 

This PR adds foreign table introspection for PostgreSQL and MySQL dialects. An `isForeign` property is added to each table object.