### PR TITLE
fix: correct JSDoc type references in migration docs

### DIFF
--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -885,12 +885,12 @@ export interface MigrationResult {
    * The execution status.
    *
    *  - `Success` means the migration was successfully executed. Note that
-   *    if any of the later migrations in the {@link MigrationResult.results}
+   *    if any of the later migrations in the {@link MigrationResultSet.results}
    *    list failed (have status `Error`) AND the dialect supports transactional
    *    DDL, even the successfull migrations were rolled back.
    *
    *  - `Error` means the migration failed. In this case the
-   *    {@link MigrationResult.error} contains the error.
+   *    {@link MigrationResultSet.error} contains the error.
    *
    *  - `NotExecuted` means that the migration was supposed to be executed
    *    but wasn't because an earlier migration failed.


### PR DESCRIPTION
Closes https://github.com/kysely-org/kysely/issues/1523

The `MigrationResult` interface only contains `migrationName`, `direction`, and `status` properties, while the `error` and `results` properties belong to the `MigrationResultSet` interface, so the references were corrected:

- Changed `{@link MigrationResult.results}` to `{@link MigrationResultSet.results}`
- Changed `{@link MigrationResult.error}` to `{@link MigrationResultSet.error}`