### PR TITLE
feat: support dropping multiple types with schema.dropType(), cascade.

### DIFF
--- a/src/operation-node/drop-type-node.ts
+++ b/src/operation-node/drop-type-node.ts
@@ -6,9 +6,8 @@ export type DropTypeNodeParams = Omit<Partial<DropTypeNode>, 'kind' | 'names'>
 
 export interface DropTypeNode extends OperationNode {
   readonly kind: 'DropTypeNode'
-  /** @deprecated Use `names` instead. */
-  readonly name?: SchemableIdentifierNode
-  readonly names: SchemableIdentifierNode[]
+  readonly name: SchemableIdentifierNode
+  readonly additionalNames?: SchemableIdentifierNode[]
   readonly ifExists?: boolean
   readonly modifier?: 'cascade' | 'restrict'
 }
@@ -22,10 +21,11 @@ export const DropTypeNode = freeze({
   },
 
   create(names: SchemableIdentifierNode | SchemableIdentifierNode[]): DropTypeNode {
+    names = Array.isArray(names) ? names : [names];
     return freeze({
       kind: 'DropTypeNode',
-      name: Array.isArray(names) ? undefined : names,
-      names: Array.isArray(names) ? names : [names],
+      name: names[0],
+      additionalNames: names.slice(1),
     })
   },
 

--- a/src/operation-node/drop-type-node.ts
+++ b/src/operation-node/drop-type-node.ts
@@ -2,7 +2,7 @@ import { freeze } from '../util/object-utils.js'
 import { OperationNode } from './operation-node.js'
 import { SchemableIdentifierNode } from './schemable-identifier-node.js'
 
-export type DropTypeNodeParams = Omit<Partial<DropTypeNode>, 'kind' | 'name'>
+export type DropTypeNodeParams = Omit<Partial<DropTypeNode>, 'kind' | 'names'>
 
 export interface DropTypeNode extends OperationNode {
   readonly kind: 'DropTypeNode'

--- a/src/operation-node/drop-type-node.ts
+++ b/src/operation-node/drop-type-node.ts
@@ -2,7 +2,10 @@ import { freeze } from '../util/object-utils.js'
 import { OperationNode } from './operation-node.js'
 import { SchemableIdentifierNode } from './schemable-identifier-node.js'
 
-export type DropTypeNodeParams = Omit<Partial<DropTypeNode>, 'kind' | 'name' | 'names'>
+export type DropTypeNodeParams = Omit<
+  Partial<DropTypeNode>,
+  'kind' | 'name' | 'additionalNames'
+>
 
 export interface DropTypeNode extends OperationNode {
   readonly kind: 'DropTypeNode'
@@ -20,8 +23,13 @@ export const DropTypeNode = freeze({
     return node.kind === 'DropTypeNode'
   },
 
-  create(names: SchemableIdentifierNode | SchemableIdentifierNode[]): DropTypeNode {
-    names = Array.isArray(names) ? names : [names];
+  create(
+    names: SchemableIdentifierNode | SchemableIdentifierNode[],
+  ): DropTypeNode {
+    if (!Array.isArray(names)) {
+      names = [names]
+    }
+
     return freeze({
       kind: 'DropTypeNode',
       name: names[0],

--- a/src/operation-node/drop-type-node.ts
+++ b/src/operation-node/drop-type-node.ts
@@ -6,6 +6,8 @@ export type DropTypeNodeParams = Omit<Partial<DropTypeNode>, 'kind' | 'names'>
 
 export interface DropTypeNode extends OperationNode {
   readonly kind: 'DropTypeNode'
+  /** @deprecated Use `names` instead. */
+  readonly name?: SchemableIdentifierNode
   readonly names: SchemableIdentifierNode[]
   readonly ifExists?: boolean
   readonly modifier?: 'cascade' | 'restrict'
@@ -19,10 +21,11 @@ export const DropTypeNode = freeze({
     return node.kind === 'DropTypeNode'
   },
 
-  create(names: SchemableIdentifierNode[]): DropTypeNode {
+  create(names: SchemableIdentifierNode | SchemableIdentifierNode[]): DropTypeNode {
     return freeze({
       kind: 'DropTypeNode',
-      names,
+      name: Array.isArray(names) ? undefined : names,
+      names: Array.isArray(names) ? names : [names],
     })
   },
 

--- a/src/operation-node/drop-type-node.ts
+++ b/src/operation-node/drop-type-node.ts
@@ -8,6 +8,7 @@ export interface DropTypeNode extends OperationNode {
   readonly kind: 'DropTypeNode'
   readonly names: SchemableIdentifierNode[]
   readonly ifExists?: boolean
+  readonly modifier?: 'cascade' | 'restrict'
 }
 
 /**

--- a/src/operation-node/drop-type-node.ts
+++ b/src/operation-node/drop-type-node.ts
@@ -2,7 +2,7 @@ import { freeze } from '../util/object-utils.js'
 import { OperationNode } from './operation-node.js'
 import { SchemableIdentifierNode } from './schemable-identifier-node.js'
 
-export type DropTypeNodeParams = Omit<Partial<DropTypeNode>, 'kind' | 'names'>
+export type DropTypeNodeParams = Omit<Partial<DropTypeNode>, 'kind' | 'name' | 'names'>
 
 export interface DropTypeNode extends OperationNode {
   readonly kind: 'DropTypeNode'

--- a/src/operation-node/drop-type-node.ts
+++ b/src/operation-node/drop-type-node.ts
@@ -6,7 +6,7 @@ export type DropTypeNodeParams = Omit<Partial<DropTypeNode>, 'kind' | 'name'>
 
 export interface DropTypeNode extends OperationNode {
   readonly kind: 'DropTypeNode'
-  readonly name: SchemableIdentifierNode
+  readonly names: SchemableIdentifierNode[]
   readonly ifExists?: boolean
 }
 
@@ -18,10 +18,10 @@ export const DropTypeNode = freeze({
     return node.kind === 'DropTypeNode'
   },
 
-  create(name: SchemableIdentifierNode): DropTypeNode {
+  create(names: SchemableIdentifierNode[]): DropTypeNode {
     return freeze({
       kind: 'DropTypeNode',
-      name,
+      names,
     })
   },
 

--- a/src/operation-node/drop-type-node.ts
+++ b/src/operation-node/drop-type-node.ts
@@ -12,7 +12,7 @@ export interface DropTypeNode extends OperationNode {
   readonly name: SchemableIdentifierNode
   readonly additionalNames?: SchemableIdentifierNode[]
   readonly ifExists?: boolean
-  readonly modifier?: 'cascade' | 'restrict'
+  readonly cascade?: boolean
 }
 
 /**

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -1031,7 +1031,7 @@ export class OperationNodeTransformer {
   ): DropTypeNode {
     return requireAllProps<DropTypeNode>({
       kind: 'DropTypeNode',
-      name: this.transformNode(node.name, queryId),
+      names: this.transformNodeList(node.names, queryId),
       ifExists: node.ifExists,
     })
   }

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -1031,6 +1031,7 @@ export class OperationNodeTransformer {
   ): DropTypeNode {
     return requireAllProps<DropTypeNode>({
       kind: 'DropTypeNode',
+      name: this.transformNode(node.name, queryId),
       names: this.transformNodeList(node.names, queryId),
       ifExists: node.ifExists,
       modifier: node.modifier,

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -1033,6 +1033,7 @@ export class OperationNodeTransformer {
       kind: 'DropTypeNode',
       names: this.transformNodeList(node.names, queryId),
       ifExists: node.ifExists,
+      modifier: node.modifier,
     })
   }
 

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -1033,8 +1033,8 @@ export class OperationNodeTransformer {
       kind: 'DropTypeNode',
       name: this.transformNode(node.name, queryId),
       additionalNames: this.transformNodeList(node.additionalNames, queryId),
+      cascade: node.cascade,
       ifExists: node.ifExists,
-      modifier: node.modifier,
     })
   }
 

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -1032,7 +1032,7 @@ export class OperationNodeTransformer {
     return requireAllProps<DropTypeNode>({
       kind: 'DropTypeNode',
       name: this.transformNode(node.name, queryId),
-      names: this.transformNodeList(node.names, queryId),
+      additionalNames: this.transformNodeList(node.additionalNames, queryId),
       ifExists: node.ifExists,
       modifier: node.modifier,
     })

--- a/src/parser/identifier-parser.ts
+++ b/src/parser/identifier-parser.ts
@@ -17,11 +17,11 @@ export function parseSchemableIdentifier(id: string): SchemableIdentifierNode {
 }
 
 export function parseSchemableIdentifierArray(id: string | string[]): SchemableIdentifierNode[] {
-  if (Array.isArray(id)) {
-		return id.map(parseSchemableIdentifier)
-	} else {
-		return [parseSchemableIdentifier(id)]
-	}
+  if (!Array.isArray(id)) {
+    id = [id]
+  }
+  
+  return id.map(parseSchemableIdentifier)
 }
 
 function trim(str: string): string {

--- a/src/parser/identifier-parser.ts
+++ b/src/parser/identifier-parser.ts
@@ -16,11 +16,13 @@ export function parseSchemableIdentifier(id: string): SchemableIdentifierNode {
   }
 }
 
-export function parseSchemableIdentifierArray(id: string | string[]): SchemableIdentifierNode[] {
+export function parseSchemableIdentifierArray(
+  id: string | string[],
+): SchemableIdentifierNode[] {
   if (!Array.isArray(id)) {
     id = [id]
   }
-  
+
   return id.map(parseSchemableIdentifier)
 }
 

--- a/src/parser/identifier-parser.ts
+++ b/src/parser/identifier-parser.ts
@@ -16,6 +16,14 @@ export function parseSchemableIdentifier(id: string): SchemableIdentifierNode {
   }
 }
 
+export function parseSchemableIdentifierArray(id: string | string[]): SchemableIdentifierNode[] {
+  if (Array.isArray(id)) {
+		return id.map(parseSchemableIdentifier)
+	} else {
+		return [parseSchemableIdentifier(id)]
+	}
+}
+
 function trim(str: string): string {
   return str.trim()
 }

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1429,7 +1429,7 @@ export class DefaultQueryCompiler
     }
 
     this.visitNode(node.name)
-    
+
     if (node.additionalNames?.length) {
       this.append(', ')
       this.compileList(node.additionalNames)

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1429,6 +1429,12 @@ export class DefaultQueryCompiler
     }
 
     this.compileList(node.names)
+
+    if (node.modifier === 'cascade') {
+      this.append(' cascade')
+    } else if (node.modifier === 'restrict') {
+      this.append(' restrict')
+    }
   }
 
   protected override visitExplain(node: ExplainNode): void {

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1428,7 +1428,12 @@ export class DefaultQueryCompiler
       this.append('if exists ')
     }
 
-    this.compileList([node.name, ...(node.additionalNames ?? [])])
+    this.visitNode(node.name)
+    
+    if (node.additionalNames?.length) {
+      this.append(', ')
+      this.compileList(node.additionalNames)
+    }
 
     if (node.modifier) {
       this.append(` ${node.modifier}`)

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1428,7 +1428,7 @@ export class DefaultQueryCompiler
       this.append('if exists ')
     }
 
-    this.visitNode(node.name)
+    this.compileList(node.names)
   }
 
   protected override visitExplain(node: ExplainNode): void {

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1428,7 +1428,7 @@ export class DefaultQueryCompiler
       this.append('if exists ')
     }
 
-    this.compileList(node.names)
+    this.compileList([node.name, ...(node.additionalNames ?? [])])
 
     if (node.modifier) {
       this.append(` ${node.modifier}`)

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1435,8 +1435,8 @@ export class DefaultQueryCompiler
       this.compileList(node.additionalNames)
     }
 
-    if (node.modifier) {
-      this.append(` ${node.modifier}`)
+    if (node.cascade) {
+      this.append(' cascade')
     }
   }
 

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1430,10 +1430,8 @@ export class DefaultQueryCompiler
 
     this.compileList(node.names)
 
-    if (node.modifier === 'cascade') {
-      this.append(' cascade')
-    } else if (node.modifier === 'restrict') {
-      this.append(' restrict')
+    if (node.modifier) {
+      this.append(` ${node.modifier}`)
     }
   }
 

--- a/src/schema/drop-type-builder.ts
+++ b/src/schema/drop-type-builder.ts
@@ -22,6 +22,24 @@ export class DropTypeBuilder implements OperationNodeSource, Compilable {
     })
   }
 
+  cascade(): DropTypeBuilder {
+    return new DropTypeBuilder({
+      ...this.#props,
+      node: DropTypeNode.cloneWith(this.#props.node, {
+        modifier: 'cascade',
+      }),
+    })
+  }
+
+  restrict(): DropTypeBuilder {
+    return new DropTypeBuilder({
+      ...this.#props,
+      node: DropTypeNode.cloneWith(this.#props.node, {
+        modifier: 'restrict',
+      }),
+    })
+  }
+
   /**
    * Simply calls the provided function passing `this` as the only argument. `$call` returns
    * what the provided function returns.

--- a/src/schema/drop-type-builder.ts
+++ b/src/schema/drop-type-builder.ts
@@ -13,6 +13,9 @@ export class DropTypeBuilder implements OperationNodeSource, Compilable {
     this.#props = freeze(props)
   }
 
+  /**
+   * Adds `if exists` to the query.
+   */
   ifExists(): DropTypeBuilder {
     return new DropTypeBuilder({
       ...this.#props,
@@ -22,20 +25,14 @@ export class DropTypeBuilder implements OperationNodeSource, Compilable {
     })
   }
 
+  /**
+   * Adds `cascade` to the query.
+   */
   cascade(): DropTypeBuilder {
     return new DropTypeBuilder({
       ...this.#props,
       node: DropTypeNode.cloneWith(this.#props.node, {
-        modifier: 'cascade',
-      }),
-    })
-  }
-
-  restrict(): DropTypeBuilder {
-    return new DropTypeBuilder({
-      ...this.#props,
-      node: DropTypeNode.cloneWith(this.#props.node, {
-        modifier: 'restrict',
+        cascade: true,
       }),
     })
   }

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -25,7 +25,7 @@ import { CreateTypeBuilder } from './create-type-builder.js'
 import { DropTypeBuilder } from './drop-type-builder.js'
 import { CreateTypeNode } from '../operation-node/create-type-node.js'
 import { DropTypeNode } from '../operation-node/drop-type-node.js'
-import { parseSchemableIdentifier } from '../parser/identifier-parser.js'
+import { parseSchemableIdentifier, parseSchemableIdentifierArray } from '../parser/identifier-parser.js'
 import { RefreshMaterializedViewBuilder } from './refresh-materialized-view-builder.js'
 import { RefreshMaterializedViewNode } from '../operation-node/refresh-materialized-view-node.js'
 
@@ -311,19 +311,19 @@ export class SchemaModule {
    *   .ifExists()
    *   .execute()
    * ```
-	 * 
-	 * ```ts
-	 * await db.schema
-	 *   .dropType(['species', 'colors'])
-	 *   .ifExists()
-	 *   .execute()
-	 * ```
+   * 
+   * ```ts
+   * await db.schema
+   *   .dropType(['species', 'colors'])
+   *   .ifExists()
+   *   .execute()
+   * ```
    */
-  dropType(typeName: string): DropTypeBuilder {
+  dropType(typeName: string | string[]): DropTypeBuilder {
     return new DropTypeBuilder({
       queryId: createQueryId(),
       executor: this.#executor,
-      node: DropTypeNode.create(parseSchemableIdentifier(typeName)),
+      node: DropTypeNode.create(parseSchemableIdentifierArray(typeName)),
     })
   }
 

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -311,6 +311,7 @@ export class SchemaModule {
    *   .ifExists()
    *   .execute()
    * ```
+   * You can also provide multiple type names:
    * 
    * ```ts
    * await db.schema

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -311,6 +311,13 @@ export class SchemaModule {
    *   .ifExists()
    *   .execute()
    * ```
+	 * 
+	 * ```ts
+	 * await db.schema
+	 *   .dropType(['species', 'colors'])
+	 *   .ifExists()
+	 *   .execute()
+	 * ```
    */
   dropType(typeName: string): DropTypeBuilder {
     return new DropTypeBuilder({

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -316,6 +316,7 @@ export class SchemaModule {
    * await db.schema
    *   .dropType(['species', 'colors'])
    *   .ifExists()
+   *   .cascade()
    *   .execute()
    * ```
    */

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -25,7 +25,10 @@ import { CreateTypeBuilder } from './create-type-builder.js'
 import { DropTypeBuilder } from './drop-type-builder.js'
 import { CreateTypeNode } from '../operation-node/create-type-node.js'
 import { DropTypeNode } from '../operation-node/drop-type-node.js'
-import { parseSchemableIdentifier, parseSchemableIdentifierArray } from '../parser/identifier-parser.js'
+import {
+  parseSchemableIdentifier,
+  parseSchemableIdentifierArray,
+} from '../parser/identifier-parser.js'
 import { RefreshMaterializedViewBuilder } from './refresh-materialized-view-builder.js'
 import { RefreshMaterializedViewNode } from '../operation-node/refresh-materialized-view-node.js'
 
@@ -311,8 +314,9 @@ export class SchemaModule {
    *   .ifExists()
    *   .execute()
    * ```
+   *
    * You can also provide multiple type names:
-   * 
+   *
    * ```ts
    * await db.schema
    *   .dropType(['species', 'colors'])

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -2457,6 +2457,7 @@ for (const dialect of DIALECTS) {
       if (sqlSpec === 'postgres') {
         it('should drop a schema cascade', async () => {
           await ctx.db.schema.createSchema('pets').execute()
+
           const builder = ctx.db.schema.dropSchema('pets').cascade()
 
           testSql(builder, dialect, {
@@ -2562,43 +2563,45 @@ for (const dialect of DIALECTS) {
           await builder.execute()
         })
 
-				it('should drop multiple types', async () => {
-					await ctx.db.schema.createType('species').execute()
-					await ctx.db.schema.createType('colors').execute()
+        it('should drop multiple types', async () => {
+          await ctx.db.schema.createType('species').execute()
+          await ctx.db.schema.createType('colors').execute()
 
-					const builder = ctx.db.schema
-						.dropType(['species', 'colors'])
-						.ifExists()
+          const builder = ctx.db.schema
+            .dropType(['species', 'colors'])
+            .ifExists()
 
-					testSql(builder, dialect, {
-						postgres: {
-							sql: `drop type if exists "species", "colors"`,
-							parameters: [],
-						},
-						mysql: NOT_SUPPORTED,
-						mssql: NOT_SUPPORTED,
-						sqlite: NOT_SUPPORTED,
-					})
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `drop type if exists "species", "colors"`,
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
 
-					await builder.execute()
-				})
+          await builder.execute()
+        })
 
-				it('should drop multiple types if exists', async () => {
-					await ctx.db.schema.createType('species').execute()
-					const builder = ctx.db.schema.dropType(['species', 'colors']).ifExists()
+        it('should drop multiple types if exists', async () => {
+          await ctx.db.schema.createType('species').execute()
+          const builder = ctx.db.schema
+            .dropType(['species', 'colors'])
+            .ifExists()
 
-					testSql(builder, dialect, {
-						postgres: {
-							sql: `drop type if exists "species", "colors"`,
-							parameters: [],
-						},
-						mysql: NOT_SUPPORTED,
-						mssql: NOT_SUPPORTED,
-						sqlite: NOT_SUPPORTED,
-					})
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `drop type if exists "species", "colors"`,
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
 
-					await builder.execute()
-				})
+          await builder.execute()
+        })
 
         it('should drop a type and cascade', async () => {
           await ctx.db.schema.createType('species').execute()

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -2599,6 +2599,24 @@ for (const dialect of DIALECTS) {
 
 					await builder.execute()
 				})
+
+        it('should drop a type and cascade', async () => {
+          await ctx.db.schema.createType('species').execute()
+
+          const builder = ctx.db.schema.dropType('species').cascade()
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `drop type "species" cascade`,
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
       }
 
       async function cleanup() {

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -2561,10 +2561,48 @@ for (const dialect of DIALECTS) {
 
           await builder.execute()
         })
+
+				it('should drop multiple types', async () => {
+					await ctx.db.schema.createType('species').execute()
+					await ctx.db.schema.createType('colors').execute()
+
+					const builder = ctx.db.schema
+						.dropType(['species', 'colors'])
+						.ifExists()
+
+					testSql(builder, dialect, {
+						postgres: {
+							sql: `drop type if exists "species", "colors"`,
+							parameters: [],
+						},
+						mysql: NOT_SUPPORTED,
+						mssql: NOT_SUPPORTED,
+						sqlite: NOT_SUPPORTED,
+					})
+
+					await builder.execute()
+				})
+
+				it('should drop multiple types if exists', async () => {
+					await ctx.db.schema.createType('species').execute()
+					const builder = ctx.db.schema.dropType(['species', 'colors']).ifExists()
+
+					testSql(builder, dialect, {
+						postgres: {
+							sql: `drop type if exists "species", "colors"`,
+							parameters: [],
+						},
+						mysql: NOT_SUPPORTED,
+						mssql: NOT_SUPPORTED,
+						sqlite: NOT_SUPPORTED,
+					})
+
+					await builder.execute()
+				})
       }
 
       async function cleanup() {
-        await ctx.db.schema.dropType('species').ifExists().execute()
+        await ctx.db.schema.dropType(['species', 'colors']).ifExists().execute()
       }
     })
 


### PR DESCRIPTION
Closes #1508

This PR adds support for arrays as input to the `schema.dropType()` method, e.g.
```ts
db.schema.dropType(['species', 'colors'])
```

While I was in the area I also added `.cascade()` ~~and `.restrict()`~~ methods, to completely support Postgres' `DROP TYPE`. I based the implementation on the one for `DropConstraintNode`.

I only added functionality tests as the existing `dropType()`  method didn't have type tests and I wasn't sure how to go about writing them.