### PR TITLE
fix: emit ON COMMIT clause for CREATE TABLE AS form

### DIFF
--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -639,16 +639,16 @@ export class DefaultQueryCompiler
       this.append(' (')
       this.compileList([...node.columns, ...(node.constraints ?? [])])
       this.append(')')
+    }
 
-      if (node.onCommit) {
-        this.append(' on commit ')
-        this.append(node.onCommit)
-      }
+    if (node.onCommit) {
+      this.append(' on commit ')
+      this.append(node.onCommit)
+    }
 
-      if (node.endModifiers && node.endModifiers.length > 0) {
-        this.append(' ')
-        this.compileList(node.endModifiers, ' ')
-      }
+    if (node.endModifiers && node.endModifiers.length > 0) {
+      this.append(' ')
+      this.compileList(node.endModifiers, ' ')
     }
   }
 

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -1106,6 +1106,26 @@ for (const dialect of DIALECTS) {
 
           await builder.execute()
         })
+
+        it('should create a temporary table with as expression and on commit statement', async () => {
+          const builder = ctx.db.schema
+            .createTable('test')
+            .temporary()
+            .onCommit('drop')
+            .as(ctx.db.selectFrom('person').select(['first_name']))
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: 'create temporary table "test" as select "first_name" from "person" on commit drop',
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
       }
 
       if (dialect === 'postgres' || dialect === 'mssql') {


### PR DESCRIPTION
## Summary

Fixes #1629

When using `.as()` to create a table from a select query, the `onCommit` clause was not being emitted in the compiled SQL.

### Before (broken)
```typescript
db.schema.createTable('a')
  .temporary()
  .onCommit('drop')
  .as(db.selectNoFrom(sql\`'foo' as "foo"\`))
  .compile().sql
// => create temporary table "a" as select 'foo' as "foo"
//    ^ missing ON COMMIT DROP
```

### After (fixed)
```typescript
// => create temporary table "a" as select 'foo' as "foo" on commit drop
```

## Changes

The `onCommit` and `endModifiers` handling was incorrectly nested inside the `else` block (for column definitions). Moved it outside the if/else so it's emitted regardless of whether we're using columns or a select query.

## Testing

Added a test case for `CREATE TABLE AS` with `onCommit('drop')` in the schema tests.