### PR TITLE
feat: allow overriding file import function @ `FileMigrationProvider`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "tarn": "3.0.2",
     "tedious": "19.2.1",
     "tsd": "0.33.0",
+    "tsx": "4.21.0",
     "typescript": "6.0.2"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       tsd:
         specifier: 0.33.0
         version: 0.33.0
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
       typescript:
         specifier: 6.0.2
         version: 6.0.2
@@ -4031,6 +4034,11 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -4059,6 +4067,9 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -6237,6 +6248,9 @@ packages:
   resolve-pathname@3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -6739,6 +6753,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -12004,6 +12023,9 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   generate-function@2.3.1:
@@ -12035,6 +12057,10 @@ snapshots:
       es-object-atoms: 1.1.1
 
   get-stream@6.0.1: {}
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-from-package@0.0.0: {}
 
@@ -14764,6 +14790,8 @@ snapshots:
 
   resolve-pathname@3.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
@@ -15332,6 +15360,13 @@ snapshots:
       read-pkg-up: 7.0.1
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ allowBuilds:
   better-sqlite3@12.8.0: true
   core-js: false # site dependency, useless scripts
   core-js-pure: false # site dependency, useless scripts
-  esbuild@0.28.0: true
+  esbuild@0.27.3 || 0.28.0: true # tsx@4.21.0 dependency || direct.
   sharp: false # wrangler dependency, useless scripts
   workerd@1.20260405.1: true # wrangler@4.81.0 dependency
 

--- a/src/migration/file-migration-provider.ts
+++ b/src/migration/file-migration-provider.ts
@@ -2,7 +2,7 @@ import { isFunction, isObject } from '../util/object-utils.js'
 import type { Migration, MigrationProvider } from './migrator.js'
 
 /**
- * Reads all migrations from a folder in node.js.
+ * Reads all migrations from a folder.
  *
  * ### Examples
  *
@@ -29,30 +29,44 @@ export class FileMigrationProvider implements MigrationProvider {
     const files = await this.#props.fs.readdir(this.#props.migrationFolder)
 
     for (const fileName of files) {
-      if (
-        fileName.endsWith('.js') ||
-        (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts')) ||
-        fileName.endsWith('.mjs') ||
-        (fileName.endsWith('.mts') && !fileName.endsWith('.d.mts'))
-      ) {
-        const migration = await import(
-          /* webpackIgnore: true */ this.#props.path.join(
-            this.#props.migrationFolder,
-            fileName,
-          )
-        )
-        const migrationKey = fileName.substring(0, fileName.lastIndexOf('.'))
+      if (!this.hasExpectedExtension(fileName)) {
+        this.#props.onDiscarded?.(fileName, 'Extension')
+        continue
+      }
 
-        // Handle esModuleInterop export's `default` prop...
-        if (isMigration(migration?.default)) {
-          migrations[migrationKey] = migration.default
-        } else if (isMigration(migration)) {
-          migrations[migrationKey] = migration
-        }
+      const filePath = this.#props.path.join(
+        this.#props.migrationFolder,
+        fileName,
+      )
+
+      const migration = this.#props.import
+        ? await this.#props.import(filePath)
+        : await import(/* webpackIgnore: true */ filePath)
+
+      const migrationKey = fileName.substring(0, fileName.lastIndexOf('.'))
+
+      // Handle esModuleInterop export's `default` prop...
+      if (isMigration(migration?.default)) {
+        migrations[migrationKey] = migration.default
+      } else if (isMigration(migration)) {
+        migrations[migrationKey] = migration
+      } else {
+        this.#props.onDiscarded?.(fileName, 'NotMigration')
       }
     }
 
     return migrations
+  }
+
+  protected hasExpectedExtension(fileName: string): boolean {
+    return (
+      fileName.endsWith('.js') ||
+      (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts')) ||
+      fileName.endsWith('.mjs') ||
+      (fileName.endsWith('.mts') && !fileName.endsWith('.d.mts')) ||
+      fileName.endsWith('.cjs') ||
+      (fileName.endsWith('.cts') && !fileName.endsWith('.d.cts'))
+    )
   }
 }
 
