### PR TITLE
fix: `executeTakeFirst` compilation error when composite.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -245,6 +245,7 @@ export type {
   ShallowDehydrateObject,
   ShallowDehydrateValue,
   SimplifyResult,
+  SimplifySingleResult,
   StringsWhenDataTypeNotAvailable,
 } from './util/type-utils.js'
 export * from './util/infer-result.js'

--- a/test/composite-ts/index.mts
+++ b/test/composite-ts/index.mts
@@ -1,4 +1,4 @@
-import type { Kysely, SelectExpression } from 'kysely'
+import type { Kysely } from 'kysely'
 
 interface DB {
   MyTable: {
@@ -12,7 +12,7 @@ export function foo<T extends 'myColumn'>(db: Kysely<DB>, field: T) {
     .selectFrom('MyTable')
     .select(field) // <------- was missing DrainOuterGeneric & ExtractColumnType
     .$narrowType<{}>() // <------- was missing KyselyTypeError
-    .execute()
+    .executeTakeFirst() // <------- was missing SimplifySingleResult
 }
 
 export function bar<T extends keyof DB['MyTable']>(


### PR DESCRIPTION
Hey :wave:

This PR fixes compilation error when using `executeTakeFirst` and `composite: true` is set by exporting `SimplifySingleResult`.