### PR TITLE
perf: optimize PostgresIntrospector `#parseTableMetadata` with Map-based lookups

### DIFF
--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -105,10 +105,17 @@ export class PostgresIntrospector implements DatabaseIntrospector {
   }
 
   #parseTableMetadata(columns: RawColumnMetadata[]): TableMetadata[] {
-    return columns.reduce<TableMetadata[]>((tables, it) => {
-      let table = tables.find(
-        (tbl) => tbl.name === it.table && tbl.schema === it.schema,
-      )
+    const tables: TableMetadata[] = []
+    const tablesBySchema = new Map<string, Map<string, TableMetadata>>()
+    for (const it of columns) {
+      let schemaTables = tablesBySchema.get(it.schema)
+
+      if (!schemaTables) {
+        schemaTables = new Map<string, TableMetadata>()
+        tablesBySchema.set(it.schema, schemaTables)
+      }
+
+      let table = schemaTables.get(it.table)
 
       if (!table) {
         table = freeze({
@@ -118,6 +125,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
           columns: [],
         })
 
+        schemaTables.set(it.table, table)
         tables.push(table)
       }
 
@@ -132,9 +140,9 @@ export class PostgresIntrospector implements DatabaseIntrospector {
           comment: it.column_description ?? undefined,
         }),
       )
+    }
 
-      return tables
-    }, [])
+    return tables
   }
 }
 


### PR DESCRIPTION
## Motivation

When introspecting databases with many schemas and tables, `#parseTableMetadata` becomes a significant bottleneck. The previous implementation used `Array.find()` to locate each table by name and schema on every column iteration, resulting in **O(n²)** complexity. For each of the *n* columns, it scans up to *n* accumulated tables.

I hit this in production with a database containing **40 schemas and ~200 tables each**, where `getTables()` had a noticeable delay just from the in-memory grouping step alone.

## Changes

Replaces the `Array.reduce` + `Array.find` pattern with a `for...of` loop using a nested `Map<schema, Map<table, TableMetadata>>` for O(1) table lookups, bringing overall complexity down to **O(n)**.

Only one file is changed: `src/dialect/postgres/postgres-introspector.ts`.

```diff
-  return columns.reduce<TableMetadata[]>((tables, it) => {
-    let table = tables.find(
-      (tbl) => tbl.name === it.table && tbl.schema === it.schema,
-    )
+  const tables: TableMetadata[] = []
+  const tablesBySchema = new Map<string, Map<string, TableMetadata>>()
+  for (const it of columns) {
+    let schemaTables = tablesBySchema.get(it.schema)
+    if (!schemaTables) {
+      schemaTables = new Map<string, TableMetadata>()
+      tablesBySchema.set(it.schema, schemaTables)
+    }
+    let table = schemaTables.get(it.table)
     if (!table) {
       table = freeze({
         name: it.table,
         isView: it.table_type === 'v',
         schema: it.schema,
         columns: [],
       })
+      schemaTables.set(it.table, table)
       tables.push(table)
     }
     // ... push column as before ...
-    return tables
-  }, [])
+  }
+  return tables
```

No public API changes. Output order is preserved.

## Benchmark Results

Isolated in-memory benchmark of `#parseTableMetadata` with synthetic column data:

| Scenario | Total Columns | Before (ms/call) | After (ms/call) | Speedup |
|---|---|---|---|---|
| Small (1 schema, 5 tables, 5 cols) | 25 | 0.002 | 0.002 | 1.1x |
| Medium (2 schemas, 20 tables, 10 cols) | 400 | 0.051 | 0.026 | **2.0x** |
| Large (3 schemas, 50 tables, 15 cols) | 2,250 | 0.731 | 0.133 | **5.5x** |
| XL (5 schemas, 100 tables, 20 cols) | 10,000 | 11.46 | 0.61 | **18.9x** |
| XXL (10 schemas, 200 tables, 25 cols) | 50,000 | 182.69 | 2.85 | **64x** |

The improvement scales quadratically: negligible for small databases, but **up to 64x faster** for large schemas. The XXL scenario (which approximates my production database) drops from **~183 ms** to **~3 ms** per call.

*Benchmarked on Node.js v25.6.1, Linux. Each result is the median of 5 runs.*

Refs #1707.

---

> **Disclosure:** This PR description was written with AI assistance. The problem identification, solution design, benchmarks, and code review were done manually.
