### PR TITLE
feat(utils): Allow explicit undefined in Updateable type (for exactOptionalPropertyTypes support)

### DIFF
--- a/src/util/column-type.ts
+++ b/src/util/column-type.ts
@@ -201,5 +201,5 @@ export type Insertable<R> = DrainOuterGeneric<
  * ```
  */
 export type Updateable<R> = DrainOuterGeneric<{
-  [K in UpdateKeys<R>]?: UpdateType<R[K]>
+  [K in UpdateKeys<R>]?: UpdateType<R[K]> | undefined
 }>


### PR DESCRIPTION
Hey👋
I tried allowing the Updateable type to accept explicit undefined values to better support TypeScript's `exactOptionalPropertyTypes` option. What do you think?
I would appreciate your review!

Fixes: https://github.com/kysely-org/kysely/issues/1492