### PR TITLE
fix: emit ON COMMIT clause when using CREATE TABLE AS expression

### DIFF
--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -633,6 +633,11 @@ export class DefaultQueryCompiler
     this.visitNode(node.table)
 
     if (node.selectQuery) {
+      if (node.onCommit) {
+        this.append(' on commit ')
+        this.append(node.onCommit)
+      }
+
       this.append(' as ')
       this.visitNode(node.selectQuery)
     } else {

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -1106,6 +1106,26 @@ for (const dialect of DIALECTS) {
 
           await builder.execute()
         })
+
+        it('should create a temporary table with on commit statement using as expression', async () => {
+          const builder = ctx.db.schema
+            .createTable('test')
+            .temporary()
+            .onCommit('drop')
+            .as(ctx.db.selectNoFrom(sql`'foo'`.as('foo')))
+
+          testSql(builder, dialect, {
+            postgres: {
+              sql: `create temporary table "test" on commit drop as select 'foo' as "foo"`,
+              parameters: [],
+            },
+            mysql: NOT_SUPPORTED,
+            mssql: NOT_SUPPORTED,
+            sqlite: NOT_SUPPORTED,
+          })
+
+          await builder.execute()
+        })
       }
 
       if (dialect === 'postgres' || dialect === 'mssql') {


### PR DESCRIPTION
## Problem

When using `createTable(...).temporary().onCommit('drop').as(selectQuery)`, the `ON COMMIT` clause is silently dropped because it was only emitted inside the column-list branch of `visitCreateTable`, never when a SELECT query is used with the `AS` form.

Repro from #1629:
```ts
db.schema.createTable('a').temporary().onCommit('drop').as(db.selectNoFrom(sql`'foo'`.as('foo'))).compile().sql
// produces: create temporary table "a" as select 'foo' as "foo"
// expected: create temporary table "a" on commit drop as select 'foo' as "foo"
```

## Root Cause

In `default-query-compiler.ts`, `visitCreateTable` only appends `on commit ...` inside the `else` block (when columns are specified). When `node.selectQuery` is present, the code takes the other branch and never emits the clause.

## Fix

Add the `ON COMMIT` clause inside the `selectQuery` branch as well, placed _before_ the `AS` keyword — which matches the PostgreSQL syntax:

```sql
CREATE TEMPORARY TABLE t ON COMMIT DROP AS SELECT 'foo' AS foo;
```

## Changes

- `src/query-compiler/default-query-compiler.ts`: move `ON COMMIT` emission into the `selectQuery` branch
- `test/node/src/schema.test.ts`: add a test covering `createTable().temporary().onCommit('drop').as(...)`

Fixes #1629