### PR TITLE
fix: `with`/`withRecursive` compilation errors when composite.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -302,3 +302,4 @@ export type {
   ExpressionOrFactory,
 } from './parser/expression-parser.js'
 export type { Collation } from './parser/collate-parser.js'
+export type { QueryCreatorWithCommonTableExpression } from './parser/with-parser.js'

--- a/test/composite-ts/index.mts
+++ b/test/composite-ts/index.mts
@@ -25,3 +25,11 @@ export function bar<T extends keyof DB['MyTable']>(
     .returning(columns) // <----- was missing SimplifyResult
     .execute()
 }
+
+export function fizz(db: Kysely<DB>) {
+  return db.with(
+    // <----- was missing QueryCreatorWithCommonTableExpression
+    'cte',
+    (db) => db.selectFrom('MyTable').selectAll(),
+  )
+}


### PR DESCRIPTION
Hey :wave:

This PR resolves compilation errors when returning the result of `with`/`withRecursive` and `composite: true` by exporting `QueryCreatorWithCommonTableExpression`.