### PR TITLE
Add datetime2 data type support for MSSQL

### DIFF
--- a/src/operation-node/data-type-node.ts
+++ b/src/operation-node/data-type-node.ts
@@ -22,6 +22,7 @@ export type SimpleColumnDataType =
   | 'bytea'
   | 'date'
   | 'datetime'
+  | 'datetime2'
   | 'time'
   | 'timetz'
   | 'timestamp'
@@ -59,6 +60,7 @@ const SIMPLE_COLUMN_DATA_TYPES: Readonly<Record<SimpleColumnDataType, true>> =
     datemultirange: true,
     daterange: true,
     datetime: true,
+    datetime2: true,
     decimal: true,
     'double precision': true,
     float4: true,
@@ -101,6 +103,7 @@ const COLUMN_DATA_TYPE_REGEX: readonly RegExp[] = freeze([
   /^numeric\(\d+, \d+\)$/,
   /^binary\(\d+\)$/,
   /^datetime\(\d+\)$/,
+  /^datetime2\(\d+\)$/,
   /^time\(\d+\)$/,
   /^timetz\(\d+\)$/,
   /^timestamp\(\d+\)$/,
@@ -116,6 +119,7 @@ export type ColumnDataType =
   | `numeric(${number}, ${number})`
   | `binary(${number})`
   | `datetime(${number})`
+  | `datetime2(${number})`
   | `time(${number})`
   | `timetz(${number})`
   | `timestamp(${number})`

--- a/test/node/src/schema.test.ts
+++ b/test/node/src/schema.test.ts
@@ -336,7 +336,7 @@ for (const dialect of DIALECTS) {
             .addColumn('r', 'double precision', (col) => col.notNull())
             .addColumn('s', 'time(6)')
             .addColumn('t', 'timestamp', (col) => col.notNull())
-            .addColumn('u', sql`datetime2`)
+            .addColumn('u', 'datetime2')
             .addColumn('v', 'char(4)')
             .addColumn('w', 'char')
             .addColumn('x', 'binary')


### PR DESCRIPTION
Fixes #1596

## Summary
Adds `datetime2` as a recognized column data type for MSSQL. MSSQL's `datetime` type only stores time to ~3.33ms accuracy, causing rounding issues when storing JavaScript dates. The `datetime2` type provides better precision (100ns increments).

## Changes
- Added `datetime2` to `SIMPLE_COLUMN_DATA_TYPES` array
- Added `datetime2(\d+)` regex pattern to `COLUMN_DATA_TYPE_REGEX` for parameterized precision
- Added `datetime2` and `datetime2(${number})` to `ColumnDataType` type union
- Updated test to use `'datetime2'` instead of `sql\`datetime2\``

## Testing
- TypeScript compiles without errors
- `isColumnDataType('datetime2')` returns `true`
- `isColumnDataType('datetime2(7)')` returns `true`

```bash
git diff --stat HEAD~1
 src/operation-node/data-type-node.ts | 3 +++
 test/node/src/schema.test.ts         | 2 +-
 2 files changed, 4 insertions(+), 1 deletion(-)
```