### PR TITLE
feat: add synchronous query execution support

### DIFF
--- a/src/dialect/dialect-adapter-base.ts
+++ b/src/dialect/dialect-adapter-base.ts
@@ -24,6 +24,10 @@ export abstract class DialectAdapterBase implements DialectAdapter {
     return false
   }
 
+  get supportsSyncExecution(): boolean {
+    return false
+  }
+
   abstract acquireMigrationLock(
     db: Kysely<any>,
     options: MigrationLockOptions,

--- a/src/dialect/dialect-adapter.ts
+++ b/src/dialect/dialect-adapter.ts
@@ -38,6 +38,11 @@ export interface DialectAdapter {
   readonly supportsOutput?: boolean
 
   /**
+   * Whether or not this dialect supports synchronous query execution.
+   */
+  readonly supportsSyncExecution?: boolean
+
+  /**
    * This method is used to acquire a lock for the migrations so that
    * it's not possible for two migration operations to run in parallel.
    *

--- a/src/dialect/sqlite/sqlite-adapter.ts
+++ b/src/dialect/sqlite/sqlite-adapter.ts
@@ -11,6 +11,10 @@ export class SqliteAdapter extends DialectAdapterBase {
     return true
   }
 
+  override get supportsSyncExecution(): boolean {
+    return true
+  }
+
   override async acquireMigrationLock(
     _db: Kysely<any>,
     _opt: MigrationLockOptions,

--- a/src/driver/connection-provider.ts
+++ b/src/driver/connection-provider.ts
@@ -8,4 +8,10 @@ export interface ConnectionProvider {
   provideConnection<T>(
     consumer: (connection: DatabaseConnection) => Promise<T>,
   ): Promise<T>
+
+  /**
+   * Provides a connection synchronously for the callback and takes care of
+   * disposing the connection after the callback has been run.
+   */
+  provideConnectionSync?<T>(consumer: (connection: DatabaseConnection) => T): T
 }

--- a/src/driver/database-connection.ts
+++ b/src/driver/database-connection.ts
@@ -11,6 +11,7 @@ export interface DatabaseConnection {
     compiledQuery: CompiledQuery,
     chunkSize?: number,
   ): AsyncIterableIterator<QueryResult<R>>
+  executeQuerySync?<R>(compiledQuery: CompiledQuery): QueryResult<R>
 }
 
 export interface QueryResult<O> {

--- a/src/driver/default-connection-provider.ts
+++ b/src/driver/default-connection-provider.ts
@@ -20,4 +20,20 @@ export class DefaultConnectionProvider implements ConnectionProvider {
       await this.#driver.releaseConnection(connection)
     }
   }
