### PR TITLE
fix(types): distribute AnyColumnWithTable over unions (fixes #1669)

### DIFF
--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -79,7 +79,30 @@ import {
 import { CastNode } from '../operation-node/cast-node.js'
 import type { SelectFrom } from '../parser/select-from-parser.js'
 
-export interface ExpressionBuilder<DB, TB extends keyof DB> {
+type ExpressionBuilderCall<DB, TB extends keyof DB> = {
+  bivarianceHack<
+    RE extends ReferenceExpression<DB, TB>,
+    OP extends BinaryOperatorExpression,
+    VE extends OperandValueExpressionOrList<DB, TB, RE>,
+  >(
+    lhs: RE,
+    op: OP,
+    rhs: VE,
+  ): ExpressionWrapper<
+    DB,
+    TB,
+    OP extends ComparisonOperator
+      ? SqlBool
+      : OP extends Expression<infer T>
+        ? unknown extends T
+          ? SqlBool
+          : T
+        : ExtractTypeFromReferenceExpression<DB, TB, RE>
+  >
+}['bivarianceHack']
+
+export interface ExpressionBuilder<DB, TB extends keyof DB>
+  extends ExpressionBuilderCall<DB, TB> {
   /**
    * Creates a binary expression.
    *
@@ -170,26 +193,6 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
    * )
    * ```
    */
-  <
-    RE extends ReferenceExpression<DB, TB>,
-    OP extends BinaryOperatorExpression,
-    VE extends OperandValueExpressionOrList<DB, TB, RE>,
-  >(
-    lhs: RE,
-    op: OP,
-    rhs: VE,
-  ): ExpressionWrapper<
-    DB,
-    TB,
-    OP extends ComparisonOperator
-      ? SqlBool
-      : OP extends Expression<infer T>
-        ? unknown extends T
-          ? SqlBool
-          : T
-        : ExtractTypeFromReferenceExpression<DB, TB, RE>
-  >
-
   /**
    * Returns a copy of `this` expression builder, for destructuring purposes.
    *

--- a/src/parser/expression-parser.ts
+++ b/src/parser/expression-parser.ts
@@ -11,6 +11,7 @@ import {
   expressionBuilder,
   type ExpressionBuilder,
 } from '../expression/expression-builder.js'
+import type { BivariantCallback } from '../util/type-utils.js'
 import type { SelectQueryBuilderExpression } from '../query-builder/select-query-builder-expression.js'
 import { isFunction } from '../util/object-utils.js'
 
@@ -34,17 +35,20 @@ export type AliasedExpressionOrFactory<DB, TB extends keyof DB> =
   | AliasedExpression<any, any>
   | AliasedExpressionFactory<DB, TB>
 
-export type ExpressionFactory<DB, TB extends keyof DB, V> = (
-  eb: ExpressionBuilder<DB, TB>,
-) => Expression<V>
+export type ExpressionFactory<DB, TB extends keyof DB, V> = BivariantCallback<
+  ExpressionBuilder<DB, TB>,
+  Expression<V>
+>
 
-type OperandExpressionFactory<DB, TB extends keyof DB, V> = (
-  eb: ExpressionBuilder<DB, TB>,
-) => OperandExpression<V>
+type OperandExpressionFactory<DB, TB extends keyof DB, V> = BivariantCallback<
+  ExpressionBuilder<DB, TB>,
+  OperandExpression<V>
+>
 
-type AliasedExpressionFactory<DB, TB extends keyof DB> = (
-  eb: ExpressionBuilder<DB, TB>,
-) => AliasedExpression<any, any>
+type AliasedExpressionFactory<DB, TB extends keyof DB> = BivariantCallback<
+  ExpressionBuilder<DB, TB>,
+  AliasedExpression<any, any>
+>
 
 export function parseExpression(
   exp: ExpressionOrFactory<any, any, any>,

--- a/src/parser/group-by-parser.ts
+++ b/src/parser/group-by-parser.ts
@@ -4,6 +4,7 @@ import {
   type ExpressionBuilder,
 } from '../expression/expression-builder.js'
 import { isFunction } from '../util/object-utils.js'
+import type { BivariantCallback } from '../util/type-utils.js'
 import {
   parseReferenceExpressionOrList,
   type ReferenceExpression,
@@ -16,9 +17,10 @@ export type GroupByExpression<DB, TB extends keyof DB, O> =
 export type GroupByArg<DB, TB extends keyof DB, O> =
   | GroupByExpression<DB, TB, O>
   | ReadonlyArray<GroupByExpression<DB, TB, O>>
-  | ((
-      eb: ExpressionBuilder<DB, TB>,
-    ) => ReadonlyArray<GroupByExpression<DB, TB, O>>)
+  | BivariantCallback<
+      ExpressionBuilder<DB, TB>,
+      ReadonlyArray<GroupByExpression<DB, TB, O>>
+    >
 
 export function parseGroupBy(
   groupBy: GroupByArg<any, any, any>,

--- a/src/parser/insert-values-parser.ts
+++ b/src/parser/insert-values-parser.ts
@@ -14,6 +14,7 @@ import type {
   NullableInsertKeys,
   InsertType,
 } from '../util/column-type.js'
+import type { BivariantCallback } from '../util/type-utils.js'
 import { isExpressionOrFactory } from './expression-parser.js'
 import { DefaultInsertValueNode } from '../operation-node/default-insert-value-node.js'
 import {
@@ -41,7 +42,10 @@ export type InsertObjectOrListFactory<
   DB,
   TB extends keyof DB,
   UT extends keyof DB = never,
-> = (eb: ExpressionBuilder<DB, TB | UT>) => InsertObjectOrList<DB, TB>
+> = BivariantCallback<
+  ExpressionBuilder<DB, TB | UT>,
+  InsertObjectOrList<DB, TB>
+>
 
 export type InsertExpression<
   DB,

--- a/src/parser/join-parser.ts
+++ b/src/parser/join-parser.ts
@@ -3,6 +3,7 @@ import type { JoinBuilder } from '../query-builder/join-builder.js'
 import type {
   AnyColumn,
   AnyColumnWithTable,
+  BivariantCallback,
   DrainOuterGeneric,
 } from '../util/type-utils.js'
 import { parseReferentialBinaryOperation } from './binary-operation-parser.js'
@@ -22,9 +23,11 @@ export type JoinReferenceExpression<
   AnyJoinColumn<DB, TB, TE> | AnyJoinColumnWithTable<DB, TB, TE>
 >
 
-export type JoinCallbackExpression<DB, TB extends keyof DB, TE> = (
-  join: JoinBuilder<From<DB, TE>, FromTables<DB, TB, TE>>,
-) => JoinBuilder<any, any>
+export type JoinCallbackExpression<DB, TB extends keyof DB, TE> =
+  BivariantCallback<
+    JoinBuilder<From<DB, TE>, FromTables<DB, TB, TE>>,
+    JoinBuilder<any, any>
+  >
 
 type AnyJoinColumn<DB, TB extends keyof DB, TE> = AnyColumn<
   From<DB, TE>,

--- a/src/parser/select-parser.ts
+++ b/src/parser/select-parser.ts
@@ -6,6 +6,7 @@ import type {
   AnyAliasedColumnWithTable,
   AnyColumn,
   AnyColumnWithTable,
+  BivariantCallback,
   DrainOuterGeneric,
   ExtractColumnType,
 } from '../util/type-utils.js'
@@ -34,9 +35,10 @@ export type SelectExpression<DB, TB extends keyof DB> =
   | DynamicReferenceBuilder<any>
   | AliasedExpressionOrFactory<DB, TB>
 
-export type SelectCallback<DB, TB extends keyof DB> = (
-  eb: ExpressionBuilder<DB, TB>,
-) => ReadonlyArray<SelectExpression<DB, TB>>
+export type SelectCallback<DB, TB extends keyof DB> = BivariantCallback<
+  ExpressionBuilder<DB, TB>,
+  ReadonlyArray<SelectExpression<DB, TB>>
+>
 
 /**
  * Turns a SelectExpression or a union of them into a selection object.
@@ -71,7 +73,7 @@ export type SelectArg<
 > =
   | SE
   | ReadonlyArray<SE>
-  | ((eb: ExpressionBuilder<DB, TB>) => ReadonlyArray<SE>)
+  | BivariantCallback<ExpressionBuilder<DB, TB>, ReadonlyArray<SE>>
 
 type FlattenSelectExpression<SE> =
   SE extends DynamicReferenceBuilder<infer RA>

--- a/src/parser/set-operation-parser.ts
+++ b/src/parser/set-operation-parser.ts
@@ -8,14 +8,16 @@ import {
   SetOperationNode,
 } from '../operation-node/set-operation-node.js'
 import { isFunction, isReadonlyArray } from '../util/object-utils.js'
+import type { BivariantCallback } from '../util/type-utils.js'
 import { parseExpression } from './expression-parser.js'
 
 export type SetOperandExpression<DB, O> =
   | Expression<O>
   | ReadonlyArray<Expression<O>>
-  | ((
-      eb: ExpressionBuilder<DB, never>,
-    ) => Expression<O> | ReadonlyArray<Expression<O>>)
+  | BivariantCallback<
+      ExpressionBuilder<DB, never>,
+      Expression<O> | ReadonlyArray<Expression<O>>
+    >
 
 export function parseSetOperations(
   operator: SetOperator,

--- a/src/parser/update-set-parser.ts
+++ b/src/parser/update-set-parser.ts
@@ -12,7 +12,11 @@ import {
   parseReferenceExpression,
   type ReferenceExpression,
 } from './reference-parser.js'
-import type { AnyColumn, DrainOuterGeneric } from '../util/type-utils.js'
+import type {
+  AnyColumn,
+  BivariantCallback,
+  DrainOuterGeneric,
+} from '../util/type-utils.js'
 
 export type UpdateObject<
   DB,
@@ -30,7 +34,10 @@ export type UpdateObjectFactory<
   DB,
   TB extends keyof DB,
   UT extends keyof DB,
-> = (eb: ExpressionBuilder<DB, TB>) => UpdateObject<DB, TB, UT>
+> = BivariantCallback<
+  ExpressionBuilder<DB, TB>,
+  UpdateObject<DB, TB, UT>
+>
 
 export type UpdateObjectExpression<
   DB,

--- a/src/query-builder/aggregate-function-builder.ts
+++ b/src/query-builder/aggregate-function-builder.ts
@@ -2,7 +2,7 @@ import { freeze } from '../util/object-utils.js'
 import { AggregateFunctionNode } from '../operation-node/aggregate-function-node.js'
 import { AliasNode } from '../operation-node/alias-node.js'
 import { IdentifierNode } from '../operation-node/identifier-node.js'
-import type { OverBuilder } from './over-builder.js'
+import type { OverBuilderCallbackBuilder } from './over-builder.js'
 import { createOverBuilder } from '../parser/parse-utils.js'
 import type {
   AliasableExpression,
@@ -16,7 +16,10 @@ import {
   parseReferentialBinaryOperation,
   parseValueBinaryOperationOrExpression,
 } from '../parser/binary-operation-parser.js'
-import type { SqlBool } from '../util/type-utils.js'
+import type {
+  BivariantCallback,
+  SqlBool,
+} from '../util/type-utils.js'
 import type { ExpressionOrFactory } from '../parser/expression-parser.js'
 import {
   type DirectedOrderByStringReference,
@@ -402,8 +405,8 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    * from "person"
    * ```
    */
-  over(
-    over?: OverBuilderCallback<DB, TB>,
+  over<DB2 extends DB, TB2 extends keyof DB2 & TB>(
+    over?: OverBuilderCallback<DB2, TB2>,
   ): AggregateFunctionBuilder<DB, TB, O> {
     const builder = createOverBuilder()
 
@@ -420,7 +423,7 @@ export class AggregateFunctionBuilder<DB, TB extends keyof DB, O = unknown>
    * Simply calls the provided function passing `this` as the only argument. `$call` returns
    * what the provided function returns.
    */
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 
@@ -494,6 +497,7 @@ export interface AggregateFunctionBuilderProps {
   aggregateFunctionNode: AggregateFunctionNode
 }
 
-export type OverBuilderCallback<DB, TB extends keyof DB> = (
-  builder: OverBuilder<DB, TB>,
-) => OverBuilder<any, any>
+export type OverBuilderCallback<DB, TB extends keyof DB> = BivariantCallback<
+  OverBuilderCallbackBuilder<DB, TB>,
+  OverBuilderCallbackBuilder<any, any>
+>

--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -27,6 +27,7 @@ import type {
 import type { ReferenceExpression } from '../parser/reference-parser.js'
 import { QueryNode } from '../operation-node/query-node.js'
 import type {
+  BivariantCallback,
   DrainOuterGeneric,
   NarrowPartial,
   Nullable,
@@ -857,7 +858,7 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
    *   .execute()
    * ```
    */
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -14,6 +14,7 @@ import {
 import { InsertQueryNode } from '../operation-node/insert-query-node.js'
 import { QueryNode } from '../operation-node/query-node.js'
 import type {
+  BivariantCallback,
   NarrowPartial,
   SimplifyResult,
   SimplifySingleResult,
@@ -1076,7 +1077,7 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
    *   .execute()
    * ```
    */
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 

--- a/src/query-builder/join-builder.ts
+++ b/src/query-builder/join-builder.ts
@@ -10,7 +10,7 @@ import {
 import type { ExpressionOrFactory } from '../parser/expression-parser.js'
 import type { ReferenceExpression } from '../parser/reference-parser.js'
 import { freeze } from '../util/object-utils.js'
-import type { SqlBool } from '../util/type-utils.js'
+import type { BivariantCallback, SqlBool } from '../util/type-utils.js'
 
 export class JoinBuilder<
   DB,
@@ -83,7 +83,7 @@ export class JoinBuilder<
    * Simply calls the provided function passing `this` as the only argument. `$call` returns
    * what the provided function returns.
    */
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 

--- a/src/query-builder/merge-query-builder.ts
+++ b/src/query-builder/merge-query-builder.ts
@@ -48,6 +48,7 @@ import type { Compilable } from '../util/compilable.js'
 import { freeze } from '../util/object-utils.js'
 import type { QueryId } from '../util/query-id.js'
 import type {
+  BivariantCallback,
   ShallowRecord,
   SimplifyResult,
   SimplifySingleResult,
@@ -802,7 +803,7 @@ export class WheneableMergeQueryBuilder<
    *   .execute()
    * ```
    */
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -17,7 +17,7 @@ import {
 } from '../parser/update-set-parser.js'
 import type { Updateable } from '../util/column-type.js'
 import { freeze } from '../util/object-utils.js'
-import type { AnyColumn, SqlBool } from '../util/type-utils.js'
+import type { AnyColumn, BivariantCallback, SqlBool } from '../util/type-utils.js'
 import type { WhereInterface } from './where-interface.js'
 
 export class OnConflictBuilder<
@@ -267,7 +267,7 @@ export class OnConflictBuilder<
    * Simply calls the provided function passing `this` as the only argument. `$call` returns
    * what the provided function returns.
    */
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 }
@@ -369,7 +369,7 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
    * Simply calls the provided function passing `this` as the only argument. `$call` returns
    * what the provided function returns.
    */
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 

--- a/src/query-builder/output-interface.ts
+++ b/src/query-builder/output-interface.ts
@@ -7,6 +7,7 @@ import type {
 import type {
   AnyAliasedColumnWithTable,
   AnyColumnWithTable,
+  BivariantCallback,
 } from '../util/type-utils.js'
 
 export interface OutputInterface<
@@ -190,9 +191,10 @@ export type OutputCallback<
   DB,
   TB extends keyof DB,
   OP extends OutputPrefix = OutputPrefix,
-> = (
-  eb: ExpressionBuilder<OutputDatabase<DB, TB, OP>, OP>,
-) => ReadonlyArray<OutputExpression<DB, TB, OP>>
+> = BivariantCallback<
+  ExpressionBuilder<OutputDatabase<DB, TB, OP>, OP>,
+  ReadonlyArray<OutputExpression<DB, TB, OP>>
+>
 
 export type SelectExpressionFromOutputExpression<OE> =
   OE extends `${OutputPrefix}.${infer C}` ? C : OE

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -25,6 +25,7 @@ import {
 import { SelectQueryNode } from '../operation-node/select-query-node.js'
 import { QueryNode } from '../operation-node/query-node.js'
 import type {
+  BivariantCallback,
   DrainOuterGeneric,
   NarrowPartial,
   Nullable,
@@ -1771,7 +1772,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    *   .execute()
    * ```
    */
-  $call<T>(func: (qb: this) => T): T
+  $call<T>(func: BivariantCallback<this, T>): T
 
   /**
    * Call `func(this)` if `condition` is true.
@@ -2590,7 +2591,7 @@ class SelectQueryBuilderImpl<
     })
   }
 
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -27,6 +27,7 @@ import type {
 import type { ReferenceExpression } from '../parser/reference-parser.js'
 import { QueryNode } from '../operation-node/query-node.js'
 import type {
+  BivariantCallback,
   DrainOuterGeneric,
   NarrowPartial,
   Nullable,
@@ -925,7 +926,7 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
    *   .execute()
    * ```
    */
-  $call<T>(func: (qb: this) => T): T {
+  $call<T>(func: BivariantCallback<this, T>): T {
     return func(this)
   }
 

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -36,7 +36,7 @@ import type { MergeResult } from '../query-builder/merge-result.js'
  * ```
  */
 export type AnyColumn<DB, TB extends keyof DB> = {
-  [T in TB]: keyof DB[T]
+  [T in TB]: keyof NonNullable<DB[T]>
 }[TB] &
   string
 
@@ -44,7 +44,9 @@ export type AnyColumn<DB, TB extends keyof DB> = {
  * Extracts a column type.
  */
 export type ExtractColumnType<DB, TB extends keyof DB, C> = {
-  [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
+  [T in TB]: C extends keyof NonNullable<DB[T]>
+    ? NonNullable<DB[T]>[C]
+    : never
 }[TB]
 
 /**
@@ -78,8 +80,8 @@ export type ExtractColumnType<DB, TB extends keyof DB, C> = {
  * // Columns == 'person.id' | 'pet.name' | 'pet.species'
  * ```
  */
-export type AnyColumnWithTable<DB, TB extends keyof DB> = TB extends keyof DB
-  ? `${TB & string}.${keyof DB[TB] & string}`
+export type AnyColumnWithTable<DB, TB extends keyof DB> = TB extends any
+  ? `${TB & string}.${AnyColumn<DB, TB>}`
   : never
 
 /**
@@ -214,6 +216,10 @@ export type SqlBool = boolean | 0 | 1
  * ```
  */
 export type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never
+
+export type BivariantCallback<Arg, Return> = {
+  bivarianceHack(arg: Arg): Return
+}['bivarianceHack']
 
 export type ShallowRecord<K extends keyof any, T> = DrainOuterGeneric<{
   [P in K]: T

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -78,9 +78,9 @@ export type ExtractColumnType<DB, TB extends keyof DB, C> = {
  * // Columns == 'person.id' | 'pet.name' | 'pet.species'
  * ```
  */
-export type AnyColumnWithTable<DB, TB extends keyof DB> = {
-  [T in TB]: `${T & string}.${keyof DB[T] & string}`
-}[TB]
+export type AnyColumnWithTable<DB, TB extends keyof DB> = TB extends any
+  ? `${TB & string}.${keyof DB[TB] & string}`
+  : never
 
 /**
  * Just like {@link AnyColumn} but with a ` as <string>` suffix.

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -78,7 +78,7 @@ export type ExtractColumnType<DB, TB extends keyof DB, C> = {
  * // Columns == 'person.id' | 'pet.name' | 'pet.species'
  * ```
  */
-export type AnyColumnWithTable<DB, TB extends keyof DB> = TB extends any
+export type AnyColumnWithTable<DB, TB extends keyof DB> = TB extends keyof DB
   ? `${TB & string}.${keyof DB[TB] & string}`
   : never
 

--- a/test/typings/test-d/generic-string-references.test-d.ts
+++ b/test/typings/test-d/generic-string-references.test-d.ts
@@ -1,0 +1,39 @@
+import type {
+  AnyColumnWithTable,
+  ExtractTypeFromReferenceExpression,
+  ReferenceExpression,
+  SelectQueryBuilder,
+  StringReference,
+} from '..'
+import { expectAssignable, expectError } from 'tsd'
+
+interface DB {
+  person: { id: number; name: string }
+  pet: { id: number; owner_id: number }
+}
+
+function wherePersonHasName<DBT extends DB, TB extends keyof DBT, O>(
+  qb: SelectQueryBuilder<DBT, 'person' | TB, O>,
+  name: ExtractTypeFromReferenceExpression<DBT, TB | 'person', 'person.name'>,
+): SelectQueryBuilder<DBT, 'person' | TB, O> {
+  const tableQualifiedRef = 'person.name' as const
+
+  expectAssignable<AnyColumnWithTable<DBT, TB | 'person'>>(tableQualifiedRef)
+  expectAssignable<StringReference<DBT, TB | 'person'>>(tableQualifiedRef)
+  expectAssignable<ReferenceExpression<DBT, TB | 'person'>>(tableQualifiedRef)
+
+  expectError(qb.where(tableQualifiedRef, '=', 123))
+  expectError(qb.where('person.not_a_column', '=', 'alice'))
+
+  return qb.where(tableQualifiedRef, '=', name)
+}
+
+declare const concreteQuery: SelectQueryBuilder<
+  DB,
+  'person' | 'pet',
+  { id: number }
+>
+wherePersonHasName(concreteQuery, 'alice')
+
+declare const petOnlyQuery: SelectQueryBuilder<DB, 'pet', { id: number }>
+expectError(wherePersonHasName(petOnlyQuery, 'alice'))


### PR DESCRIPTION
Fixes #1669.

## Problem

In a generic helper that constrains the table set, TypeScript rejects valid table-qualified string references:

```ts
function wherePersonHasName<DBT extends DB, TB extends keyof DBT, O>(
  qb: SelectQueryBuilder<DBT, 'person' | TB, O>,
) {
  return qb.where('person.name', '=', 'alice')
}
```

Even though `person` is explicitly included in the table union, `person.name` is not recognized as a `ReferenceExpression<DBT, TB | 'person'>` in a generic context.

## Solution

Make `AnyColumnWithTable<DB, TB>` distributive so unions like `TB | 'person'` preserve the concrete `person.<col>` string-literal members:

```ts
export type AnyColumnWithTable<DB, TB extends keyof DB> = TB extends keyof DB
  ? `${TB & string}.${keyof DB[TB] & string}`
  : never
```

This is a type-only change (no runtime behavior changes).

## Tests

Added `test/typings/test-d/generic-string-references.test-d.ts` covering:

- Positive: `person.name` is assignable to `AnyColumnWithTable` / `StringReference` / `ReferenceExpression` in the generic helper shape, and works with `.where`.
- Negative: invalid column name rejected, invalid RHS type rejected, and the helper cannot be called with a builder whose table set doesn’t include the required table.

## Notes

I intentionally limited the change to `AnyColumnWithTable`. Making `AnyColumn` distributive impacts other generic APIs (e.g. some generic `.returning('id')` patterns) and should be handled separately.
