### PR TITLE
feat: add introspector filtering

### DIFF
--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -26,6 +26,15 @@ export interface DatabaseMetadataOptions {
    * such as the migration tables.
    */
   withInternalKyselyTables: boolean
+
+  /**
+   * Limits the metadata to a list of schemas when provided.
+   */
+  schemas?: string[]
+  /**
+   * Limits the metadata to a list of tables/views when provided.
+   */
+  tables?: string[]
 }
 
 export interface SchemaMetadata {

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -59,6 +59,12 @@ export class MssqlIntrospector implements DatabaseIntrospector {
           .where('tables.name', '!=', DEFAULT_MIGRATION_TABLE)
           .where('tables.name', '!=', DEFAULT_MIGRATION_LOCK_TABLE),
       )
+      .$if(!!options.schemas, (qb) =>
+        qb.where('table_schemas.name', 'in', options.schemas!),
+      )
+      .$if(!!options.tables, (qb) =>
+        qb.where('tables.name', 'in', options.tables!),
+      )
       .select([
         'tables.name as table_name',
         (eb) =>
@@ -110,6 +116,12 @@ export class MssqlIntrospector implements DatabaseIntrospector {
               .onRef('comments.major_id', '=', 'views.object_id')
               .onRef('comments.minor_id', '=', 'columns.column_id')
               .on('comments.name', '=', 'MS_Description'),
+          )
+          .$if(!!options.schemas, (qb) =>
+            qb.where('view_schemas.name', 'in', options.schemas!),
+          )
+          .$if(!!options.tables, (qb) =>
+            qb.where('views.name', 'in', options.tables!),
           )
           .select([
             'views.name as table_name',

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -52,7 +52,17 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         'columns.EXTRA',
         'columns.COLUMN_COMMENT',
       ])
-      .where('columns.TABLE_SCHEMA', '=', sql`database()`)
+    if (options.schemas) {
+      query = query.where('columns.TABLE_SCHEMA', 'in', options.schemas)
+    } else {
+      query = query.where('columns.TABLE_SCHEMA', '=', sql`database()`)
+    }
+
+    if (options.tables) {
+      query = query.where('columns.TABLE_NAME', 'in', options.tables)
+    }
+
+    query = query
       .orderBy('columns.TABLE_NAME')
       .orderBy('columns.ORDINAL_POSITION')
       .$castTo<RawColumnMetadata>()

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -85,6 +85,14 @@ export class PostgresIntrospector implements DatabaseIntrospector {
       .orderBy('a.attnum')
       .$castTo<RawColumnMetadata>()
 
+    if (options.schemas) {
+      query = query.where('ns.nspname', 'in', options.schemas)
+    }
+
+    if (options.tables) {
+      query = query.where('c.relname', 'in', options.tables)
+    }
+
     if (!options.withInternalKyselyTables) {
       query = query
         .where('c.relname', '!=', DEFAULT_MIGRATION_TABLE)

--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -74,6 +74,10 @@ export class SqliteIntrospector implements DatabaseIntrospector {
       .select(['name', 'sql', 'type'])
       .orderBy('name')
 
+    if (options.tables) {
+      tablesQuery = tablesQuery.where('name', 'in', options.tables)
+    }
+
     if (!options.withInternalKyselyTables) {
       tablesQuery = tablesQuery
         .where('name', '!=', DEFAULT_MIGRATION_TABLE)

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -479,11 +479,11 @@ export class Migrator {
 
     const tables = await this.#props.db.introspection.getTables({
       withInternalKyselyTables: true,
+      schemas: schema ? [schema] : undefined,
+      tables: [tableName],
     })
 
-    return tables.some(
-      (it) => it.name === tableName && (!schema || it.schema === schema),
-    )
+    return tables.length > 0
   }
 
   async #doesLockRowExists(): Promise<boolean> {

--- a/test/node/src/introspect.test.ts
+++ b/test/node/src/introspect.test.ts
@@ -873,6 +873,71 @@ for (const dialect of DIALECTS) {
       }
     })
 
+    describe('getTables (filters)', () => {
+      it('should filter by tables', async () => {
+        const tables = await ctx.db.introspection.getTables({
+          tables: ['person', 'pet'],
+          withInternalKyselyTables: false,
+        })
+
+        if (dialect === 'postgres' || dialect === 'mssql') {
+          expect(tables).to.have.length(3)
+          expect(tables.map((it) => it.name).sort()).to.eql([
+            'person',
+            'pet',
+            'pet',
+          ])
+        } else {
+          expect(tables).to.have.length(2)
+          expect(tables.map((it) => it.name).sort()).to.eql(['person', 'pet'])
+        }
+      })
+
+      if (
+        dialect === 'postgres' ||
+        dialect === 'mssql' ||
+        dialect === 'mysql'
+      ) {
+        it('should filter by schema', async () => {
+          const schema =
+            dialect === 'postgres'
+              ? 'some_schema'
+              : dialect === 'mssql'
+                ? 'some_schema'
+                : 'kysely_test'
+
+          const tables = await ctx.db.introspection.getTables({
+            schemas: [schema],
+            withInternalKyselyTables: false,
+          })
+
+          expect(tables).to.not.be.empty
+          tables.forEach((table) => {
+            expect(table.schema).to.equal(schema)
+          })
+        })
+
+        it('should filter by schema and tables', async () => {
+          const schema =
+            dialect === 'postgres'
+              ? 'some_schema'
+              : dialect === 'mssql'
+                ? 'some_schema'
+                : 'kysely_test'
+
+          const tables = await ctx.db.introspection.getTables({
+            schemas: [schema],
+            tables: ['pet'],
+            withInternalKyselyTables: false,
+          })
+
+          expect(tables).to.have.length(1)
+          expect(tables[0].name).to.equal('pet')
+          expect(tables[0].schema).to.equal(schema)
+        })
+      }
+    })
+
     async function createView() {
       ctx.db.schema
         .createView('toy_names')


### PR DESCRIPTION
## Motivation

When calling `migrateToLatest()`, the migrator calls `#doesTableExist` to check for the migration and lock tables. Currently this fetches **every table in every schema** via `getTables()` and filters in JavaScript:

```typescript
const tables = await this.#props.db.introspection.getTables({
  withInternalKyselyTables: true,
})
return tables.some(
  (it) => it.name === tableName && (!schema || it.schema === schema),
)
```

With large databases (e.g. 40 schemas, 200 tables each), this means introspecting ~8,000 tables and ~50,000 columns **twice**, just to check if 2 specific tables exist. This is the dominant contributor to the **~500s startup time** I observed in production.

## Changes

### 1. New `schemas` and `tables` filter options

Added two optional fields to `DatabaseMetadataOptions`:

```typescript
export interface DatabaseMetadataOptions {
  withInternalKyselyTables: boolean
  schemas?: string[]   // Limits metadata to specific schemas
  tables?: string[]    // Limits metadata to specific tables/views
}
```

Both are optional and backward-compatible. When both are provided, they act as an **AND** filter (schema ∩ tables).

### 2. All 4 dialect introspectors updated

- **Postgres**: Adds `WHERE ns.nspname IN (...)` and `WHERE c.relname IN (...)`.
- **MySQL**: Adds `WHERE columns.TABLE_SCHEMA IN (...)` (overrides the default `database()` filter) and `WHERE columns.TABLE_NAME IN (...)`.
- **MSSQL**: Uses the existing `.$if()` pattern to filter both the tables and views queries.
- **SQLite**: Adds `WHERE name IN (...)` for tables (schemas not applicable).

### 3. Optimized `#doesTableExist` in migrator

```diff
 const tables = await this.#props.db.introspection.getTables({
   withInternalKyselyTables: true,
+  schemas: schema ? [schema] : undefined,
+  tables: [tableName],
 })
-return tables.some(
-  (it) => it.name === tableName && (!schema || it.schema === schema),
-)
+return tables.length > 0
```

Instead of fetching all tables and filtering in JS, this now queries for only the exact table it needs. This reduces startup from **~500s down to seconds** in large-schema environments.

### 4. Tests

New `getTables (filters)` test suite in `introspect.test.ts` with 3 tests:

| Test | Dialects | Verifies |
|---|---|---|
| filter by tables | All | Filtering to `person` + `pet` returns correct count |
| filter by schema | PG, MSSQL, MySQL | Results only contain the requested schema |
| filter by schema + tables | PG, MSSQL, MySQL | AND filter returns single matching result |

## Benchmark Results

Full roundtrip benchmark (`getTables()` SQL query → parse) across all dialects, comparing "Fetch All" vs "Fetch Filtered (1 table)":

| Scale | Specs | Postgres | MySQL | MSSQL | SQLite |
|---|---|---|---|---|---|
| **S** | 1 sc, 10 tb | 4.8 → 2.5 ms | 2.3 → 1.6 ms | 125 → 47 ms | 0.9 → 0.6 ms |
| **M** | 5 sc, 50 tb | 5.1 → 2.4 ms | 3.6 → 1.5 ms | 60 → 48 ms | 1.1 → 0.5 ms |
| **L** | 10 sc, 100 tb | 8.2 → 3.5 ms | 5.6 → 1.7 ms | 342 → 45 ms | 1.0 → 0.4 ms |
| **XL** | 20 sc, 500 tb | 22.4 → 3.3 ms (**6.8x**) | 16.1 → 2.1 ms (**7.7x**) | 334 → 44 ms (**7.6x**) | 4.7 → 0.4 ms (**12x**) |
| **XXL** | 50 sc, 1000 tb | **44.1 → 2.0 ms (22x)** | **37.4 → 1.8 ms (21x)** | **241 → 46 ms (5x)** | **6.5 → 0.9 ms (7x)** |

*sc = schema, tb = table. MSSQL benchmarked with single schema due to test environment limitations. SQLite has no schema support. Node.js v25.6.1, Linux.*

Refs #1707.

---

> **Disclosure:** This PR description was written with AI assistance. The problem identification, solution design, benchmarks, and code review were done manually.