+
+  provideConnectionSync<T>(consumer: (connection: DatabaseConnection) => T): T {
+    if (!this.#driver.acquireConnectionSync) {
+      throw new Error(
+        'The current dialect does not support synchronous execution.',
+      )
+    }
+
+    const connection = this.#driver.acquireConnectionSync()
+
+    try {
+      return consumer(connection)
+    } finally {
+      this.#driver.releaseConnectionSync?.(connection)
+    }
+  }
 }

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -74,6 +74,21 @@ export interface Driver {
    * Destroys the driver and releases all resources.
    */
   destroy(): Promise<void>
+
+  /**
+   * Initializes the driver synchronously.
+   */
+  initSync?(): void
+
+  /**
+   * Acquires a connection synchronously.
+   */
+  acquireConnectionSync?(): DatabaseConnection
+
+  /**
+   * Releases a connection synchronously.
+   */
+  releaseConnectionSync?(connection: DatabaseConnection): void
 }
 
 export interface TransactionSettings {

--- a/src/driver/single-connection-provider.ts
+++ b/src/driver/single-connection-provider.ts
@@ -28,6 +28,17 @@ export class SingleConnectionProvider implements ConnectionProvider {
     return this.#runningPromise
   }
 
+  provideConnectionSync<T>(consumer: (connection: DatabaseConnection) => T): T {
+    if (this.#runningPromise) {
+      throw new Error(
+        'Cannot execute synchronously while an async operation is in progress. ' +
+          'Await all async operations before using sync methods.',
+      )
+    }
+
+    return consumer(this.#connection)
+  }
+
   // Run the runner in an async function to make sure it doesn't
   // throw synchronous errors.
   async #run<T>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,6 +245,7 @@ export type {
   StringsWhenDataTypeNotAvailable,
 } from './util/type-utils.js'
 export * from './util/infer-result.js'
+export * from './util/sync-not-supported-error.js'
 export { logOnce } from './util/log-once.js'
 export { createQueryId, type QueryId } from './util/query-id.js'
 

--- a/src/plugin/camel-case/camel-case-plugin.ts
+++ b/src/plugin/camel-case/camel-case-plugin.ts
@@ -139,6 +139,14 @@ export class CamelCasePlugin implements KyselyPlugin {
   async transformResult(
     args: PluginTransformResultArgs,
   ): Promise<QueryResult<UnknownRow>> {
+    return this.#transformResult(args)
+  }
+
+  transformResultSync(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
+    return this.#transformResult(args)
+  }
+
+  #transformResult(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
     if (args.result.rows && Array.isArray(args.result.rows)) {
       return {
         ...args.result,

--- a/src/plugin/deduplicate-joins/deduplicate-joins-plugin.ts
+++ b/src/plugin/deduplicate-joins/deduplicate-joins-plugin.ts
@@ -25,4 +25,8 @@ export class DeduplicateJoinsPlugin implements KyselyPlugin {
   ): Promise<QueryResult<UnknownRow>> {
     return Promise.resolve(args.result)
   }
+
+  transformResultSync(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
+    return args.result
+  }
 }

--- a/src/plugin/handle-empty-in-lists/handle-empty-in-lists-plugin.ts
+++ b/src/plugin/handle-empty-in-lists/handle-empty-in-lists-plugin.ts
@@ -168,4 +168,8 @@ export class HandleEmptyInListsPlugin implements KyselyPlugin {
   ): Promise<QueryResult<UnknownRow>> {
     return args.result
   }
+
+  transformResultSync(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
+    return args.result
+  }
 }

--- a/src/plugin/immediate-value/immediate-value-plugin.ts
+++ b/src/plugin/immediate-value/immediate-value-plugin.ts
@@ -28,4 +28,8 @@ export class ImmediateValuePlugin implements KyselyPlugin {
   ): Promise<QueryResult<UnknownRow>> {
     return Promise.resolve(args.result)
   }
+
+  transformResultSync(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
+    return args.result
+  }
 }

--- a/src/plugin/kysely-plugin.ts
+++ b/src/plugin/kysely-plugin.ts
@@ -65,6 +65,11 @@ export interface KyselyPlugin {
   transformResult(
     args: PluginTransformResultArgs,
   ): Promise<QueryResult<UnknownRow>>
+
+  /**
+   * Synchronous version of {@link transformResult}.
+   */
+  transformResultSync?(args: PluginTransformResultArgs): QueryResult<UnknownRow>
 }
 
 export interface PluginTransformQueryArgs {

--- a/src/plugin/noop-plugin.ts
+++ b/src/plugin/noop-plugin.ts
@@ -17,4 +17,8 @@ export class NoopPlugin implements KyselyPlugin {
   ): Promise<QueryResult<UnknownRow>> {
     return args.result
   }
+
+  transformResultSync(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
+    return args.result
+  }
 }

--- a/src/plugin/parse-json-results/parse-json-results-plugin.ts
+++ b/src/plugin/parse-json-results/parse-json-results-plugin.ts
@@ -83,6 +83,14 @@ export class ParseJSONResultsPlugin implements KyselyPlugin {
   async transformResult(
     args: PluginTransformResultArgs,
   ): Promise<QueryResult<UnknownRow>> {
+    return this.#transformResult(args)
+  }
+
+  transformResultSync(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
+    return this.#transformResult(args)
+  }
+
+  #transformResult(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
     return {
       ...args.result,
       rows: parseArray(args.result.rows, this.#objectStrategy),

--- a/src/plugin/with-schema/with-schema-plugin.ts
+++ b/src/plugin/with-schema/with-schema-plugin.ts
@@ -24,4 +24,8 @@ export class WithSchemaPlugin implements KyselyPlugin {
   ): Promise<QueryResult<UnknownRow>> {
     return args.result
   }
+
+  transformResultSync(args: PluginTransformResultArgs): QueryResult<UnknownRow> {
+    return args.result
+  }
 }

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -1347,6 +1347,69 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
     return result as SimplifyResult<O>
   }
 
+  /**
+   * Executes the query synchronously and returns an array of rows.
+   *
+   * Also see the {@link executeTakeFirstSync} and {@link executeTakeFirstOrThrowSync} methods.
+   */
+  executeSync(): SimplifyResult<O>[] {
+    const compiledQuery = this.compile()
+
+    const result = this.#props.executor.executeQuerySync<O>(compiledQuery)
+
+    const { adapter } = this.#props.executor
+    const query = compiledQuery.query as InsertQueryNode
+
+    if (
+      (query.returning && adapter.supportsReturning) ||
+      (query.output && adapter.supportsOutput)
+    ) {
+      return result.rows as any
+    }
+
+    return [
+      new InsertResult(
+        result.insertId,
+        result.numAffectedRows ?? BigInt(0),
+      ) as any,
+    ]
+  }
+
+  /**
+   * Executes the query synchronously and returns the first result or undefined if
+   * the query returned no result.
+   */
+  executeTakeFirstSync(): SimplifySingleResult<O> {
+    const [result] = this.executeSync()
+    return result as SimplifySingleResult<O>
+  }
+
+  /**
+   * Executes the query synchronously and returns the first result or throws if
+   * the query returned no result.
+   *
+   * By default an instance of {@link NoResultError} is thrown, but you can
+   * provide a custom error class, or callback as the only argument to throw a different
+   * error.
+   */
+  executeTakeFirstOrThrowSync(
+    errorConstructor:
+      | NoResultErrorConstructor
+      | ((node: QueryNode) => Error) = NoResultError,
+  ): SimplifyResult<O> {
+    const result = this.executeTakeFirstSync()
+
+    if (result === undefined) {
+      const error = isNoResultErrorConstructor(errorConstructor)
+        ? new errorConstructor(this.toOperationNode())
+        : errorConstructor(this.toOperationNode())
+
+      throw error
+    }
+
+    return result as SimplifyResult<O>
+  }
+
   async *stream(chunkSize: number = 100): AsyncIterableIterator<O> {
     const compiledQuery = this.compile()
 

--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -932,6 +932,64 @@ export class WheneableMergeQueryBuilder<
 
     return result as SimplifyResult<O>
   }
+
+  /**
+   * Executes the query synchronously and returns an array of rows.
+   *
+   * Also see the {@link executeTakeFirstSync} and {@link executeTakeFirstOrThrowSync} methods.
+   */
+  executeSync(): SimplifyResult<O>[] {
+    const compiledQuery = this.compile()
+
+    const result = this.#props.executor.executeQuerySync<O>(compiledQuery)
+
+    const { adapter } = this.#props.executor
+    const query = compiledQuery.query as MergeQueryNode
+
+    if (
+      (query.returning && adapter.supportsReturning) ||
+      (query.output && adapter.supportsOutput)
+    ) {
+      return result.rows as any
+    }
+
+    return [new MergeResult(result.numAffectedRows) as any]
+  }
+
+  /**
+   * Executes the query synchronously and returns the first result or undefined if
+   * the query returned no result.
+   */
+  executeTakeFirstSync(): SimplifySingleResult<O> {
+    const [result] = this.executeSync()
+    return result as SimplifySingleResult<O>
+  }
+
+  /**
+   * Executes the query synchronously and returns the first result or throws if
+   * the query returned no result.
+   *
+   * By default an instance of {@link NoResultError} is thrown, but you can
+   * provide a custom error class, or callback as the only argument to throw a different
+   * error.
+   */
+  executeTakeFirstOrThrowSync(
+    errorConstructor:
+      | NoResultErrorConstructor
+      | ((node: QueryNode) => Error) = NoResultError,
+  ): SimplifyResult<O> {
+    const result = this.executeTakeFirstSync()
+
+    if (result === undefined) {
+      const error = isNoResultErrorConstructor(errorConstructor)
+        ? new errorConstructor(this.toOperationNode())
+        : errorConstructor(this.toOperationNode())
+
+      throw error
+    }
+
+    return result as SimplifyResult<O>
+  }
 }
 
 export class MatchedThenableMergeQueryBuilder<

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -1203,6 +1203,69 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
     return result as SimplifyResult<O>
   }
 
