### PR TITLE
feat: add `datetime2` column data type

### DIFF
--- a/src/operation-node/data-type-node.ts
+++ b/src/operation-node/data-type-node.ts
@@ -22,6 +22,7 @@ const SIMPLE_COLUMN_DATA_TYPES = [
   'bytea',
   'date',
   'datetime',
+  'datetime2',
   'time',
   'timetz',
   'timestamp',
@@ -54,6 +55,7 @@ const COLUMN_DATA_TYPE_REGEX = [
   /^numeric\(\d+, \d+\)$/,
   /^binary\(\d+\)$/,
   /^datetime\(\d+\)$/,
+  /^datetime2\(\d+\)$/,
   /^time\(\d+\)$/,
   /^timetz\(\d+\)$/,
   /^timestamp\(\d+\)$/,
@@ -71,6 +73,7 @@ export type ColumnDataType =
   | `numeric(${number}, ${number})`
   | `binary(${number})`
   | `datetime(${number})`
+  | `datetime2(${number})`
   | `time(${number})`
   | `timetz(${number})`
   | `timestamp(${number})`

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -334,7 +334,7 @@ for (const dialect of DIALECTS) {
             .addColumn('r', 'double precision', (col) => col.notNull())
             .addColumn('s', 'time(6)')
             .addColumn('t', 'timestamp', (col) => col.notNull())
-            .addColumn('u', sql`datetime2`)
+            .addColumn('u', 'datetime2')
             .addColumn('v', 'char(4)')
             .addColumn('w', 'char')
             .addColumn('x', 'binary')


### PR DESCRIPTION
Hey 👋

Closes #1596.

Adds `datetime2` as a recognized column data type for MSSQL, alongside the existing `datetime` type.

## Changes

- Added `'datetime2'` to `SIMPLE_COLUMN_DATA_TYPES` in `data-type-node.ts`
- Added `/^datetime2\(\d+\)$/` to `COLUMN_DATA_TYPE_REGEX` for precision support (e.g. `datetime2(7)`)
- Added ```datetime2(${number})``` to the `ColumnDataType` union
- Updated the MSSQL schema test to use `'datetime2'` string literal directly instead of the  sql`datetime2`  workaround

## Context

`datetime` in MSSQL only stores fractional seconds to ~3.33 ms accuracy (rounding to 0, 3, or 7 ms), whereas `datetime2` supports up to 100-nanosecond precision. Kysely users currently have to use  sql`datetime2`  as a workaround; this PR makes it a first-class data type.