### PR TITLE
fix: `$narrowType` compilation errors when `composite: true`.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,7 @@ export type {
 export * from './util/infer-result.js'
 export { logOnce } from './util/log-once.js'
 export { createQueryId, type QueryId } from './util/query-id.js'
+export type { KyselyTypeError } from './util/type-error.js'
 
 export type {
   SelectExpression,

--- a/test/composite-ts/index.mts
+++ b/test/composite-ts/index.mts
@@ -7,5 +7,5 @@ interface DB {
 }
 
 export function foo<T extends 'myColumn'>(db: Kysely<DB>, field: T) {
-  return db.selectFrom('MyTable').select(field).execute()
+  return db.selectFrom('MyTable').select(field).$narrowType<{}>().execute()
 }


### PR DESCRIPTION
Hey :wave:

closes #1609.

This PR exports `KyselyTypeError` to resolve `composite: true` related compilation errors when using `$narrowType`.