### PR TITLE
feat: support IF EXISTS in DROP COLUMN

### DIFF
--- a/src/dialect/mssql/mssql-query-compiler.ts
+++ b/src/dialect/mssql/mssql-query-compiler.ts
@@ -58,8 +58,9 @@ export class MssqlQueryCompiler extends DefaultQueryCompiler {
 
     if (nodesByKind.DropColumnNode) {
       if (!first) this.append(', ')
-      this.append('drop column ')
+      this.append('drop ')
       this.compileList(nodesByKind.DropColumnNode)
+      first = false
     }
 
     // not really supported by mssql, but for the sake of WYSIWYG.
@@ -80,6 +81,10 @@ export class MssqlQueryCompiler extends DefaultQueryCompiler {
   }
 
   protected override visitDropColumn(node: DropColumnNode): void {
+    this.append('column ')
+    if (node.ifExists) {
+      this.append('if exists ')
+    }
     this.visitNode(node.column)
   }
 

--- a/src/dialect/mssql/mssql-query-compiler.ts
+++ b/src/dialect/mssql/mssql-query-compiler.ts
@@ -52,12 +52,18 @@ export class MssqlQueryCompiler extends DefaultQueryCompiler {
     // multiple of these are not really supported by mssql,
     // but for the sake of WYSIWYG.
     if (nodesByKind.AlterColumnNode) {
-      if (!first) this.append(', ')
+      if (!first) {
+        this.append(', ')
+      }
+
       this.compileList(nodesByKind.AlterColumnNode)
     }
 
     if (nodesByKind.DropColumnNode) {
-      if (!first) this.append(', ')
+      if (!first) {
+        this.append(', ')
+      }
+
       this.append('drop ')
       this.compileList(nodesByKind.DropColumnNode)
       first = false
@@ -65,13 +71,19 @@ export class MssqlQueryCompiler extends DefaultQueryCompiler {
 
     // not really supported by mssql, but for the sake of WYSIWYG.
     if (nodesByKind.ModifyColumnNode) {
-      if (!first) this.append(', ')
+      if (!first) {
+        this.append(', ')
+      }
+
       this.compileList(nodesByKind.ModifyColumnNode)
     }
 
     // not really supported by mssql, but for the sake of WYSIWYG.
     if (nodesByKind.RenameColumnNode) {
-      if (!first) this.append(', ')
+      if (!first) {
+        this.append(', ')
+      }
+
       this.compileList(nodesByKind.RenameColumnNode)
     }
   }
@@ -82,9 +94,11 @@ export class MssqlQueryCompiler extends DefaultQueryCompiler {
 
   protected override visitDropColumn(node: DropColumnNode): void {
     this.append('column ')
+
     if (node.ifExists) {
       this.append('if exists ')
     }
+
     this.visitNode(node.column)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export * from './schema/create-view-builder.js'
 export * from './schema/refresh-materialized-view-builder.js'
 export * from './schema/drop-view-builder.js'
 export * from './schema/alter-column-builder.js'
+export * from './schema/drop-column-builder.js'
 
 export * from './dynamic/dynamic.js'
 export * from './dynamic/dynamic-reference-builder.js'

--- a/src/operation-node/drop-column-node.ts
+++ b/src/operation-node/drop-column-node.ts
@@ -5,11 +5,16 @@ import { ColumnNode } from './column-node.js'
 export interface DropColumnNode extends OperationNode {
   readonly kind: 'DropColumnNode'
   readonly column: ColumnNode
+  readonly ifExists?: boolean
 }
 
 type DropColumnNodeFactory = Readonly<{
   is(node: OperationNode): node is DropColumnNode
   create(column: string): Readonly<DropColumnNode>
+  cloneWith(
+    node: DropColumnNode,
+    props: Omit<Partial<DropColumnNode>, 'kind' | 'column'>,
+  ): Readonly<DropColumnNode>
 }>
 
 /**
@@ -25,6 +30,13 @@ export const DropColumnNode: DropColumnNodeFactory =
       return freeze({
         kind: 'DropColumnNode',
         column: ColumnNode.create(column),
+      })
+    },
+
+    cloneWith(node, props) {
+      return freeze({
+        ...node,
+        ...props,
       })
     },
   })

--- a/src/operation-node/drop-column-node.ts
+++ b/src/operation-node/drop-column-node.ts
@@ -2,6 +2,8 @@ import type { OperationNode } from './operation-node.js'
 import { freeze } from '../util/object-utils.js'
 import { ColumnNode } from './column-node.js'
 
+export type DropColumnNodeProps = Omit<DropColumnNode, 'kind' | 'column'>
+
 export interface DropColumnNode extends OperationNode {
   readonly kind: 'DropColumnNode'
   readonly column: ColumnNode
@@ -13,7 +15,7 @@ type DropColumnNodeFactory = Readonly<{
   create(column: string): Readonly<DropColumnNode>
   cloneWith(
     node: DropColumnNode,
-    props: Omit<Partial<DropColumnNode>, 'kind' | 'column'>,
+    props: DropColumnNodeProps,
   ): Readonly<DropColumnNode>
 }>
 

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -865,6 +865,7 @@ export class OperationNodeTransformer {
     return {
       kind: 'DropColumnNode',
       column: this.transformNode(node.column, queryId),
+      ifExists: node.ifExists,
     } satisfies AllProps<DropColumnNode>
   }
 

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1232,9 +1232,13 @@ export class DefaultQueryCompiler
 
   protected override visitDropColumn(node: DropColumnNode): void {
     this.append('drop column ')
+
+    if (node.ifExists) {
+      this.append('if exists ')
+    }
+
     this.visitNode(node.column)
   }
-
   protected override visitAlterColumn(node: AlterColumnNode): void {
     this.append('alter column ')
     this.visitNode(node.column)

--- a/src/schema/alter-table-builder.ts
+++ b/src/schema/alter-table-builder.ts
@@ -111,7 +111,9 @@ export class AlterTableBuilder implements ColumnAlteringInterface {
     column: string,
     build: DropColumnBuilderCallback = noop,
   ): AlterTableColumnAlteringBuilder {
-    const builder = build(new DropColumnBuilder(DropColumnNode.create(column)))
+    const builder = build(
+      new DropColumnBuilder({ node: DropColumnNode.create(column) }),
+    )
 
     return new AlterTableColumnAlteringBuilder({
       ...this.#props,
@@ -444,7 +446,9 @@ export class AlterTableColumnAlteringBuilder
     column: string,
     build: DropColumnBuilderCallback = noop,
   ): AlterTableColumnAlteringBuilder {
-    const builder = build(new DropColumnBuilder(DropColumnNode.create(column)))
+    const builder = build(
+      new DropColumnBuilder({ node: DropColumnNode.create(column) }),
+    )
 
     return new AlterTableColumnAlteringBuilder({
       ...this.#props,

--- a/src/schema/alter-table-builder.ts
+++ b/src/schema/alter-table-builder.ts
@@ -59,6 +59,10 @@ import {
   type ExpressionOrFactory,
   parseExpression,
 } from '../parser/expression-parser.js'
+import {
+  DropColumnBuilder,
+  type DropColumnBuilderCallback,
+} from './drop-column-builder.js'
 
 /**
  * This builder can be used to create a `alter table` query.
@@ -103,12 +107,17 @@ export class AlterTableBuilder implements ColumnAlteringInterface {
     })
   }
 
-  dropColumn(column: string): AlterTableColumnAlteringBuilder {
+  dropColumn(
+    column: string,
+    build: DropColumnBuilderCallback = noop,
+  ): AlterTableColumnAlteringBuilder {
+    const builder = build(new DropColumnBuilder(DropColumnNode.create(column)))
+
     return new AlterTableColumnAlteringBuilder({
       ...this.#props,
       node: AlterTableNode.cloneWithColumnAlteration(
         this.#props.node,
-        DropColumnNode.create(column),
+        builder.toOperationNode(),
       ),
     })
   }
@@ -431,12 +440,17 @@ export class AlterTableColumnAlteringBuilder
     })
   }
 
-  dropColumn(column: string): AlterTableColumnAlteringBuilder {
+  dropColumn(
+    column: string,
+    build: DropColumnBuilderCallback = noop,
+  ): AlterTableColumnAlteringBuilder {
+    const builder = build(new DropColumnBuilder(DropColumnNode.create(column)))
+
     return new AlterTableColumnAlteringBuilder({
       ...this.#props,
       node: AlterTableNode.cloneWithColumnAlteration(
         this.#props.node,
-        DropColumnNode.create(column),
+        builder.toOperationNode(),
       ),
     })
   }

--- a/src/schema/drop-column-builder.ts
+++ b/src/schema/drop-column-builder.ts
@@ -1,0 +1,25 @@
+import { DropColumnNode } from '../operation-node/drop-column-node.js'
+import type { OperationNodeSource } from '../operation-node/operation-node-source.js'
+import { freeze } from '../util/object-utils.js'
+
+export class DropColumnBuilder implements OperationNodeSource {
+  readonly #node: DropColumnNode
+
+  constructor(node: DropColumnNode) {
+    this.#node = node
+  }
+
+  ifExists(): DropColumnBuilder {
+    return new DropColumnBuilder(
+      DropColumnNode.cloneWith(this.#node, { ifExists: true }),
+    )
+  }
+
+  toOperationNode(): DropColumnNode {
+    return this.#node
+  }
+}
+
+export type DropColumnBuilderCallback = (
+  builder: DropColumnBuilder,
+) => DropColumnBuilder

--- a/src/schema/drop-column-builder.ts
+++ b/src/schema/drop-column-builder.ts
@@ -3,21 +3,26 @@ import type { OperationNodeSource } from '../operation-node/operation-node-sourc
 import { freeze } from '../util/object-utils.js'
 
 export class DropColumnBuilder implements OperationNodeSource {
-  readonly #node: DropColumnNode
+  readonly #props: DropColumnBuilderProps
 
-  constructor(node: DropColumnNode) {
-    this.#node = node
+  constructor(props: DropColumnBuilderProps) {
+    this.#props = freeze({ ...props })
   }
 
   ifExists(): DropColumnBuilder {
-    return new DropColumnBuilder(
-      DropColumnNode.cloneWith(this.#node, { ifExists: true }),
-    )
+    return new DropColumnBuilder({
+      ...this.#props,
+      node: DropColumnNode.cloneWith(this.#props.node, { ifExists: true }),
+    })
   }
 
   toOperationNode(): DropColumnNode {
-    return this.#node
+    return this.#props.node
   }
+}
+
+export interface DropColumnBuilderProps {
+  readonly node: DropColumnNode
 }
 
 export type DropColumnBuilderCallback = (

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -2954,6 +2954,7 @@ for (const dialect of DIALECTS) {
           .createTable('test')
           .addColumn('varchar_col', 'varchar(255)')
           .addColumn('integer_col', 'integer')
+          .addColumn('different_col', 'text')
           .execute()
       })
 
@@ -3397,6 +3398,29 @@ for (const dialect of DIALECTS) {
           await builder.execute()
         })
 
+        if (sqlSpec === 'postgres' || sqlSpec === 'mssql') {
+          it('should drop a column if it exists', async () => {
+            const builder = ctx.db.schema
+              .alterTable('test')
+              .dropColumn('varchar_col', (col) => col.ifExists())
+
+            testSql(builder, dialect, {
+              postgres: {
+                sql: 'alter table "test" drop column if exists "varchar_col"',
+                parameters: [],
+              },
+              mysql: NOT_SUPPORTED,
+              mssql: {
+                sql: 'alter table "test" drop column if exists "varchar_col"',
+                parameters: [],
+              },
+              sqlite: NOT_SUPPORTED,
+            })
+
+            await builder.execute()
+          })
+        }
+
         if (
           sqlSpec === 'postgres' ||
           sqlSpec === 'mysql' ||
@@ -3434,7 +3458,7 @@ for (const dialect of DIALECTS) {
                 sql: [
                   'alter table "test"',
                   'drop column "varchar_col",',
-                  '"text_col"',
+                  'column "text_col"',
                 ],
                 parameters: [],
               },
@@ -3452,6 +3476,41 @@ for (const dialect of DIALECTS) {
           })
         }
       })
+
+      if (sqlSpec === 'postgres' || sqlSpec === 'mssql') {
+        it('should drop multiple columns if it exists', async () => {
+          const builder = ctx.db.schema
+            .alterTable('test')
+            .dropColumn('varchar_col')
+            .dropColumn('not_exist_col', (col) => col.ifExists())
+            .dropColumn('different_col')
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: [
+                'alter table "test"',
+                'drop column "varchar_col",',
+                'drop column if exists "not_exist_col",',
+                'drop column "different_col"',
+              ],
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: {
+              sql: [
+                'alter table "test"',
+                'drop column "varchar_col",',
+                'column if exists "not_exist_col",',
+                'column "different_col"',
+              ],
+              parameters: [],
+            },
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
+      }
 
       if (
         sqlSpec === 'postgres' ||


### PR DESCRIPTION
add support for `IF EXISTS` in `DROP COLUMN` for PostgreSQL and MSSQL.
refs: 
MSSQL: https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver16#drop-columns-and-constraints
PostgreSQL: https://www.postgresql.org/docs/current/sql-altertable.html

closes #1623
