### PR TITLE
feat(postgres): add ALTER TABLE IF EXISTS support

### DIFF
--- a/src/dialect/postgres/postgres-query-compiler.ts
+++ b/src/dialect/postgres/postgres-query-compiler.ts
@@ -1,3 +1,4 @@
+import type { AlterTableNode } from '../../operation-node/alter-table-node.js'
 import { DefaultQueryCompiler } from '../../query-compiler/default-query-compiler.js'
 
 const ID_WRAP_REGEX = /"/g
@@ -5,5 +6,50 @@ const ID_WRAP_REGEX = /"/g
 export class PostgresQueryCompiler extends DefaultQueryCompiler {
   protected override sanitizeIdentifier(identifier: string): string {
     return identifier.replace(ID_WRAP_REGEX, '""')
+  }
+
+  protected override visitAlterTable(node: AlterTableNode): void {
+    this.append('alter table ')
+
+    if (node.ifExists) {
+      this.append('if exists ')
+    }
+
+    this.visitNode(node.table)
+    this.append(' ')
+
+    if (node.renameTo) {
+      this.append('rename to ')
+      this.visitNode(node.renameTo)
+    }
+
+    if (node.setSchema) {
+      this.append('set schema ')
+      this.visitNode(node.setSchema)
+    }
+
+    if (node.addConstraint) {
+      this.visitNode(node.addConstraint)
+    }
+
+    if (node.dropConstraint) {
+      this.visitNode(node.dropConstraint)
+    }
+
+    if (node.renameConstraint) {
+      this.visitNode(node.renameConstraint)
+    }
+
+    if (node.columnAlterations) {
+      this.compileColumnAlterations(node.columnAlterations)
+    }
+
+    if (node.addIndex) {
+      this.visitNode(node.addIndex)
+    }
+
+    if (node.dropIndex) {
+      this.visitNode(node.dropIndex)
+    }
   }
 }

--- a/src/operation-node/alter-table-node.ts
+++ b/src/operation-node/alter-table-node.ts
@@ -15,6 +15,7 @@ import type { RenameConstraintNode } from './rename-constraint-node.js'
 
 export type AlterTableNodeTableProps = Pick<
   AlterTableNode,
+  | 'ifExists'
   | 'renameTo'
   | 'setSchema'
   | 'addConstraint'
@@ -34,6 +35,7 @@ export type AlterTableColumnAlterationNode =
 export interface AlterTableNode extends OperationNode {
   readonly kind: 'AlterTableNode'
   readonly table: TableNode
+  readonly ifExists?: boolean
   readonly renameTo?: TableNode
   readonly setSchema?: IdentifierNode
   readonly columnAlterations?: ReadonlyArray<AlterTableColumnAlterationNode>

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -836,6 +836,7 @@ export class OperationNodeTransformer {
     return requireAllProps<AlterTableNode>({
       kind: 'AlterTableNode',
       table: this.transformNode(node.table, queryId),
+      ifExists: node.ifExists,
       renameTo: this.transformNode(node.renameTo, queryId),
       setSchema: this.transformNode(node.setSchema, queryId),
       columnAlterations: this.transformNodeList(

--- a/src/schema/alter-table-builder.ts
+++ b/src/schema/alter-table-builder.ts
@@ -66,6 +66,22 @@ export class AlterTableBuilder implements ColumnAlteringInterface {
     this.#props = freeze(props)
   }
 
+  /**
+   * Adds the "if exists" modifier.
+   *
+   * If the table doesn't exist, no error is thrown if this method has been called.
+   *
+   * This is supported by PostgreSQL.
+   */
+  ifExists(): AlterTableBuilder {
+    return new AlterTableBuilder({
+      ...this.#props,
+      node: AlterTableNode.cloneWithTableProps(this.#props.node, {
+        ifExists: true,
+      }),
+    })
+  }
+
   renameTo(newTableName: string): AlterTableExecutor {
     return new AlterTableExecutor({
       ...this.#props,

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -2544,6 +2544,27 @@ for (const dialect of DIALECTS) {
           .execute()
       })
 
+      if (dialect === 'postgres') {
+        it('should alter table if exists', async () => {
+          const builder = ctx.db.schema
+            .alterTable('test')
+            .ifExists()
+            .addColumn('date_col', 'date')
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: 'alter table if exists "test" add column "date_col" date',
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
+      }
+
       describe('add column', () => {
         it('should add a column', async () => {
           const builder = ctx.db.schema

--- a/test/typings/test-d/alter-table.test-d.ts
+++ b/test/typings/test-d/alter-table.test-d.ts
@@ -3,6 +3,14 @@ import type { AlterTableBuilder, Kysely } from '..'
 import type { Database } from '../shared'
 import type { AlterTableExecutor } from '../../../dist/cjs/schema/alter-table-executor'
 
+async function testAlterTableIfExists(db: Kysely<Database>) {
+  expectType<AlterTableBuilder>(db.schema.alterTable('test').ifExists())
+
+  expectType<AlterTableExecutor>(
+    db.schema.alterTable('test').ifExists().renameTo('test2'),
+  )
+}
+
 async function testAlterTableWithAddUniqueConstraint(db: Kysely<Database>) {
   expectType<AlterTableBuilder>(db.schema.alterTable('test'))
 


### PR DESCRIPTION
Add support for the PostgreSQL-specific `IF EXISTS` modifier in ALTER TABLE statements. This allows queries to silently succeed when the target table doesn't exist, rather than throwing an error.

Implementation:
- Add `ifExists?: boolean` property to AlterTableNode
- Add `ifExists()` method to AlterTableBuilder
- Override visitAlterTable in PostgresQueryCompiler to emit IF EXISTS

Usage:
```ts
db.schema.alterTable('test')
  .ifExists()
  .addColumn('col', 'text')
  .execute()
```

Generates: `ALTER TABLE IF EXISTS "test" ADD COLUMN "col" text`

Closes #1272