### PR TITLE
fix: update MysqlPoolConnection.query parameters type for mysql2 v3.18.2 compatibility

### DIFF
--- a/src/dialect/mysql/mysql-dialect-config.ts
+++ b/src/dialect/mysql/mysql-dialect-config.ts
@@ -41,14 +41,31 @@ export interface MysqlPool {
   end(callback: (error: unknown) => void): void
 }
 
+/**
+ * Values that can be passed as query parameters to mysql2.
+ * Compatible with mysql2 v3.18.2+ QueryValues type.
+ */
+export type MysqlQueryValues =
+  | string
+  | number
+  | bigint
+  | boolean
+  | Date
+  | null
+  | undefined
+  | Uint8Array
+  | { toSqlString(): string }
+  | Array<{} | null | undefined>
+  | { [key: string]: MysqlQueryValues }
+
 export interface MysqlPoolConnection {
   query(
     sql: string,
-    parameters: ReadonlyArray<unknown>,
+    parameters: MysqlQueryValues | ReadonlyArray<unknown>,
   ): { stream: <T>(options: MysqlStreamOptions) => MysqlStream<T> }
   query(
     sql: string,
-    parameters: ReadonlyArray<unknown>,
+    parameters: MysqlQueryValues | ReadonlyArray<unknown>,
     callback: (error: unknown, result: MysqlQueryResult) => void,
   ): void
   release(): void


### PR DESCRIPTION
Fixes #1722

## Changes
- Add MysqlQueryValues type matching mysql2's QueryValues
- Update query method signature to accept both MysqlQueryValues and ReadonlyArray<unknown>
- Maintains backward compatibility while supporting mysql2 v3.18.2+

## Testing
Type checking passes, backward compatible with existing code.