### PR TITLE
fix(mysql): use readonly any[] for query parameters to fix mysql2 v3.18.2 compatibility

### DIFF
--- a/src/dialect/mysql/mysql-dialect-config.ts
+++ b/src/dialect/mysql/mysql-dialect-config.ts
@@ -44,11 +44,11 @@ export interface MysqlPool {
 export interface MysqlPoolConnection {
   query(
     sql: string,
-    parameters: ReadonlyArray<unknown>,
+    parameters: readonly any[],
   ): { stream: <T>(options: MysqlStreamOptions) => MysqlStream<T> }
   query(
     sql: string,
-    parameters: ReadonlyArray<unknown>,
+    parameters: readonly any[],
     callback: (error: unknown, result: MysqlQueryResult) => void,
   ): void
   release(): void


### PR DESCRIPTION
## Problem

`mysql2@v3.18.2` narrowed the `query()` parameters type from `any` to a specific `QueryValues` union (see [mysql2#4129](https://github.com/sidorares/node-mysql2/pull/4129)). This broke the structural type check between mysql2's `PoolConnection` and Kysely's `MysqlPoolConnection`: neither `QueryValues` nor `ReadonlyArray<unknown>` is assignable to the other, so TypeScript rejects valid pool instances.

## Fix

Changed `parameters: ReadonlyArray<unknown>` to `parameters: readonly any[]` in both overloads of `MysqlPoolConnection.query`.

- **External**: the bivariance check for method signatures now passes — `readonly any[]` is assignable to `QueryValues` (covers the array branch), making mysql2's `PoolConnection` assignable to `MysqlPoolConnection`.
- **Internal**: `ReadonlyArray<unknown>` (from `CompiledQuery.parameters`) remains assignable to `readonly any[]` since `unknown` is assignable to `any`.
- **Future-proof**: using a deliberately wide type means minor mysql2 type changes won't require another fix.

Fixes #1722