### PR TITLE
fix: use file specifiers for absolute paths in file-migration-provider

### DIFF
--- a/src/migration/file-migration-provider.ts
+++ b/src/migration/file-migration-provider.ts
@@ -35,11 +35,14 @@ export class FileMigrationProvider implements MigrationProvider {
         fileName.endsWith('.mjs') ||
         (fileName.endsWith('.mts') && !fileName.endsWith('.d.mts'))
       ) {
+        const importPath = this.#props.path.join(
+          this.#props.migrationFolder,
+          fileName,
+        )
         const migration = await import(
-          /* webpackIgnore: true */ this.#props.path.join(
-            this.#props.migrationFolder,
-            fileName,
-          )
+          /* webpackIgnore: true */ importPath.startsWith('/')
+            ? `file://${importPath}`
+            : importPath
         )
         const migrationKey = fileName.substring(0, fileName.lastIndexOf('.'))
 


### PR DESCRIPTION
This is necessary for Deno + JSR, as because an absolute path inside a JSR package in Deno refers to the root of the JSR server, not of the system being run on. Specifying that its a file path ensures that this works as expected in Deno.