### PR TITLE
docs: document immediate value behavior in case().then() and case().else()

### DIFF
--- a/src/parser/value-parser.ts
+++ b/src/parser/value-parser.ts
@@ -56,12 +56,29 @@ export function parseValueExpression(
   return ValueNode.create(exp)
 }
 
+/**
+ * Returns true for primitive values that are safe to embed directly in the SQL
+ * string as immediate literals: numbers, booleans and null.
+ *
+ * Strings are intentionally excluded — they must always be parameterized to
+ * prevent SQL injection. Use `eb.lit()` or `sql` to embed strings inline.
+ *
+ * This is used by {@link CaseThenBuilder.then} and {@link CaseWhenBuilder.else}
+ * to decide whether a value should be an immediate literal or a query parameter.
+ */
 export function isSafeImmediateValue(
   value: unknown,
 ): value is number | boolean | null {
   return isNumber(value) || isBoolean(value) || isNull(value)
 }
 
+/**
+ * Creates an immediate {@link ValueNode} for a safe primitive value (number,
+ * boolean or null). The value is embedded directly in the SQL string rather
+ * than sent as a query parameter.
+ *
+ * Throws if the value is not a safe immediate value (e.g. a string).
+ */
 export function parseSafeImmediateValue(
   value: number | boolean | null,
 ): ValueNode {

--- a/src/query-builder/case-builder.ts
+++ b/src/query-builder/case-builder.ts
@@ -75,6 +75,18 @@ export class CaseThenBuilder<DB, TB extends keyof DB, W, O> {
    *
    * A `then` call can be followed by {@link Whenable.when}, {@link CaseWhenBuilder.else},
    * {@link CaseWhenBuilder.end} or {@link CaseWhenBuilder.endCase} call.
+   *
+   * ### Immediate values
+   *
+   * Unlike most value-first methods in Kysely (which append values as query parameters),
+   * `then` injects `number`, `boolean`, and `null` values **directly into the SQL string**
+   * as immediate literals. This is intentional — `eb.lit()` is not allowed inside `then`,
+   * so safe primitive types are embedded inline instead.
+   *
+   * For example, `.then(1)` produces `then 1` in SQL, not `then $1`.
+   *
+   * Strings are always parameterized. To pass a string as an immediate value,
+   * wrap it with {@link ExpressionBuilder.val | eb.val()} or {@link sql}.
    */
   then<E extends Expression<unknown>>(
     expression: E,
@@ -137,6 +149,16 @@ export class CaseWhenBuilder<DB, TB extends keyof DB, W, O>
    * Adds an `else` clause to the `case` statement.
    *
    * An `else` call must be followed by an {@link Endable.end} or {@link Endable.endCase} call.
+   *
+   * ### Immediate values
+   *
+   * Like {@link CaseThenBuilder.then}, `else` injects `number`, `boolean`, and `null` values
+   * **directly into the SQL string** as immediate literals rather than query parameters.
+   *
+   * For example, `.else(0)` produces `else 0` in SQL, not `else $1`.
+   *
+   * Strings are always parameterized. To pass a string as an immediate value,
+   * wrap it with {@link ExpressionBuilder.val | eb.val()} or {@link sql}.
    */
   else<E extends Expression<unknown>>(
     expression: E,


### PR DESCRIPTION
Closes #1593

The `then` and `else` methods on `CaseBuilder` have a subtlety that isn't documented anywhere: unlike most value-first methods in Kysely (which append values as query parameters), they inject `number`, `boolean`, and `null` directly into the SQL string as immediate literals.

This is surprising because the rest of the API consistently parameterizes values — only `eb.lit()` / `sql` are supposed to produce inline literals. The behavior exists because `eb.lit('string')` is not allowed inside `then`/`else`, so safe primitives are embedded inline as a workaround.

**Changes:**
- Added a **"Immediate values"** section to the JSDoc for `CaseThenBuilder.then` explaining the inline-embedding behavior and noting that strings are still parameterized
- Added the same section to `CaseWhenBuilder.else`
- Added JSDoc to `isSafeImmediateValue` and `parseSafeImmediateValue` in `value-parser.ts` explaining their purpose and why strings are excluded