+  /**
+   * Executes the query synchronously and returns an array of rows.
+   *
+   * Also see the {@link executeTakeFirstSync} and {@link executeTakeFirstOrThrowSync} methods.
+   */
+  executeSync(): SimplifyResult<O>[] {
+    const compiledQuery = this.compile()
+
+    const result = this.#props.executor.executeQuerySync<O>(compiledQuery)
+
+    const { adapter } = this.#props.executor
+    const query = compiledQuery.query as UpdateQueryNode
+
+    if (
+      (query.returning && adapter.supportsReturning) ||
+      (query.output && adapter.supportsOutput)
+    ) {
+      return result.rows as any
+    }
+
+    return [
+      new UpdateResult(
+        result.numAffectedRows ?? BigInt(0),
+        result.numChangedRows,
+      ) as any,
+    ]
+  }
+
+  /**
+   * Executes the query synchronously and returns the first result or undefined if
+   * the query returned no result.
+   */
+  executeTakeFirstSync(): SimplifySingleResult<O> {
+    const [result] = this.executeSync()
+    return result as SimplifySingleResult<O>
+  }
+
+  /**
+   * Executes the query synchronously and returns the first result or throws if
+   * the query returned no result.
+   *
+   * By default an instance of {@link NoResultError} is thrown, but you can
+   * provide a custom error class, or callback as the only argument to throw a different
+   * error.
+   */
+  executeTakeFirstOrThrowSync(
+    errorConstructor:
+      | NoResultErrorConstructor
+      | ((node: QueryNode) => Error) = NoResultError,
+  ): SimplifyResult<O> {
+    const result = this.executeTakeFirstSync()
+
+    if (result === undefined) {
+      const error = isNoResultErrorConstructor(errorConstructor)
+        ? new errorConstructor(this.toOperationNode())
+        : errorConstructor(this.toOperationNode())
+
+      throw error
+    }
+
+    return result as SimplifyResult<O>
+  }
+
   async *stream(chunkSize: number = 100): AsyncIterableIterator<O> {
     const compiledQuery = this.compile()
 

--- a/src/query-executor/default-query-executor.ts
+++ b/src/query-executor/default-query-executor.ts
@@ -42,6 +42,16 @@ export class DefaultQueryExecutor extends QueryExecutorBase {
     return this.#connectionProvider.provideConnection(consumer)
   }
 
+  provideConnectionSync<T>(consumer: (connection: DatabaseConnection) => T): T {
+    if (!this.#connectionProvider.provideConnectionSync) {
+      throw new Error(
+        'The current dialect does not support synchronous execution.',
+      )
+    }
+
+    return this.#connectionProvider.provideConnectionSync(consumer)
+  }
+
   withPlugins(plugins: ReadonlyArray<KyselyPlugin>): DefaultQueryExecutor {
     return new DefaultQueryExecutor(
       this.#compiler,

--- a/src/query-executor/noop-query-executor.ts
+++ b/src/query-executor/noop-query-executor.ts
@@ -21,6 +21,10 @@ export class NoopQueryExecutor extends QueryExecutorBase {
     throw new Error('this query cannot be executed')
   }
 
+  provideConnectionSync<T>(): T {
+    throw new Error('this query cannot be executed')
+  }
+
   withConnectionProvider(): NoopQueryExecutor {
     throw new Error('this query cannot have a connection provider')
   }

--- a/src/query-executor/query-executor.ts
+++ b/src/query-executor/query-executor.ts
@@ -47,6 +47,12 @@ export interface QueryExecutor extends ConnectionProvider {
   executeQuery<R>(compiledQuery: CompiledQuery<R>): Promise<QueryResult<R>>
 
   /**
+   * Executes a compiled query synchronously and runs the result through all
+   * plugins' `transformResultSync` method.
+   */
+  executeQuerySync<R>(compiledQuery: CompiledQuery<R>): QueryResult<R>
+
+  /**
    * Executes a compiled query and runs the result through all plugins'
    * `transformResult` method. Results are streamead instead of loaded
    * at once.

--- a/src/raw-builder/raw-builder.ts
+++ b/src/raw-builder/raw-builder.ts
@@ -137,6 +137,19 @@ export interface RawBuilder<O> extends AliasableExpression<O> {
    */
   execute(executorProvider: QueryExecutorProvider): Promise<QueryResult<O>>
 
+  /**
+   * Executes the raw query synchronously.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * import { sql } from 'kysely'
+   *
+   * const result = sql`select * from ${sql.table('person')}`.executeSync(db)
+   * ```
+   */
+  executeSync(executorProvider: QueryExecutorProvider): QueryResult<O>
+
   toOperationNode(): RawNode
 }
 
@@ -191,6 +204,12 @@ class RawBuilderImpl<O> implements RawBuilder<O> {
     const executor = this.#getExecutor(executorProvider)
 
     return executor.executeQuery<O>(this.#compile(executor))
+  }
+
+  executeSync(executorProvider: QueryExecutorProvider): QueryResult<O> {
+    const executor = this.#getExecutor(executorProvider)
+
+    return executor.executeQuerySync<O>(this.#compile(executor))
   }
 
   #getExecutor(executorProvider?: QueryExecutorProvider): QueryExecutor {

--- a/src/util/sync-not-supported-error.ts
+++ b/src/util/sync-not-supported-error.ts
@@ -1,0 +1,22 @@
+export class SyncNotSupportedError extends Error {
+  constructor() {
+    super(
+      'Synchronous execution is not supported by the current dialect. ' +
+        'Only SQLite currently supports sync execution.',
+    )
+    this.name = 'SyncNotSupportedError'
+  }
+}
+
+export class PluginSyncNotSupportedError extends Error {
+  readonly pluginName: string
+
+  constructor(pluginName: string) {
+    super(
+      `Plugin '${pluginName}' does not support synchronous execution. ` +
+        'Ensure the plugin implements the transformResultSync method.',
+    )
+    this.name = 'PluginSyncNotSupportedError'
+    this.pluginName = pluginName
+  }
+}

--- a/test/node/src/sync-execution.test.ts
+++ b/test/node/src/sync-execution.test.ts
@@ -1,0 +1,520 @@
+import Database from 'better-sqlite3'
+import {
+  CamelCasePlugin,
+  CompiledQuery,
+  DeleteResult,
+  InsertResult,
+  Kysely,
+  KyselyPlugin,
+  NoResultError,
+  PluginSyncNotSupportedError,
+  QueryNode,
+  sql,
+  SqliteDialect,
+  SyncNotSupportedError,
+  UpdateResult,
+} from '../../../'
+import {
+  clearDatabase,
+  destroyTest,
+  DIALECTS,
+  expect,
+  initTest,
+  insertDefaultDataSet,
+  TestContext,
+} from './test-setup.js'
+
+describe('sqlite: sync execution', () => {
+  let ctx: TestContext
+
+  before(async function () {
+    ctx = await initTest(this, 'sqlite')
+  })
+
+  beforeEach(async () => {
+    await insertDefaultDataSet(ctx)
+  })
+
+  afterEach(async () => {
+    await clearDatabase(ctx)
+  })
+
+  after(async () => {
+    await destroyTest(ctx)
+  })
+
+  describe('SelectQueryBuilder', () => {
+    it('should execute a select query synchronously', () => {
+      const result = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .orderBy('first_name')
+        .executeSync()
+
+      expect(result).to.have.length(3)
+      expect(result[0].first_name).to.equal('Arnold')
+      expect(result[1].first_name).to.equal('Jennifer')
+      expect(result[2].first_name).to.equal('Sylvester')
+    })
+
+    it('should return first result with executeTakeFirstSync', () => {
+      const result = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .orderBy('first_name')
+        .executeTakeFirstSync()
+
+      expect(result).to.not.be.undefined
+      expect(result!.first_name).to.equal('Arnold')
+    })
+
+    it('should return undefined from executeTakeFirstSync when no result', () => {
+      const result = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .where('id', '=', 99999999)
+        .executeTakeFirstSync()
+
+      expect(result).to.be.undefined
+    })
+
+    it('should return first result with executeTakeFirstOrThrowSync', () => {
+      const result = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .orderBy('first_name')
+        .executeTakeFirstOrThrowSync()
+
+      expect(result.first_name).to.equal('Arnold')
+    })
+
+    it('should throw NoResultError from executeTakeFirstOrThrowSync when no result', () => {
+      try {
+        ctx.db
+          .selectFrom('person')
+          .selectAll()
+          .where('id', '=', 99999999)
+          .executeTakeFirstOrThrowSync()
+
+        throw new Error('should not get here')
+      } catch (error) {
+        expect(error instanceof NoResultError).to.equal(true)
+      }
+    })
+
+    it('should throw custom error constructor from executeTakeFirstOrThrowSync', () => {
+      class MyNotFoundError extends Error {
+        node: QueryNode
+
+        constructor(node: QueryNode) {
+          super('custom error')
+          this.node = node
+        }
+      }
+
+      try {
+        ctx.db
+          .selectFrom('person')
+          .selectAll()
+          .where('id', '=', 99999999)
+          .executeTakeFirstOrThrowSync(MyNotFoundError)
+
+        throw new Error('should not get here')
+      } catch (error) {
+        expect(error instanceof MyNotFoundError).to.equal(true)
+
+        if (error instanceof MyNotFoundError) {
+          expect(error.node.kind).to.equal('SelectQueryNode')
+        }
+      }
+    })
+
+    it('should throw custom error from function in executeTakeFirstOrThrowSync', () => {
+      const message = 'my custom error'
+      const customError = new Error(message)
+
+      try {
+        ctx.db
+          .selectFrom('person')
+          .selectAll()
+          .where('id', '=', 99999999)
+          .executeTakeFirstOrThrowSync(() => customError)
+
+        throw new Error('should not get here')
+      } catch (error: any) {
+        expect(error.message).to.equal(message)
+      }
+    })
+  })
+
+  describe('InsertQueryBuilder', () => {
+    it('should execute an insert query synchronously', () => {
+      const result = ctx.db
+        .insertInto('person')
+        .values({
+          first_name: 'New',
+          last_name: 'Person',
+          gender: 'other',
+        })
+        .executeTakeFirstSync()
+
+      expect(result).to.be.instanceOf(InsertResult)
+      expect(result!.insertId).to.be.a('bigint')
+    })
+  })
+
+  describe('UpdateQueryBuilder', () => {
+    it('should execute an update query synchronously', () => {
+      const result = ctx.db
+        .updateTable('person')
+        .set({ last_name: 'Updated' })
+        .where('first_name', '=', 'Jennifer')
+        .executeTakeFirstSync()
+
+      expect(result).to.be.instanceOf(UpdateResult)
+      expect(result!.numUpdatedRows).to.equal(1n)
+    })
+  })
+
+  describe('DeleteQueryBuilder', () => {
+    it('should execute a delete query synchronously', () => {
+      const result = ctx.db
+        .deleteFrom('pet')
+        .where('name', '=', 'Catto')
+        .executeTakeFirstSync()
+
+      expect(result).to.be.instanceOf(DeleteResult)
+      expect(result!.numDeletedRows).to.be.a('bigint')
+    })
+  })
+
+  describe('Kysely.executeQuerySync', () => {
+    it('should execute a compiled query synchronously', () => {
+      const compiledQuery = CompiledQuery.raw('select 1 as count')
+
+      const result = ctx.db.executeQuerySync(compiledQuery)
+
+      expect(result.rows).to.have.length(1)
+      expect(result.rows[0]).to.deep.equal({ count: 1 })
+    })
+
+    it('should compile and execute a query builder synchronously', () => {
+      const query = ctx.db.selectFrom('person').selectAll()
+
+      const result = ctx.db.executeQuerySync(query)
+
+      expect(result.rows).to.have.length(3)
+    })
+  })
+
+  describe('InsertQueryBuilder with returning', () => {
+    it('should execute insert with returning synchronously', () => {
+      const result = ctx.db
+        .insertInto('person')
+        .values({ first_name: 'Test', last_name: 'Person', gender: 'other' })
+        .returning(['id', 'first_name'])
+        .executeSync()
+
+      expect(result).to.have.length(1)
+      expect(result[0].first_name).to.equal('Test')
+      expect(result[0].id).to.be.a('number')
+    })
+  })
+
+  describe('UpdateQueryBuilder with returning', () => {
+    it('should execute update with returning synchronously', () => {
+      const result = ctx.db
+        .updateTable('person')
+        .set({ last_name: 'Updated' })
+        .where('first_name', '=', 'Jennifer')
+        .returning(['first_name', 'last_name'])
+        .executeSync()
+
+      expect(result).to.have.length(1)
+      expect(result[0].last_name).to.equal('Updated')
+    })
+  })
+
+  describe('DeleteQueryBuilder with returning', () => {
+    it('should execute delete with returning synchronously', () => {
+      const result = ctx.db
+        .deleteFrom('pet')
+        .where('name', '=', 'Catto')
+        .returning('name')
+        .executeSync()
+
+      expect(result).to.have.length(1)
+      expect(result[0].name).to.equal('Catto')
+    })
+  })
+
+  describe('RawBuilder', () => {
+    it('should execute raw query synchronously', () => {
+      const result = sql`select first_name from person where first_name = ${'Jennifer'}`.executeSync(
+        ctx.db,
+      )
+
+      expect(result.rows).to.have.length(1)
+    })
+  })
+
+  describe('plugin integration', () => {
+    it('should throw PluginSyncNotSupportedError when plugin lacks transformResultSync', () => {
+      const badPlugin: KyselyPlugin = {
+        transformQuery: (args) => args.node,
+        transformResult: async (args) => args.result,
+      }
+
+      const dbWithBadPlugin = ctx.db.withPlugin(badPlugin)
+
+      try {
+        dbWithBadPlugin.selectFrom('person').selectAll().executeSync()
+        throw new Error('should not get here')
+      } catch (error) {
+        expect(error instanceof PluginSyncNotSupportedError).to.equal(true)
+      }
+    })
+
+    it('should work with CamelCasePlugin synchronously', async () => {
+      const dbWithCamelCase = new Kysely<any>({
+        dialect: new SqliteDialect({
+          database: new Database(':memory:'),
+        }),
+        plugins: [new CamelCasePlugin()],
+      })
+
+      await sql`CREATE TABLE test_table (first_name TEXT)`.execute(
+        dbWithCamelCase,
+      )
+      await sql`INSERT INTO test_table VALUES ('Test')`.execute(dbWithCamelCase)
+
+      const result = dbWithCamelCase.executeQuerySync<{ firstName: string }>(
+        CompiledQuery.raw('SELECT first_name FROM test_table'),
+      )
+
+      expect(result.rows[0].firstName).to.equal('Test')
+
+      await dbWithCamelCase.destroy()
+    })
+  })
+
+  describe('synchronous initialization', () => {
+    it('should auto-initialize when executeSync is called first', async () => {
+      const freshDb = new Kysely<any>({
+        dialect: new SqliteDialect({
+          database: new Database(':memory:'),
+        }),
+      })
+
+      try {
+        freshDb.executeQuerySync(
+          CompiledQuery.raw('CREATE TABLE test (id INTEGER PRIMARY KEY)'),
+        )
+        freshDb.executeQuerySync(CompiledQuery.raw('INSERT INTO test VALUES (1)'))
+
+        const result = freshDb.executeQuerySync<{ id: number }>(
+          CompiledQuery.raw('SELECT * FROM test'),
+        )
+
+        expect(result.rows).to.have.length(1)
+        expect(result.rows[0].id).to.equal(1)
+      } finally {
+        await freshDb.destroy()
+      }
+    })
+
+    it('should throw when database is provided as factory function', async () => {
+      const dbWithFactory = new Kysely<any>({
+        dialect: new SqliteDialect({
+          database: async () => new Database(':memory:'),
+        }),
+      })
+
+      try {
+        dbWithFactory.selectFrom('person').selectAll().executeSync()
+        throw new Error('should not get here')
+      } catch (error: any) {
+        expect(error.message).to.include('factory function')
+      } finally {
+        await dbWithFactory.destroy()
+      }
+    })
+
+    it('should throw when onCreateConnection hook is provided', async () => {
+      const dbWithHook = new Kysely<any>({
+        dialect: new SqliteDialect({
+          database: new Database(':memory:'),
+          onCreateConnection: async () => {},
+        }),
+      })
+
+      try {
+        dbWithHook.selectFrom('person').selectAll().executeSync()
+        throw new Error('should not get here')
+      } catch (error: any) {
+        expect(error.message).to.include('onCreateConnection')
+      } finally {
+        await dbWithHook.destroy()
+      }
+    })
+  })
+
+  describe('sync execution in transactions', () => {
+    it('should execute sync select within a transaction', async () => {
+      await ctx.db.transaction().execute(async (trx) => {
+        const result = trx
+          .selectFrom('person')
+          .selectAll()
+          .orderBy('first_name')
+          .executeSync()
+
+        expect(result).to.have.length(3)
+        expect(result[0].first_name).to.equal('Arnold')
+      })
+    })
+
+    it('should execute sync insert within a transaction', async () => {
+      await ctx.db.transaction().execute(async (trx) => {
+        const result = trx
+          .insertInto('person')
+          .values({ first_name: 'Sync', last_name: 'Test', gender: 'other' })
+          .returning('first_name')
+          .executeTakeFirstSync()
+
+        expect(result).to.not.be.undefined
+        expect(result!.first_name).to.equal('Sync')
+      })
+
+      // Verify the insert was committed
+      const person = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .where('first_name', '=', 'Sync')
+        .executeTakeFirstSync()
+
+      expect(person).to.not.be.undefined
+      expect(person!.first_name).to.equal('Sync')
+    })
+
+    it('should rollback sync changes on transaction error', async () => {
+      try {
+        await ctx.db.transaction().execute(async (trx) => {
+          trx
+            .insertInto('person')
+            .values({ first_name: 'Rollback', last_name: 'Test', gender: 'other' })
+            .executeTakeFirstSync()
+
+          throw new Error('force rollback')
+        })
+      } catch {
+        // Expected
+      }
+
+      // Verify the insert was rolled back
+      const person = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .where('first_name', '=', 'Rollback')
+        .executeTakeFirstSync()
+
+      expect(person).to.be.undefined
+    })
+
+    it('should work with controlled transactions', async () => {
+      const trx = await ctx.db.startTransaction().execute()
+
+      try {
+        const result = trx
+          .selectFrom('person')
+          .selectAll()
+          .orderBy('first_name')
+          .executeSync()
+
+        expect(result).to.have.length(3)
+
+        trx
+          .insertInto('person')
+          .values({ first_name: 'Controlled', last_name: 'Sync', gender: 'other' })
+          .executeTakeFirstSync()
+
+        await trx.commit().execute()
+      } catch {
+        await trx.rollback().execute()
+        throw new Error('should not get here')
+      }
+
+      // Verify the insert was committed
+      const person = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .where('first_name', '=', 'Controlled')
+        .executeTakeFirstSync()
+
+      expect(person).to.not.be.undefined
+    })
+
+    it('should execute sync update within a transaction', async () => {
+      await ctx.db.transaction().execute(async (trx) => {
+        const result = trx
+          .updateTable('person')
+          .set({ last_name: 'TransactionUpdated' })
+          .where('first_name', '=', 'Jennifer')
+          .executeTakeFirstSync()
+
+        expect(result!.numUpdatedRows).to.equal(1n)
+      })
+
+      // Verify the update was committed
+      const person = ctx.db
+        .selectFrom('person')
+        .selectAll()
+        .where('first_name', '=', 'Jennifer')
+        .executeTakeFirstSync()
+
+      expect(person!.last_name).to.equal('TransactionUpdated')
+    })
+
+    it('should execute sync delete within a transaction', async () => {
+      await ctx.db.transaction().execute(async (trx) => {
+        const result = trx
+          .deleteFrom('pet')
+          .where('name', '=', 'Catto')
+          .executeTakeFirstSync()
+
+        expect(result!.numDeletedRows).to.be.a('bigint')
+      })
+
+      // Verify the delete was committed
+      const pet = ctx.db
+        .selectFrom('pet')
+        .selectAll()
+        .where('name', '=', 'Catto')
+        .executeTakeFirstSync()
+
+      expect(pet).to.be.undefined
+    })
+  })
+})
+
+for (const dialect of DIALECTS.filter((d) => d !== 'sqlite')) {
+  describe(`${dialect}: sync execution errors`, () => {
+    let ctx: TestContext
+
+    before(async function () {
+      ctx = await initTest(this, dialect)
+    })
+
+    after(async () => {
+      await destroyTest(ctx)
+    })
+
+    it('should throw SyncNotSupportedError', () => {
+      try {
+        ctx.db.selectFrom('person').selectAll().executeSync()
+        throw new Error('should not get here')
+      } catch (error) {
+        expect(error instanceof SyncNotSupportedError).to.equal(true)
+      }
+    })
+  })
+}


### PR DESCRIPTION
closes #1556

this PR adds sync execution methods for dialects that support it (SQLite with better-sqlite3).

- `executeSync()`, `executeTakeFirstSync()`, `executeTakeFirstOrThrowSync()` on all query builders
- `executeQuerySync()` on Kysely class
- `executeSync()` on RawBuilder
- `supportsSyncExecution` flag on DialectAdapter
- `transformResultSync` on KyselyPlugin
- `SyncNotSupportedError` and `PluginSyncNotSupportedError` errors

this duplicates a lot of methods which isn't ideal, so i'm open to suggestions on how to reduce that