@@ -70,6 +84,8 @@ export interface FileMigrationProviderPath {
 
 export interface FileMigrationProviderProps {
   fs: FileMigrationProviderFS
-  path: FileMigrationProviderPath
+  import?(module: string): Promise<any>
   migrationFolder: string
+  onDiscarded?(fileName: string, reason: 'Extension' | 'NotMigration'): void
+  path: FileMigrationProviderPath
 }

--- a/src/migration/file-migration-provider.ts
+++ b/src/migration/file-migration-provider.ts
@@ -30,7 +30,7 @@ export class FileMigrationProvider implements MigrationProvider {
 
     for (const fileName of files) {
       if (!this.hasExpectedExtension(fileName)) {
-        this.#props.onDiscarded?.(fileName, 'Extension')
+        this.#props.onFileIgnored?.(fileName, 'Extension')
         continue
       }
 
@@ -51,7 +51,7 @@ export class FileMigrationProvider implements MigrationProvider {
       } else if (isMigration(migration)) {
         migrations[migrationKey] = migration
       } else {
-        this.#props.onDiscarded?.(fileName, 'NotMigration')
+        this.#props.onFileIgnored?.(fileName, 'NotMigration')
       }
     }
 
@@ -86,6 +86,6 @@ export interface FileMigrationProviderProps {
   fs: FileMigrationProviderFS
   import?(module: string): Promise<any>
   migrationFolder: string
-  onDiscarded?(fileName: string, reason: 'Extension' | 'NotMigration'): void
+  onFileIgnored?(fileName: string, reason: 'Extension' | 'NotMigration'): void
   path: FileMigrationProviderPath
 }

--- a/test/node/src/file-migration-provider.test.ts
+++ b/test/node/src/file-migration-provider.test.ts
@@ -1,0 +1,89 @@
+import { mkdir, readdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { require as tsxRequire } from 'tsx/cjs/api'
+import { FileMigrationProvider } from '../../..'
+import { expect } from './test-setup.js'
+
+describe('FileMigrationProvider', () => {
+  ;['js', 'ts', 'mjs', 'cjs', 'mts', 'cts'].forEach((extension) => {
+    describe(`${extension} files`, () => {
+      const migrationFolder = `${extension}-migrations`
+      const migrationFolderPath = join(__dirname, migrationFolder)
+      let provider: FileMigrationProvider
+      const migrationName = '123_noop'
+
+      before(async () => {
+        await mkdir(migrationFolderPath)
+        await writeFile(
+          join(migrationFolderPath, `${migrationName}.${extension}`),
+          extension.endsWith('js')
+            ? 'exports.up = () => {}'
+            : 'export const up = () => {}',
+        )
+
+        provider = new FileMigrationProvider({
+          fs: { readdir },
+          import:
+            extension.endsWith('ts') || extension.startsWith('m')
+              ? (module: string) => tsxRequire(module, __filename)
+              : undefined,
+          migrationFolder: migrationFolderPath,
+          path: { join },
+        })
+      })
+
+      after(async () => {
+        await rm(migrationFolderPath, { recursive: true })
+      })
+
+      it('should get migration files with this extension', async () => {
+        const migrations = await provider.getMigrations()
+
+        expect(migrations).to.have.property(migrationName)
+      })
+    })
+  })
+  //
+  ;['zip', 'd.ts', 'd.mts', 'd.cts'].forEach((extension) => {
+    describe(`${extension} files`, () => {
+      const migrationFolder = `${extension}-migrations`
+      const migrationFolderPath = join(__dirname, migrationFolder)
+      let provider: FileMigrationProvider
+      const migrationFileName = `123_noop.${extension}`
+      let discarded: { fileName: string; reason: string }[]
+
+      before(async () => {
+        await mkdir(migrationFolderPath)
+        await writeFile(
+          join(migrationFolderPath, migrationFileName),
+          extension.endsWith('ts') ? 'export {}' : '==asdhjgbaudg1827dg127',
+        )
+        discarded = []
+
+        provider = new FileMigrationProvider({
+          fs: { readdir },
+          migrationFolder: migrationFolderPath,
+          onDiscarded: (fileName, reason) => {
+            discarded.push({ fileName, reason })
+          },
+          path: { join },
+        })
+      })
+
+      after(async () => {
+        await rm(migrationFolderPath, { recursive: true })
+      })
+
+      it('should discard files with this extension', async () => {
+        const migrations = await provider.getMigrations()
+
+        expect(migrations).to.deep.equal({})
+        expect(discarded).to.have.length(1)
+        expect(discarded[0]).to.deep.equal({
+          fileName: migrationFileName,
+          reason: 'Extension',
+        })
+      })
+    })
+  })
+})

--- a/test/node/src/file-migration-provider.test.ts
+++ b/test/node/src/file-migration-provider.test.ts
@@ -54,7 +54,7 @@ describe('FileMigrationProvider', () => {
       const migrationFolderPath = join(__dirname, migrationFolder)
       let provider: FileMigrationProvider
       const migrationFileName = `123_noop.${extension}`
-      let discarded: { fileName: string; reason: string }[]
+      const ignored: { fileName: string; reason: string }[] = []
 
       before(async () => {
         await mkdir(migrationFolderPath)
@@ -62,13 +62,12 @@ describe('FileMigrationProvider', () => {
           join(migrationFolderPath, migrationFileName),
           extension.endsWith('ts') ? 'export {}' : '==asdhjgbaudg1827dg127',
         )
-        discarded = []
 
         provider = new FileMigrationProvider({
           fs: { readdir },
           migrationFolder: migrationFolderPath,
-          onDiscarded: (fileName, reason) => {
-            discarded.push({ fileName, reason })
+          onFileIgnored: (fileName, reason) => {
+            ignored.push({ fileName, reason })
           },
           path: { join },
         })
@@ -82,8 +81,8 @@ describe('FileMigrationProvider', () => {
         const migrations = await provider.getMigrations()
 
         expect(migrations).to.deep.equal({})
-        expect(discarded).to.have.length(1)
-        expect(discarded[0]).to.deep.equal({
+        expect(ignored).to.have.length(1)
+        expect(ignored[0]).to.deep.equal({
           fileName: migrationFileName,
           reason: 'Extension',
         })

--- a/test/node/src/file-migration-provider.test.ts
+++ b/test/node/src/file-migration-provider.test.ts
@@ -1,8 +1,12 @@
 import { mkdir, readdir, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'pathe'
 import { require as tsxRequire } from 'tsx/cjs/api'
-import { FileMigrationProvider } from '../../..'
+import { FileMigrationProvider } from '../../../dist/migration/file-migration-provider.js'
 import { expect } from './test-setup.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 describe('FileMigrationProvider', () => {
   ;['js', 'ts', 'mjs', 'cjs', 'mts', 'cts'].forEach((extension) => {
@@ -16,17 +20,16 @@ describe('FileMigrationProvider', () => {
         await mkdir(migrationFolderPath)
         await writeFile(
           join(migrationFolderPath, `${migrationName}.${extension}`),
-          extension.endsWith('js')
+          extension.startsWith('c')
             ? 'exports.up = () => {}'
             : 'export const up = () => {}',
         )
 
         provider = new FileMigrationProvider({
           fs: { readdir },
-          import:
-            extension.endsWith('ts') || extension.startsWith('m')
-              ? (module: string) => tsxRequire(module, __filename)
-              : undefined,
+          import: extension.startsWith('c')
+            ? (module: string) => tsxRequire(module, __filename)
+            : undefined,
           migrationFolder: migrationFolderPath,
           path: { join },
         })

--- a/test/node/src/file-migration-provider.test.ts
+++ b/test/node/src/file-migration-provider.test.ts
@@ -27,9 +27,10 @@ describe('FileMigrationProvider', () => {
 
         provider = new FileMigrationProvider({
           fs: { readdir },
-          import: extension.startsWith('c')
-            ? (module: string) => tsxRequire(module, __filename)
-            : undefined,
+          import:
+            extension.startsWith('c') || process.version.startsWith('v20.')
+              ? (module: string) => tsxRequire(module, __filename)
+              : undefined,
           migrationFolder: migrationFolderPath,
           path: { join },
         })

--- a/test/node/src/test-migrations/migration1.ts
+++ b/test/node/src/test-migrations/migration1.ts
@@ -1,4 +1,4 @@
-import { Kysely } from '../../../../dist/index.js'
+import type { Kysely } from '../../../../dist/index.js'
 
 export async function up(db: Kysely<any>): Promise<void> {
   await db.schema

--- a/test/node/src/test-migrations/migration2.ts
+++ b/test/node/src/test-migrations/migration2.ts
@@ -1,4 +1,4 @@
-import { Kysely } from '../../../../dist/index.js'
+import type { Kysely } from '../../../../dist/index.js'
 
 export async function up(db: Kysely<any>): Promise<void> {
   await db.schema


### PR DESCRIPTION
Hey 👋 

This PR adds an `import` property to the configuration object accepted by `FileMigrationProvider`. This allows you to pass your own file loading function - e.g. a custom require from `tsx`, a `jiti` importer that's configured to understand your project's `paths` aliases, etc.

Also adds a `onFileIgnored` hook.

Born out of learnings from the `kysely-ctl` project, which has it's own provider implementation given the current provider was limiting.