### PR TITLE
fix: `returning` compilation errors when `composite`.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -244,6 +244,7 @@ export type {
   NumericString,
   ShallowDehydrateObject,
   ShallowDehydrateValue,
+  SimplifyResult,
   StringsWhenDataTypeNotAvailable,
 } from './util/type-utils.js'
 export * from './util/infer-result.js'

--- a/test/composite-ts/index.mts
+++ b/test/composite-ts/index.mts
@@ -1,11 +1,27 @@
-import type { Kysely } from 'kysely'
+import type { Kysely, SelectExpression } from 'kysely'
 
 interface DB {
   MyTable: {
     myColumn: string
+    anotherColumn: number
   }
 }
 
 export function foo<T extends 'myColumn'>(db: Kysely<DB>, field: T) {
-  return db.selectFrom('MyTable').select(field).$narrowType<{}>().execute()
+  return db
+    .selectFrom('MyTable')
+    .select(field) // <------- was missing DrainOuterGeneric & ExtractColumnType
+    .$narrowType<{}>() // <------- was missing KyselyTypeError
+    .execute()
+}
+
+export function bar<T extends keyof DB['MyTable']>(
+  db: Kysely<DB>,
+  columns: T[],
+) {
+  return db
+    .insertInto('MyTable')
+    .values({ myColumn: 'test', anotherColumn: 1 })
+    .returning(columns) // <----- was missing SimplifyResult
+    .execute()
 }


### PR DESCRIPTION
Hey :wave:

This PR resolves compilation errors when using `returning ` in `composite: true` by exporting `SimplifyResult`.