### PR TITLE
Add Node SQLite link to dialects documentation

### DIFF
--- a/site/docs/dialects.md
+++ b/site/docs/dialects.md
@@ -34,6 +34,7 @@ A dialect is the glue between Kysely and the underlying database engine. Check t
 | Fetch driver                  | https://github.com/andersgee/kysely-fetch-driver                            |
 | SQLite WASM                   | https://github.com/DallasHoff/sqlocal                                       |
 | Deno SQLite                   | https://gitlab.com/soapbox-pub/kysely-deno-sqlite                           |
+| Node SQLite                   | https://github.com/wolfie/kysely-node-native-sqlite)                        |
 | TiDB Cloud Serverless Driver  | https://github.com/tidbcloud/kysely                                         |
 | Capacitor SQLite Kysely       | https://github.com/DawidWetzler/capacitor-sqlite-kysely                     |
 | BigQuery                      | https://github.com/maktouch/kysely-bigquery                                 |


### PR DESCRIPTION
I wrote a thin wrapper around the [native node SQLite module](https://nodejs.org/api/sqlite.html). Feel free to link to it if you wish.