### PR TITLE
feat: deny passing `BLOB`-like columns to SQLite JSON helpers

### DIFF
--- a/src/helpers/sqlite.ts
+++ b/src/helpers/sqlite.ts
@@ -3,12 +3,23 @@ import type { SelectQueryNode } from '../operation-node/select-query-node.js'
 import type { SelectQueryBuilderExpression } from '../query-builder/select-query-builder-expression.js'
 import type { RawBuilder } from '../raw-builder/raw-builder.js'
 import { sql } from '../raw-builder/sql.js'
+import type { KyselyTypeError } from '../util/type-error.js'
 import { getJsonObjectArgs } from '../util/json-object-args.js'
 import type {
+  HasUint8Array,
+  ObjectHasUint8ArrayProperty,
   ShallowDehydrateObject,
   ShallowDehydrateValue,
   Simplify,
 } from '../util/type-utils.js'
+
+type ExpressionRecordHasUint8Array<
+  O extends Record<string, Expression<unknown>>,
+> = true extends {
+  [K in keyof O]: O[K] extends Expression<infer V> ? HasUint8Array<V> : false
+}[keyof O]
+  ? true
+  : false
 
 /**
  * A SQLite helper for aggregating a subquery into a JSON array.
@@ -73,10 +84,12 @@ import type {
  */
 export function jsonArrayFrom<O>(
   expr: SelectQueryBuilderExpression<O>,
-): RawBuilder<Simplify<ShallowDehydrateObject<O>>[]> {
+): ObjectHasUint8ArrayProperty<O> extends true
+  ? KyselyTypeError<'SQLite jsonArrayFrom does not support Buffer/Uint8Array columns. Cast to text using eb.cast<string>(column, "text") or sql<string>`hex(column)`'>
+  : RawBuilder<Simplify<ShallowDehydrateObject<O>>[]> {
   return sql`(select coalesce(json_group_array(json_object(${sql.join(
     getSqliteJsonObjectArgs(expr.toOperationNode(), 'agg'),
-  )})), '[]') from ${expr} as agg)`
+  )})), '[]') from ${expr} as agg)` as any
 }
 
 /**
@@ -144,10 +157,12 @@ export function jsonArrayFrom<O>(
  */
 export function jsonObjectFrom<O>(
   expr: SelectQueryBuilderExpression<O>,
-): RawBuilder<Simplify<ShallowDehydrateObject<O>> | null> {
+): ObjectHasUint8ArrayProperty<O> extends true
+  ? KyselyTypeError<'SQLite jsonObjectFrom does not support Buffer/Uint8Array columns. Cast to text using eb.cast<string>(column, "text") or sql<string>`hex(column)`'>
+  : RawBuilder<Simplify<ShallowDehydrateObject<O>> | null> {
   return sql`(select json_object(${sql.join(
     getSqliteJsonObjectArgs(expr.toOperationNode(), 'obj'),
-  )}) from ${expr} as obj)`
+  )}) from ${expr} as obj)` as any
 }
 
 /**
@@ -208,16 +223,18 @@ export function jsonObjectFrom<O>(
  */
 export function jsonBuildObject<O extends Record<string, Expression<unknown>>>(
   obj: O,
-): RawBuilder<
-  Simplify<{
-    [K in keyof O]: O[K] extends Expression<infer V>
-      ? ShallowDehydrateValue<V>
-      : never
-  }>
-> {
+): ExpressionRecordHasUint8Array<O> extends true
+  ? KyselyTypeError<'SQLite jsonBuildObject does not support Buffer/Uint8Array values. Cast to text using eb.cast<string>(column, "text") or sql<string>`hex(column)`'>
+  : RawBuilder<
+      Simplify<{
+        [K in keyof O]: O[K] extends Expression<infer V>
+          ? ShallowDehydrateValue<V>
+          : never
+      }>
+    > {
   return sql`json_object(${sql.join(
     Object.keys(obj).flatMap((k) => [sql.lit(k), obj[k]]),
-  )})`
+  )})` as any
 }
 
 function getSqliteJsonObjectArgs(

--- a/src/helpers/sqlite.ts
+++ b/src/helpers/sqlite.ts
@@ -6,20 +6,20 @@ import { sql } from '../raw-builder/sql.js'
 import type { KyselyTypeError } from '../util/type-error.js'
 import { getJsonObjectArgs } from '../util/json-object-args.js'
 import type {
-  HasUint8Array,
-  ObjectHasUint8ArrayProperty,
+  IsNever,
   ShallowDehydrateObject,
   ShallowDehydrateValue,
   Simplify,
 } from '../util/type-utils.js'
 
-type ExpressionRecordHasUint8Array<
-  O extends Record<string, Expression<unknown>>,
-> = true extends {
-  [K in keyof O]: O[K] extends Expression<infer V> ? HasUint8Array<V> : false
+/**
+ * Used to check for `BLOB` column existence in result records.
+ */
+export type ExtractBlobs<O> = {
+  [K in keyof O]: O[K] extends Expression<infer V>
+    ? Extract<V, Uint8Array>
+    : Extract<O[K], Uint8Array>
 }[keyof O]
-  ? true
-  : false
 
 /**
  * A SQLite helper for aggregating a subquery into a JSON array.
@@ -83,13 +83,16 @@ type ExpressionRecordHasUint8Array<
  * ```
  */
 export function jsonArrayFrom<O>(
-  expr: SelectQueryBuilderExpression<O>,
-): ObjectHasUint8ArrayProperty<O> extends true
-  ? KyselyTypeError<'SQLite jsonArrayFrom does not support Buffer/Uint8Array columns. Cast to text using eb.cast<string>(column, "text") or sql<string>`hex(column)`'>
-  : RawBuilder<Simplify<ShallowDehydrateObject<O>>[]> {
+  expr: IsNever<ExtractBlobs<O>> extends true
+    ? SelectQueryBuilderExpression<O>
+    : KyselyTypeError<'SQLite does not support passing `BLOB` values to `json_object`. Cast to `TEXT`.'>,
+): RawBuilder<Simplify<ShallowDehydrateObject<O>>[]> {
   return sql`(select coalesce(json_group_array(json_object(${sql.join(
-    getSqliteJsonObjectArgs(expr.toOperationNode(), 'agg'),
-  )})), '[]') from ${expr} as agg)` as any
+    getSqliteJsonObjectArgs(
+      (expr as SelectQueryBuilderExpression<O>).toOperationNode(),
+      'agg',
+    ),
+  )})), '[]') from ${expr} as agg)`
 }
 
 /**
@@ -156,13 +159,16 @@ export function jsonArrayFrom<O>(
  * ```
  */
 export function jsonObjectFrom<O>(
-  expr: SelectQueryBuilderExpression<O>,
-): ObjectHasUint8ArrayProperty<O> extends true
-  ? KyselyTypeError<'SQLite jsonObjectFrom does not support Buffer/Uint8Array columns. Cast to text using eb.cast<string>(column, "text") or sql<string>`hex(column)`'>
-  : RawBuilder<Simplify<ShallowDehydrateObject<O>> | null> {
+  expr: IsNever<ExtractBlobs<O>> extends true
+    ? SelectQueryBuilderExpression<O>
+    : KyselyTypeError<'SQLite does not support passing `BLOB` values to `json_object`. Cast to `TEXT`.'>,
+): RawBuilder<Simplify<ShallowDehydrateObject<O>> | null> {
   return sql`(select json_object(${sql.join(
-    getSqliteJsonObjectArgs(expr.toOperationNode(), 'obj'),
-  )}) from ${expr} as obj)` as any
+    getSqliteJsonObjectArgs(
+      (expr as SelectQueryBuilderExpression<O>).toOperationNode(),
+      'obj',
+    ),
+  )}) from ${expr} as obj)`
 }
 
 /**
@@ -222,19 +228,22 @@ export function jsonObjectFrom<O>(
  * ```
  */
 export function jsonBuildObject<O extends Record<string, Expression<unknown>>>(
-  obj: O,
-): ExpressionRecordHasUint8Array<O> extends true
-  ? KyselyTypeError<'SQLite jsonBuildObject does not support Buffer/Uint8Array values. Cast to text using eb.cast<string>(column, "text") or sql<string>`hex(column)`'>
-  : RawBuilder<
-      Simplify<{
-        [K in keyof O]: O[K] extends Expression<infer V>
-          ? ShallowDehydrateValue<V>
-          : never
-      }>
-    > {
+  obj: IsNever<ExtractBlobs<O>> extends true
+    ? O
+    : KyselyTypeError<'SQLite does not support passing `BLOB` values to `json_object`. Cast to `TEXT`.'>,
+): RawBuilder<
+  Simplify<{
+    [K in keyof O]: O[K] extends Expression<infer V>
+      ? ShallowDehydrateValue<V>
+      : never
+  }>
+> {
   return sql`json_object(${sql.join(
-    Object.keys(obj).flatMap((k) => [sql.lit(k), obj[k]]),
-  )})` as any
+    Object.keys(obj).flatMap((k) => [
+      sql.lit(k),
+      (obj as Record<string, unknown>)[k],
+    ]),
+  )})`
 }
 
 function getSqliteJsonObjectArgs(

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -262,13 +262,9 @@ export type NumbersWhenDataTypeNotAvailable = bigint | NumericString
 export type NumericString = `${number}`
 
 /**
- * Evaluates to `true` if type `T` contains `Uint8Array`.
+ * Evaluates to `true` if type `T` is assignable to `Uint8Array`.
  */
-export type HasUint8Array<T> = Uint8Array extends T
-  ? true
-  : T extends Uint8Array
-    ? true
-    : false
+export type HasUint8Array<T> = T extends Uint8Array ? true : false
 
 /**
  * Evaluates to `true` if any property in object type `O` contains `Uint8Array`.

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -260,3 +260,21 @@ export type StringsWhenDataTypeNotAvailable =
 export type NumbersWhenDataTypeNotAvailable = bigint | NumericString
 
 export type NumericString = `${number}`
+
+/**
+ * Evaluates to `true` if type `T` contains `Uint8Array`.
+ */
+export type HasUint8Array<T> = Uint8Array extends T
+  ? true
+  : T extends Uint8Array
+    ? true
+    : false
+
+/**
+ * Evaluates to `true` if any property in object type `O` contains `Uint8Array`.
+ */
+export type ObjectHasUint8ArrayProperty<O> = true extends {
+  [K in keyof O]: HasUint8Array<O[K]>
+}[keyof O]
+  ? true
+  : false

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -277,3 +277,21 @@ export type NumericString = `${number}`
  * Unlike `Required<T>`, this does not strip `undefined` from property types.
  */
 export type AllProps<T> = T & { [P in keyof T]-?: unknown }
+
+/**
+ * Evaluates to `true` if type `T` contains `Uint8Array`.
+ */
+export type HasUint8Array<T> = Uint8Array extends T
+  ? true
+  : T extends Uint8Array
+    ? true
+    : false
+
+/**
+ * Evaluates to `true` if any property in object type `O` contains `Uint8Array`.
+ */
+export type ObjectHasUint8ArrayProperty<O> = true extends {
+  [K in keyof O]: HasUint8Array<O[K]>
+}[keyof O]
+  ? true
+  : false

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -279,13 +279,9 @@ export type NumericString = `${number}`
 export type AllProps<T> = T & { [P in keyof T]-?: unknown }
 
 /**
- * Evaluates to `true` if type `T` contains `Uint8Array`.
+ * Evaluates to `true` if type `T` is assignable to `Uint8Array`.
  */
-export type HasUint8Array<T> = Uint8Array extends T
-  ? true
-  : T extends Uint8Array
-    ? true
-    : false
+export type HasUint8Array<T> = T extends Uint8Array ? true : false
 
 /**
  * Evaluates to `true` if any property in object type `O` contains `Uint8Array`.

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -277,17 +277,3 @@ export type NumericString = `${number}`
  * Unlike `Required<T>`, this does not strip `undefined` from property types.
  */
 export type AllProps<T> = T & { [P in keyof T]-?: unknown }
-
-/**
- * Evaluates to `true` if type `T` is assignable to `Uint8Array`.
- */
-export type HasUint8Array<T> = T extends Uint8Array ? true : false
-
-/**
- * Evaluates to `true` if any property in object type `O` contains `Uint8Array`.
- */
-export type ObjectHasUint8ArrayProperty<O> = true extends {
-  [K in keyof O]: HasUint8Array<O[K]>
-}[keyof O]
-  ? true
-  : false

--- a/test/node/src/json.test.ts
+++ b/test/node/src/json.test.ts
@@ -414,14 +414,17 @@ for (const dialect of DIALECTS) {
         ).as('doggo'),
 
         // Nest an object that holds the person's formatted name
-        jsonBuildObject({
-          first: eb.ref('first_name'),
-          last: eb.ref('last_name'),
-          full:
-            dialect === 'sqlite'
-              ? sql<string>`first_name || ' ' || last_name`
-              : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
-        }).as('name'),
+        // Type assertion needed due to union of dialect helper types
+        (
+          jsonBuildObject({
+            first: eb.ref('first_name'),
+            last: eb.ref('last_name'),
+            full:
+              dialect === 'sqlite'
+                ? sql<string>`first_name || ' ' || last_name`
+                : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
+          }) as RawBuilder<{ first: string; last: string | null; full: string }>
+        ).as('name'),
 
         // Nest an empty list
         jsonArrayFrom(
@@ -564,14 +567,17 @@ for (const dialect of DIALECTS) {
       const result = await db
         .selectNoFrom([
           buffer,
-          jsonObjectFrom(
-            db.selectNoFrom([
-              dialect === 'sqlite'
-                ? expressionBuilder()
-                    .cast<string>(buffer.expression, 'text')
-                    .as('buffer')
-                : buffer,
-            ]),
+          // Type assertion needed due to union of dialect helper types
+          (
+            jsonObjectFrom(
+              db.selectNoFrom([
+                dialect === 'sqlite'
+                  ? expressionBuilder()
+                      .cast<string>(buffer.expression, 'text')
+                      .as('buffer')
+                  : buffer,
+              ]),
+            ) as RawBuilder<{ buffer: string } | null>
           )
             .$notNull()
             .as('dehydrated'),

--- a/test/node/src/json.test.ts
+++ b/test/node/src/json.test.ts
@@ -414,17 +414,14 @@ for (const dialect of DIALECTS) {
         ).as('doggo'),
 
         // Nest an object that holds the person's formatted name
-        // Type assertion needed due to union of dialect helper types
-        (
-          jsonBuildObject({
-            first: eb.ref('first_name'),
-            last: eb.ref('last_name'),
-            full:
-              dialect === 'sqlite'
-                ? sql<string>`first_name || ' ' || last_name`
-                : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
-          }) as RawBuilder<{ first: string; last: string | null; full: string }>
-        ).as('name'),
+        jsonBuildObject({
+          first: eb.ref('first_name'),
+          last: eb.ref('last_name'),
+          full:
+            dialect === 'sqlite'
+              ? sql<string>`first_name || ' ' || last_name`
+              : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
+        }).as('name'),
 
         // Nest an empty list
         jsonArrayFrom(

--- a/test/node/src/json.test.ts
+++ b/test/node/src/json.test.ts
@@ -417,14 +417,17 @@ for (const dialect of DIALECTS) {
         ).as('doggo'),
 
         // Nest an object that holds the person's formatted name
-        jsonBuildObject({
-          first: eb.ref('first_name'),
-          last: eb.ref('last_name'),
-          full:
-            sqlSpec === 'sqlite'
-              ? sql<string>`first_name || ' ' || last_name`
-              : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
-        }).as('name'),
+        // Type assertion needed due to union of dialect helper types
+        (
+          jsonBuildObject({
+            first: eb.ref('first_name'),
+            last: eb.ref('last_name'),
+            full:
+              dialect === 'sqlite'
+                ? sql<string>`first_name || ' ' || last_name`
+                : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
+          }) as RawBuilder<{ first: string; last: string | null; full: string }>
+        ).as('name'),
 
         // Nest an empty list
         jsonArrayFrom(
@@ -574,14 +577,17 @@ for (const dialect of DIALECTS) {
       const result = await db
         .selectNoFrom([
           buffer,
-          jsonObjectFrom(
-            db.selectNoFrom([
-              sqlSpec === 'sqlite'
-                ? expressionBuilder()
-                    .cast<string>(buffer.expression, 'text')
-                    .as('buffer')
-                : buffer,
-            ]),
+          // Type assertion needed due to union of dialect helper types
+          (
+            jsonObjectFrom(
+              db.selectNoFrom([
+                dialect === 'sqlite'
+                  ? expressionBuilder()
+                      .cast<string>(buffer.expression, 'text')
+                      .as('buffer')
+                  : buffer,
+              ]),
+            ) as RawBuilder<{ buffer: string } | null>
           )
             .$notNull()
             .as('dehydrated'),

--- a/test/node/src/json.test.ts
+++ b/test/node/src/json.test.ts
@@ -579,13 +579,13 @@ for (const dialect of DIALECTS) {
         .selectNoFrom([
           buffer,
           jsonObjectFrom(
-            db.selectNoFrom(
+            db.selectNoFrom([
               sqlSpec === 'sqlite'
                 ? expressionBuilder()
                     .cast<string>(buffer.expression, 'text')
                     .as('buffer')
                 : buffer,
-            ),
+            ]),
           )
             .$notNull()
             .as('dehydrated'),

--- a/test/node/src/json.test.ts
+++ b/test/node/src/json.test.ts
@@ -72,6 +72,10 @@ const jsonFunctions = {
     jsonArrayFrom: sqlite_jsonArrayFrom,
     jsonObjectFrom: sqlite_jsonObjectFrom,
     jsonBuildObject: sqlite_jsonBuildObject,
+  } as never as {
+    jsonArrayFrom: typeof pg_jsonArrayFrom
+    jsonObjectFrom: typeof pg_jsonObjectFrom
+    jsonBuildObject: typeof pg_jsonBuildObject
   },
 } as const
 
@@ -421,7 +425,7 @@ for (const dialect of DIALECTS) {
           first: eb.ref('first_name'),
           last: eb.ref('last_name'),
           full:
-            dialect === 'sqlite'
+            sqlSpec === 'sqlite'
               ? sql<string>`first_name || ' ' || last_name`
               : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
         }).as('name'),
@@ -574,17 +578,14 @@ for (const dialect of DIALECTS) {
       const result = await db
         .selectNoFrom([
           buffer,
-          // Type assertion needed due to union of dialect helper types
-          (
-            jsonObjectFrom(
-              db.selectNoFrom([
-                dialect === 'sqlite'
-                  ? expressionBuilder()
-                      .cast<string>(buffer.expression, 'text')
-                      .as('buffer')
-                  : buffer,
-              ]),
-            ) as RawBuilder<{ buffer: string } | null>
+          jsonObjectFrom(
+            db.selectNoFrom(
+              sqlSpec === 'sqlite'
+                ? expressionBuilder()
+                    .cast<string>(buffer.expression, 'text')
+                    .as('buffer')
+                : buffer,
+            ),
           )
             .$notNull()
             .as('dehydrated'),

--- a/test/node/src/json.test.ts
+++ b/test/node/src/json.test.ts
@@ -417,17 +417,14 @@ for (const dialect of DIALECTS) {
         ).as('doggo'),
 
         // Nest an object that holds the person's formatted name
-        // Type assertion needed due to union of dialect helper types
-        (
-          jsonBuildObject({
-            first: eb.ref('first_name'),
-            last: eb.ref('last_name'),
-            full:
-              dialect === 'sqlite'
-                ? sql<string>`first_name || ' ' || last_name`
-                : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
-          }) as RawBuilder<{ first: string; last: string | null; full: string }>
-        ).as('name'),
+        jsonBuildObject({
+          first: eb.ref('first_name'),
+          last: eb.ref('last_name'),
+          full:
+            dialect === 'sqlite'
+              ? sql<string>`first_name || ' ' || last_name`
+              : eb.fn('concat', ['first_name', sql.lit(' '), 'last_name']),
+        }).as('name'),
 
         // Nest an empty list
         jsonArrayFrom(

--- a/test/typings/test-d/sqlite-json.test-d.ts
+++ b/test/typings/test-d/sqlite-json.test-d.ts
@@ -1,5 +1,6 @@
 import { expectError, expectType } from 'tsd'
-import type { Kysely, RawBuilder } from '..'
+import type { Kysely } from '..'
+import type { Database as SharedDatabase } from '../shared'
 import {
   jsonArrayFrom,
   jsonBuildObject,
@@ -7,44 +8,39 @@ import {
 } from '../../../helpers/sqlite'
 import { sql } from '../../..'
 
-interface Database {
-  person: {
+interface Database extends SharedDatabase {
+  blob_test: {
     id: number
     name: string
     data: Buffer
     nullable_data: Buffer | null
   }
-  pet: {
-    id: number
-    name: string
-    owner_id: number
-  }
 }
 
 // jsonArrayFrom should error when selecting Buffer columns
-async function testJsonArrayFromWithBuffer(db: Kysely<Database>) {
+function testJsonArrayFromWithBuffer(db: Kysely<Database>) {
   expectError(
     db
-      .selectFrom('person')
+      .selectFrom('blob_test')
       .select((eb) => [
         'id',
-        jsonArrayFrom(eb.selectFrom('person').select(['id', 'data'])).as(
-          'people',
+        jsonArrayFrom(eb.selectFrom('blob_test').select(['id', 'data'])).as(
+          'rows',
         ),
       ]),
   )
 }
 
 // jsonArrayFrom should error when selecting Buffer | null columns
-async function testJsonArrayFromWithNullableBuffer(db: Kysely<Database>) {
+function testJsonArrayFromWithNullableBuffer(db: Kysely<Database>) {
   expectError(
     db
-      .selectFrom('person')
+      .selectFrom('blob_test')
       .select((eb) => [
         'id',
         jsonArrayFrom(
-          eb.selectFrom('person').select(['id', 'nullable_data']),
-        ).as('people'),
+          eb.selectFrom('blob_test').select(['id', 'nullable_data']),
+        ).as('rows'),
       ]),
   )
 }
@@ -52,45 +48,45 @@ async function testJsonArrayFromWithNullableBuffer(db: Kysely<Database>) {
 // jsonArrayFrom should succeed when no Buffer columns are used
 async function testJsonArrayFromWithoutBuffer(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonArrayFrom(
         eb
-          .selectFrom('pet')
-          .select(['pet.id', 'pet.name'])
-          .whereRef('pet.owner_id', '=', 'person.id'),
-      ).as('pets'),
+          .selectFrom('blob_test')
+          .select(['blob_test.id', 'blob_test.name'])
+          .where('blob_test.id', '>', 0),
+      ).as('rows'),
     ])
     .execute()
 
-  expectType<{ id: number; pets: { id: number; name: string }[] }[]>(result)
+  expectType<{ id: number; rows: { id: number; name: string }[] }[]>(result)
 }
 
 // jsonObjectFrom should error when selecting Buffer columns
-async function testJsonObjectFromWithBuffer(db: Kysely<Database>) {
+function testJsonObjectFromWithBuffer(db: Kysely<Database>) {
   expectError(
     db
-      .selectFrom('person')
+      .selectFrom('blob_test')
       .select((eb) => [
         'id',
         jsonObjectFrom(
-          eb.selectFrom('person').select(['id', 'data']).limit(1),
-        ).as('person_data'),
+          eb.selectFrom('blob_test').select(['id', 'data']).limit(1),
+        ).as('row'),
       ]),
   )
 }
 
 // jsonObjectFrom should error when selecting Buffer | null columns
-async function testJsonObjectFromWithNullableBuffer(db: Kysely<Database>) {
+function testJsonObjectFromWithNullableBuffer(db: Kysely<Database>) {
   expectError(
     db
-      .selectFrom('person')
+      .selectFrom('blob_test')
       .select((eb) => [
         'id',
         jsonObjectFrom(
-          eb.selectFrom('person').select(['id', 'nullable_data']).limit(1),
-        ).as('person_data'),
+          eb.selectFrom('blob_test').select(['id', 'nullable_data']).limit(1),
+        ).as('row'),
       ]),
   )
 }
@@ -98,26 +94,26 @@ async function testJsonObjectFromWithNullableBuffer(db: Kysely<Database>) {
 // jsonObjectFrom should succeed when no Buffer columns are used
 async function testJsonObjectFromWithoutBuffer(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonObjectFrom(
         eb
-          .selectFrom('pet')
-          .select(['pet.id', 'pet.name'])
-          .whereRef('pet.owner_id', '=', 'person.id')
+          .selectFrom('blob_test')
+          .select(['blob_test.id', 'blob_test.name'])
+          .where('blob_test.id', '>', 0)
           .limit(1),
-      ).as('pet'),
+      ).as('row'),
     ])
     .execute()
 
-  expectType<{ id: number; pet: { id: number; name: string } | null }[]>(result)
+  expectType<{ id: number; row: { id: number; name: string } | null }[]>(result)
 }
 
 // jsonBuildObject should error when passing Expression<Buffer>
-async function testJsonBuildObjectWithBuffer(db: Kysely<Database>) {
+function testJsonBuildObjectWithBuffer(db: Kysely<Database>) {
   expectError(
-    db.selectFrom('person').select((eb) => [
+    db.selectFrom('blob_test').select((eb) => [
       'id',
       jsonBuildObject({
         name: eb.ref('name'),
@@ -128,9 +124,9 @@ async function testJsonBuildObjectWithBuffer(db: Kysely<Database>) {
 }
 
 // jsonBuildObject should error when passing Expression<Buffer | null>
-async function testJsonBuildObjectWithNullableBuffer(db: Kysely<Database>) {
+function testJsonBuildObjectWithNullableBuffer(db: Kysely<Database>) {
   expectError(
-    db.selectFrom('person').select((eb) => [
+    db.selectFrom('blob_test').select((eb) => [
       'id',
       jsonBuildObject({
         name: eb.ref('name'),
@@ -143,7 +139,7 @@ async function testJsonBuildObjectWithNullableBuffer(db: Kysely<Database>) {
 // jsonBuildObject should succeed when no Buffer values are used
 async function testJsonBuildObjectWithoutBuffer(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonBuildObject({
@@ -159,37 +155,35 @@ async function testJsonBuildObjectWithoutBuffer(db: Kysely<Database>) {
 // jsonArrayFrom should succeed when Buffer is cast using sql`hex()` (workaround)
 async function testJsonArrayFromWithHexWorkaround(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonArrayFrom(
         eb
-          .selectFrom('person')
+          .selectFrom('blob_test')
           .select(['id', sql<string>`hex(data)`.as('data_hex')]),
-      ).as('people'),
+      ).as('rows'),
     ])
     .execute()
 
-  expectType<{ id: number; people: { id: number; data_hex: string }[] }[]>(
-    result,
-  )
+  expectType<{ id: number; rows: { id: number; data_hex: string }[] }[]>(result)
 }
 
 // jsonArrayFrom should succeed when Buffer is cast using eb.cast<string>() (workaround)
 async function testJsonArrayFromWithCastWorkaround(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonArrayFrom(
         eb
-          .selectFrom('person')
+          .selectFrom('blob_test')
           .select(['id', eb.cast<string>('data', 'text').as('data_text')]),
-      ).as('people'),
+      ).as('rows'),
     ])
     .execute()
 
-  expectType<{ id: number; people: { id: number; data_text: string }[] }[]>(
+  expectType<{ id: number; rows: { id: number; data_text: string }[] }[]>(
     result,
   )
 }
@@ -197,47 +191,47 @@ async function testJsonArrayFromWithCastWorkaround(db: Kysely<Database>) {
 // jsonObjectFrom should succeed when Buffer is cast using sql`hex()` (workaround)
 async function testJsonObjectFromWithHexWorkaround(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonObjectFrom(
         eb
-          .selectFrom('person')
+          .selectFrom('blob_test')
           .select(['id', sql<string>`hex(data)`.as('data_hex')])
           .limit(1),
-      ).as('person_data'),
+      ).as('row'),
     ])
     .execute()
 
-  expectType<
-    { id: number; person_data: { id: number; data_hex: string } | null }[]
-  >(result)
+  expectType<{ id: number; row: { id: number; data_hex: string } | null }[]>(
+    result,
+  )
 }
 
 // jsonObjectFrom should succeed when Buffer is cast using eb.cast<string>() (workaround)
 async function testJsonObjectFromWithCastWorkaround(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonObjectFrom(
         eb
-          .selectFrom('person')
+          .selectFrom('blob_test')
           .select(['id', eb.cast<string>('data', 'text').as('data_text')])
           .limit(1),
-      ).as('person_data'),
+      ).as('row'),
     ])
     .execute()
 
-  expectType<
-    { id: number; person_data: { id: number; data_text: string } | null }[]
-  >(result)
+  expectType<{ id: number; row: { id: number; data_text: string } | null }[]>(
+    result,
+  )
 }
 
 // jsonBuildObject should succeed when Buffer is cast using sql`hex()` (workaround)
 async function testJsonBuildObjectWithHexWorkaround(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonBuildObject({
@@ -253,7 +247,7 @@ async function testJsonBuildObjectWithHexWorkaround(db: Kysely<Database>) {
 // jsonBuildObject should succeed when Buffer is cast using eb.cast<string>() (workaround)
 async function testJsonBuildObjectWithCastWorkaround(db: Kysely<Database>) {
   const result = await db
-    .selectFrom('person')
+    .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonBuildObject({

--- a/test/typings/test-d/sqlite-json.test-d.ts
+++ b/test/typings/test-d/sqlite-json.test-d.ts
@@ -14,6 +14,9 @@ interface Database extends SharedDatabase {
     name: string
     data: Buffer
     nullable_data: Buffer | null
+    uint8_data: Uint8Array
+    any_data: any
+    mixed_data: Buffer | string
   }
 }
 
@@ -136,6 +139,74 @@ function testJsonBuildObjectWithNullableBuffer(db: Kysely<Database>) {
   )
 }
 
+// jsonArrayFrom should error when selecting Uint8Array columns
+function testJsonArrayFromWithUint8Array(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonArrayFrom(eb.selectFrom('blob_test').select(['id', 'uint8_data'])).as(
+          'rows',
+        ),
+      ]),
+  )
+}
+
+// jsonObjectFrom should error when selecting Buffer | string columns
+function testJsonObjectFromWithMixedBufferString(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonObjectFrom(
+          eb.selectFrom('blob_test').select(['id', 'mixed_data']).limit(1),
+        ).as('row'),
+      ]),
+  )
+}
+
+// jsonArrayFrom should error when selecting any-typed columns
+function testJsonArrayFromWithAny(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonArrayFrom(eb.selectFrom('blob_test').select(['id', 'any_data'])).as(
+          'rows',
+        ),
+      ]),
+  )
+}
+
+// jsonObjectFrom should error when selecting any-typed columns
+function testJsonObjectFromWithAny(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonObjectFrom(eb.selectFrom('blob_test').select(['id', 'any_data']))
+          .as('row'),
+      ]),
+  )
+}
+
+// jsonBuildObject should error when passing Expression<any>
+function testJsonBuildObjectWithAny(db: Kysely<Database>) {
+  expectError(
+    db.selectFrom('blob_test').select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        data: eb.ref('any_data'),
+      }).as('obj'),
+    ]),
+  )
+}
+
 // jsonBuildObject should succeed when no Buffer values are used
 async function testJsonBuildObjectWithoutBuffer(db: Kysely<Database>) {
   const result = await db
@@ -150,6 +221,59 @@ async function testJsonBuildObjectWithoutBuffer(db: Kysely<Database>) {
     .execute()
 
   expectType<{ id: number; obj: { name: string; computed: string } }[]>(result)
+}
+
+// jsonBuildObject should succeed with untyped sql expressions (unknown)
+async function testJsonBuildObjectWithUntypedSql(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('blob_test')
+    .select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        one: sql`1`,
+      }).as('obj'),
+    ])
+    .execute()
+
+  expectType<{ id: number; obj: { name: string; one: unknown } }[]>(result)
+}
+
+// jsonArrayFrom should succeed with untyped sql expressions (unknown)
+async function testJsonArrayFromWithUntypedSql(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('blob_test')
+    .select((eb) => [
+      'id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('blob_test')
+          .select(['id', sql`1`.as('one')])
+          .where('blob_test.id', '>', 0),
+      ).as('rows'),
+    ])
+    .execute()
+
+  expectType<{ id: number; rows: { id: number; one: unknown }[] }[]>(result)
+}
+
+// jsonObjectFrom should succeed with untyped sql expressions (unknown)
+async function testJsonObjectFromWithUntypedSql(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('blob_test')
+    .select((eb) => [
+      'id',
+      jsonObjectFrom(
+        eb
+          .selectFrom('blob_test')
+          .select(['id', sql`1`.as('one')])
+          .where('blob_test.id', '>', 0)
+          .limit(1),
+      ).as('row'),
+    ])
+    .execute()
+
+  expectType<{ id: number; row: { id: number; one: unknown } | null }[]>(result)
 }
 
 // jsonArrayFrom should succeed when Buffer is cast using sql`hex()` (workaround)

--- a/test/typings/test-d/sqlite-json.test-d.ts
+++ b/test/typings/test-d/sqlite-json.test-d.ts
@@ -1,0 +1,267 @@
+import { expectError, expectType } from 'tsd'
+import type { Kysely, RawBuilder } from '..'
+import {
+  jsonArrayFrom,
+  jsonBuildObject,
+  jsonObjectFrom,
+} from '../../../helpers/sqlite'
+import { sql } from '../../..'
+
+interface Database {
+  person: {
+    id: number
+    name: string
+    data: Buffer
+    nullable_data: Buffer | null
+  }
+  pet: {
+    id: number
+    name: string
+    owner_id: number
+  }
+}
+
+// jsonArrayFrom should error when selecting Buffer columns
+async function testJsonArrayFromWithBuffer(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('person')
+      .select((eb) => [
+        'id',
+        jsonArrayFrom(eb.selectFrom('person').select(['id', 'data'])).as(
+          'people',
+        ),
+      ]),
+  )
+}
+
+// jsonArrayFrom should error when selecting Buffer | null columns
+async function testJsonArrayFromWithNullableBuffer(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('person')
+      .select((eb) => [
+        'id',
+        jsonArrayFrom(
+          eb.selectFrom('person').select(['id', 'nullable_data']),
+        ).as('people'),
+      ]),
+  )
+}
+
+// jsonArrayFrom should succeed when no Buffer columns are used
+async function testJsonArrayFromWithoutBuffer(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('pet')
+          .select(['pet.id', 'pet.name'])
+          .whereRef('pet.owner_id', '=', 'person.id'),
+      ).as('pets'),
+    ])
+    .execute()
+
+  expectType<{ id: number; pets: { id: number; name: string }[] }[]>(result)
+}
+
+// jsonObjectFrom should error when selecting Buffer columns
+async function testJsonObjectFromWithBuffer(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('person')
+      .select((eb) => [
+        'id',
+        jsonObjectFrom(
+          eb.selectFrom('person').select(['id', 'data']).limit(1),
+        ).as('person_data'),
+      ]),
+  )
+}
+
+// jsonObjectFrom should error when selecting Buffer | null columns
+async function testJsonObjectFromWithNullableBuffer(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('person')
+      .select((eb) => [
+        'id',
+        jsonObjectFrom(
+          eb.selectFrom('person').select(['id', 'nullable_data']).limit(1),
+        ).as('person_data'),
+      ]),
+  )
+}
+
+// jsonObjectFrom should succeed when no Buffer columns are used
+async function testJsonObjectFromWithoutBuffer(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonObjectFrom(
+        eb
+          .selectFrom('pet')
+          .select(['pet.id', 'pet.name'])
+          .whereRef('pet.owner_id', '=', 'person.id')
+          .limit(1),
+      ).as('pet'),
+    ])
+    .execute()
+
+  expectType<{ id: number; pet: { id: number; name: string } | null }[]>(result)
+}
+
+// jsonBuildObject should error when passing Expression<Buffer>
+async function testJsonBuildObjectWithBuffer(db: Kysely<Database>) {
+  expectError(
+    db.selectFrom('person').select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        data: eb.ref('data'),
+      }).as('obj'),
+    ]),
+  )
+}
+
+// jsonBuildObject should error when passing Expression<Buffer | null>
+async function testJsonBuildObjectWithNullableBuffer(db: Kysely<Database>) {
+  expectError(
+    db.selectFrom('person').select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        data: eb.ref('nullable_data'),
+      }).as('obj'),
+    ]),
+  )
+}
+
+// jsonBuildObject should succeed when no Buffer values are used
+async function testJsonBuildObjectWithoutBuffer(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        computed: sql<string>`upper(name)`,
+      }).as('obj'),
+    ])
+    .execute()
+
+  expectType<{ id: number; obj: { name: string; computed: string } }[]>(result)
+}
+
+// jsonArrayFrom should succeed when Buffer is cast using sql`hex()` (workaround)
+async function testJsonArrayFromWithHexWorkaround(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('person')
+          .select(['id', sql<string>`hex(data)`.as('data_hex')]),
+      ).as('people'),
+    ])
+    .execute()
+
+  expectType<{ id: number; people: { id: number; data_hex: string }[] }[]>(
+    result,
+  )
+}
+
+// jsonArrayFrom should succeed when Buffer is cast using eb.cast<string>() (workaround)
+async function testJsonArrayFromWithCastWorkaround(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('person')
+          .select(['id', eb.cast<string>('data', 'text').as('data_text')]),
+      ).as('people'),
+    ])
+    .execute()
+
+  expectType<{ id: number; people: { id: number; data_text: string }[] }[]>(
+    result,
+  )
+}
+
+// jsonObjectFrom should succeed when Buffer is cast using sql`hex()` (workaround)
+async function testJsonObjectFromWithHexWorkaround(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonObjectFrom(
+        eb
+          .selectFrom('person')
+          .select(['id', sql<string>`hex(data)`.as('data_hex')])
+          .limit(1),
+      ).as('person_data'),
+    ])
+    .execute()
+
+  expectType<
+    { id: number; person_data: { id: number; data_hex: string } | null }[]
+  >(result)
+}
+
+// jsonObjectFrom should succeed when Buffer is cast using eb.cast<string>() (workaround)
+async function testJsonObjectFromWithCastWorkaround(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonObjectFrom(
+        eb
+          .selectFrom('person')
+          .select(['id', eb.cast<string>('data', 'text').as('data_text')])
+          .limit(1),
+      ).as('person_data'),
+    ])
+    .execute()
+
+  expectType<
+    { id: number; person_data: { id: number; data_text: string } | null }[]
+  >(result)
+}
+
+// jsonBuildObject should succeed when Buffer is cast using sql`hex()` (workaround)
+async function testJsonBuildObjectWithHexWorkaround(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        data: sql<string>`hex(data)`,
+      }).as('obj'),
+    ])
+    .execute()
+
+  expectType<{ id: number; obj: { name: string; data: string } }[]>(result)
+}
+
+// jsonBuildObject should succeed when Buffer is cast using eb.cast<string>() (workaround)
+async function testJsonBuildObjectWithCastWorkaround(db: Kysely<Database>) {
+  const result = await db
+    .selectFrom('person')
+    .select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        data: eb.cast<string>('data', 'text'),
+      }).as('obj'),
+    ])
+    .execute()
+
+  expectType<{ id: number; obj: { name: string; data: string } }[]>(result)
+}

--- a/test/typings/test-d/sqlite-json.test-d.ts
+++ b/test/typings/test-d/sqlite-json.test-d.ts
@@ -1,14 +1,12 @@
 import { expectError, expectType } from 'tsd'
-import type { Kysely } from '..'
-import type { Database as SharedDatabase } from '../shared'
 import {
   jsonArrayFrom,
   jsonBuildObject,
   jsonObjectFrom,
-} from '../../../helpers/sqlite'
-import { sql } from '../../..'
+} from '../../../dist/helpers/sqlite.js'
+import { type Kysely, sql } from '../index.js'
 
-interface Database extends SharedDatabase {
+interface Database {
   blob_test: {
     id: number
     name: string
@@ -20,37 +18,8 @@ interface Database extends SharedDatabase {
   }
 }
 
-// jsonArrayFrom should error when selecting Buffer columns
-function testJsonArrayFromWithBuffer(db: Kysely<Database>) {
-  expectError(
-    db
-      .selectFrom('blob_test')
-      .select((eb) => [
-        'id',
-        jsonArrayFrom(eb.selectFrom('blob_test').select(['id', 'data'])).as(
-          'rows',
-        ),
-      ]),
-  )
-}
-
-// jsonArrayFrom should error when selecting Buffer | null columns
-function testJsonArrayFromWithNullableBuffer(db: Kysely<Database>) {
-  expectError(
-    db
-      .selectFrom('blob_test')
-      .select((eb) => [
-        'id',
-        jsonArrayFrom(
-          eb.selectFrom('blob_test').select(['id', 'nullable_data']),
-        ).as('rows'),
-      ]),
-  )
-}
-
-// jsonArrayFrom should succeed when no Buffer columns are used
-async function testJsonArrayFromWithoutBuffer(db: Kysely<Database>) {
-  const result = await db
+async function testJsonArrayFrom(db: Kysely<Database>) {
+  const r1 = await db
     .selectFrom('blob_test')
     .select((eb) => [
       'id',
@@ -63,112 +32,56 @@ async function testJsonArrayFromWithoutBuffer(db: Kysely<Database>) {
     ])
     .execute()
 
-  expectType<{ id: number; rows: { id: number; name: string }[] }[]>(result)
-}
+  expectType<{ id: number; rows: { id: number; name: string }[] }[]>(r1)
 
-// jsonObjectFrom should error when selecting Buffer columns
-function testJsonObjectFromWithBuffer(db: Kysely<Database>) {
-  expectError(
-    db
-      .selectFrom('blob_test')
-      .select((eb) => [
-        'id',
-        jsonObjectFrom(
-          eb.selectFrom('blob_test').select(['id', 'data']).limit(1),
-        ).as('row'),
-      ]),
-  )
-}
-
-// jsonObjectFrom should error when selecting Buffer | null columns
-function testJsonObjectFromWithNullableBuffer(db: Kysely<Database>) {
-  expectError(
-    db
-      .selectFrom('blob_test')
-      .select((eb) => [
-        'id',
-        jsonObjectFrom(
-          eb.selectFrom('blob_test').select(['id', 'nullable_data']).limit(1),
-        ).as('row'),
-      ]),
-  )
-}
-
-// jsonObjectFrom should succeed when no Buffer columns are used
-async function testJsonObjectFromWithoutBuffer(db: Kysely<Database>) {
-  const result = await db
+  const r2 = await db
     .selectFrom('blob_test')
     .select((eb) => [
       'id',
-      jsonObjectFrom(
+      jsonArrayFrom(
         eb
           .selectFrom('blob_test')
-          .select(['blob_test.id', 'blob_test.name'])
-          .where('blob_test.id', '>', 0)
-          .limit(1),
-      ).as('row'),
+          .select(['id', sql`1`.as('one')])
+          .where('blob_test.id', '>', 0),
+      ).as('rows'),
     ])
     .execute()
 
-  expectType<{ id: number; row: { id: number; name: string } | null }[]>(result)
-}
+  expectType<{ id: number; rows: { id: number; one: unknown }[] }[]>(r2)
 
-// jsonBuildObject should error when passing Expression<Buffer>
-function testJsonBuildObjectWithBuffer(db: Kysely<Database>) {
-  expectError(
-    db.selectFrom('blob_test').select((eb) => [
-      'id',
-      jsonBuildObject({
-        name: eb.ref('name'),
-        data: eb.ref('data'),
-      }).as('obj'),
-    ]),
-  )
-}
-
-// jsonBuildObject should error when passing Expression<Buffer | null>
-function testJsonBuildObjectWithNullableBuffer(db: Kysely<Database>) {
-  expectError(
-    db.selectFrom('blob_test').select((eb) => [
-      'id',
-      jsonBuildObject({
-        name: eb.ref('name'),
-        data: eb.ref('nullable_data'),
-      }).as('obj'),
-    ]),
-  )
-}
-
-// jsonArrayFrom should error when selecting Uint8Array columns
-function testJsonArrayFromWithUint8Array(db: Kysely<Database>) {
   expectError(
     db
       .selectFrom('blob_test')
       .select((eb) => [
         'id',
-        jsonArrayFrom(eb.selectFrom('blob_test').select(['id', 'uint8_data'])).as(
+        jsonArrayFrom(eb.selectFrom('blob_test').select(['id', 'data'])).as(
           'rows',
         ),
       ]),
   )
-}
 
-// jsonObjectFrom should error when selecting Buffer | string columns
-function testJsonObjectFromWithMixedBufferString(db: Kysely<Database>) {
   expectError(
     db
       .selectFrom('blob_test')
       .select((eb) => [
         'id',
-        jsonObjectFrom(
-          eb.selectFrom('blob_test').select(['id', 'mixed_data']).limit(1),
-        ).as('row'),
+        jsonArrayFrom(
+          eb.selectFrom('blob_test').select(['id', 'nullable_data']),
+        ).as('rows'),
       ]),
   )
-}
 
-// jsonArrayFrom should error when selecting any-typed columns
-function testJsonArrayFromWithAny(db: Kysely<Database>) {
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonArrayFrom(
+          eb.selectFrom('blob_test').select(['id', 'uint8_data']),
+        ).as('rows'),
+      ]),
+  )
+
   expectError(
     db
       .selectFrom('blob_test')
@@ -181,85 +94,24 @@ function testJsonArrayFromWithAny(db: Kysely<Database>) {
   )
 }
 
-// jsonObjectFrom should error when selecting any-typed columns
-function testJsonObjectFromWithAny(db: Kysely<Database>) {
-  expectError(
-    db
-      .selectFrom('blob_test')
-      .select((eb) => [
-        'id',
-        jsonObjectFrom(eb.selectFrom('blob_test').select(['id', 'any_data']))
-          .as('row'),
-      ]),
-  )
-}
-
-// jsonBuildObject should error when passing Expression<any>
-function testJsonBuildObjectWithAny(db: Kysely<Database>) {
-  expectError(
-    db.selectFrom('blob_test').select((eb) => [
-      'id',
-      jsonBuildObject({
-        name: eb.ref('name'),
-        data: eb.ref('any_data'),
-      }).as('obj'),
-    ]),
-  )
-}
-
-// jsonBuildObject should succeed when no Buffer values are used
-async function testJsonBuildObjectWithoutBuffer(db: Kysely<Database>) {
-  const result = await db
+async function testJsonObjectFrom(db: Kysely<Database>) {
+  const r1 = await db
     .selectFrom('blob_test')
     .select((eb) => [
       'id',
-      jsonBuildObject({
-        name: eb.ref('name'),
-        computed: sql<string>`upper(name)`,
-      }).as('obj'),
-    ])
-    .execute()
-
-  expectType<{ id: number; obj: { name: string; computed: string } }[]>(result)
-}
-
-// jsonBuildObject should succeed with untyped sql expressions (unknown)
-async function testJsonBuildObjectWithUntypedSql(db: Kysely<Database>) {
-  const result = await db
-    .selectFrom('blob_test')
-    .select((eb) => [
-      'id',
-      jsonBuildObject({
-        name: eb.ref('name'),
-        one: sql`1`,
-      }).as('obj'),
-    ])
-    .execute()
-
-  expectType<{ id: number; obj: { name: string; one: unknown } }[]>(result)
-}
-
-// jsonArrayFrom should succeed with untyped sql expressions (unknown)
-async function testJsonArrayFromWithUntypedSql(db: Kysely<Database>) {
-  const result = await db
-    .selectFrom('blob_test')
-    .select((eb) => [
-      'id',
-      jsonArrayFrom(
+      jsonObjectFrom(
         eb
           .selectFrom('blob_test')
-          .select(['id', sql`1`.as('one')])
-          .where('blob_test.id', '>', 0),
-      ).as('rows'),
+          .select(['blob_test.id', 'blob_test.name'])
+          .where('blob_test.id', '>', 0)
+          .limit(1),
+      ).as('row'),
     ])
     .execute()
 
-  expectType<{ id: number; rows: { id: number; one: unknown }[] }[]>(result)
-}
+  expectType<{ id: number; row: { id: number; name: string } | null }[]>(r1)
 
-// jsonObjectFrom should succeed with untyped sql expressions (unknown)
-async function testJsonObjectFromWithUntypedSql(db: Kysely<Database>) {
-  const result = await db
+  const r2 = await db
     .selectFrom('blob_test')
     .select((eb) => [
       'id',
@@ -273,113 +125,107 @@ async function testJsonObjectFromWithUntypedSql(db: Kysely<Database>) {
     ])
     .execute()
 
-  expectType<{ id: number; row: { id: number; one: unknown } | null }[]>(result)
-}
+  expectType<{ id: number; row: { id: number; one: unknown } | null }[]>(r2)
 
-// jsonArrayFrom should succeed when Buffer is cast using sql`hex()` (workaround)
-async function testJsonArrayFromWithHexWorkaround(db: Kysely<Database>) {
-  const result = await db
-    .selectFrom('blob_test')
-    .select((eb) => [
-      'id',
-      jsonArrayFrom(
-        eb
-          .selectFrom('blob_test')
-          .select(['id', sql<string>`hex(data)`.as('data_hex')]),
-      ).as('rows'),
-    ])
-    .execute()
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonObjectFrom(
+          eb.selectFrom('blob_test').select(['id', 'data']).limit(1),
+        ).as('row'),
+      ]),
+  )
 
-  expectType<{ id: number; rows: { id: number; data_hex: string }[] }[]>(result)
-}
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonObjectFrom(
+          eb.selectFrom('blob_test').select(['id', 'nullable_data']).limit(1),
+        ).as('row'),
+      ]),
+  )
 
-// jsonArrayFrom should succeed when Buffer is cast using eb.cast<string>() (workaround)
-async function testJsonArrayFromWithCastWorkaround(db: Kysely<Database>) {
-  const result = await db
-    .selectFrom('blob_test')
-    .select((eb) => [
-      'id',
-      jsonArrayFrom(
-        eb
-          .selectFrom('blob_test')
-          .select(['id', eb.cast<string>('data', 'text').as('data_text')]),
-      ).as('rows'),
-    ])
-    .execute()
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonObjectFrom(
+          eb.selectFrom('blob_test').select(['id', 'mixed_data']).limit(1),
+        ).as('row'),
+      ]),
+  )
 
-  expectType<{ id: number; rows: { id: number; data_text: string }[] }[]>(
-    result,
+  expectError(
+    db
+      .selectFrom('blob_test')
+      .select((eb) => [
+        'id',
+        jsonObjectFrom(
+          eb.selectFrom('blob_test').select(['id', 'any_data']),
+        ).as('row'),
+      ]),
   )
 }
 
-// jsonObjectFrom should succeed when Buffer is cast using sql`hex()` (workaround)
-async function testJsonObjectFromWithHexWorkaround(db: Kysely<Database>) {
-  const result = await db
-    .selectFrom('blob_test')
-    .select((eb) => [
-      'id',
-      jsonObjectFrom(
-        eb
-          .selectFrom('blob_test')
-          .select(['id', sql<string>`hex(data)`.as('data_hex')])
-          .limit(1),
-      ).as('row'),
-    ])
-    .execute()
-
-  expectType<{ id: number; row: { id: number; data_hex: string } | null }[]>(
-    result,
-  )
-}
-
-// jsonObjectFrom should succeed when Buffer is cast using eb.cast<string>() (workaround)
-async function testJsonObjectFromWithCastWorkaround(db: Kysely<Database>) {
-  const result = await db
-    .selectFrom('blob_test')
-    .select((eb) => [
-      'id',
-      jsonObjectFrom(
-        eb
-          .selectFrom('blob_test')
-          .select(['id', eb.cast<string>('data', 'text').as('data_text')])
-          .limit(1),
-      ).as('row'),
-    ])
-    .execute()
-
-  expectType<{ id: number; row: { id: number; data_text: string } | null }[]>(
-    result,
-  )
-}
-
-// jsonBuildObject should succeed when Buffer is cast using sql`hex()` (workaround)
-async function testJsonBuildObjectWithHexWorkaround(db: Kysely<Database>) {
-  const result = await db
+async function testJsonBuildObject(db: Kysely<Database>) {
+  const r1 = await db
     .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonBuildObject({
         name: eb.ref('name'),
-        data: sql<string>`hex(data)`,
+        computed: sql<string>`upper(name)`,
       }).as('obj'),
     ])
     .execute()
 
-  expectType<{ id: number; obj: { name: string; data: string } }[]>(result)
-}
+  expectType<{ id: number; obj: { name: string; computed: string } }[]>(r1)
 
-// jsonBuildObject should succeed when Buffer is cast using eb.cast<string>() (workaround)
-async function testJsonBuildObjectWithCastWorkaround(db: Kysely<Database>) {
-  const result = await db
+  const r2 = await db
     .selectFrom('blob_test')
     .select((eb) => [
       'id',
       jsonBuildObject({
         name: eb.ref('name'),
-        data: eb.cast<string>('data', 'text'),
+        one: sql`1`,
       }).as('obj'),
     ])
     .execute()
 
-  expectType<{ id: number; obj: { name: string; data: string } }[]>(result)
+  expectType<{ id: number; obj: { name: string; one: unknown } }[]>(r2)
+
+  expectError(
+    db.selectFrom('blob_test').select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        data: eb.ref('data'),
+      }).as('obj'),
+    ]),
+  )
+
+  expectError(
+    db.selectFrom('blob_test').select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        data: eb.ref('nullable_data'),
+      }).as('obj'),
+    ]),
+  )
+
+  expectError(
+    db.selectFrom('blob_test').select((eb) => [
+      'id',
+      jsonBuildObject({
+        name: eb.ref('name'),
+        data: eb.ref('any_data'),
+      }).as('obj'),
+    ]),
+  )
 }

--- a/test/typings/tsconfig.json
+++ b/test/typings/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,
-    "target": "es2022"
+    "target": "es2022",
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
Hey 👋 

closes #1687.

This PR adds input checks that compile-time error in SQLite's JSON helpers when a `BLOB`-like column exists in the result object type.

It uses a localized `ExtractBlobs` helper type to check whether those objects have at least 1 `BLOB`-like column, and if so, `KyselyTypeError`s the input argument.

----

Original post:

Howdy 🖖,

This PR adds compile-time type checks to SQLite JSON helpers (`jsonArrayFrom`, `jsonObjectFrom`, `jsonBuildObject`) to reject `Buffer`/`Uint8Array` columns.

Passing binary values to JSON functions throws `SqliteError: JSON cannot hold BLOB values`. This change catches common cases at compile time, avoiding the runtime error when using these helpers.

  ### Changes

- Added `HasUint8Array<T>` and `ObjectHasUint8ArrayProperty<O>` type utilities
- SQLite JSON helpers now return `KyselyTypeError` when binary columns are detected
- Error message includes workarounds: `eb.cast(column, "text")` or `` sql`hex(column)` ``