### PR TITLE
fix: "this is likely not portable" when composite when using `$narrowType`.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -244,6 +244,7 @@ export type {
   ShallowDehydrateValue,
   StringsWhenDataTypeNotAvailable,
 } from './util/type-utils.js'
+export type { KyselyTypeError } from './util/type-error.js'
 export * from './util/infer-result.js'
 export { logOnce } from './util/log-once.js'
 export { createQueryId, type QueryId } from './util/query-id.js'

--- a/test/composite-ts/foo.mts
+++ b/test/composite-ts/foo.mts
@@ -8,5 +8,5 @@ export function foo<T extends 'myColumn'>(
   }>,
   field: T,
 ) {
-  return db.selectFrom('MyTable').select(field)
+  return db.selectFrom('MyTable').select(field).$narrowType<{}>()
 }


### PR DESCRIPTION
Hey :wave:

closes #1609.