### PR TITLE
feat(mysql): Update types for `mysql2@v3.18.2 ` support #1722

### DIFF
--- a/src/dialect/mysql/mysql-dialect-config.ts
+++ b/src/dialect/mysql/mysql-dialect-config.ts
@@ -44,11 +44,11 @@ export interface MysqlPool {
 export interface MysqlPoolConnection {
   query(
     sql: string,
-    parameters: ReadonlyArray<unknown>,
+    parameters: Array<unknown>,
   ): { stream: <T>(options: MysqlStreamOptions) => MysqlStream<T> }
   query(
     sql: string,
-    parameters: ReadonlyArray<unknown>,
+    parameters: Array<unknown>,
     callback: (error: unknown, result: MysqlQueryResult) => void,
   ): void
   release(): void

--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -210,7 +210,7 @@ class MysqlConnection implements DatabaseConnection {
     return new Promise((resolve, reject) => {
       this.#rawConnection.query(
         compiledQuery.sql,
-        compiledQuery.parameters,
+        compiledQuery.parameters as Array<unknown>,
         (err, result) => {
           if (err) {
             reject(err)
@@ -227,7 +227,7 @@ class MysqlConnection implements DatabaseConnection {
     _chunkSize: number,
   ): AsyncIterableIterator<QueryResult<O>> {
     const stream = this.#rawConnection
-      .query(compiledQuery.sql, compiledQuery.parameters)
+      .query(compiledQuery.sql, compiledQuery.parameters as Array<unknown>)
       .stream<O>({
         objectMode: true,
       })


### PR DESCRIPTION
Fixes #1722. Tested with:
- mysql2@3.16.2
- mysql2@3.18.1
- mysql2@3.18.2
- mysql2@3.19.0