### PR TITLE
feat: add .as() to InsertQueryBuilder for INSERT INTO table AS alias

### DIFF
--- a/src/operation-node/insert-query-node.ts
+++ b/src/operation-node/insert-query-node.ts
@@ -1,4 +1,5 @@
 import { freeze } from '../util/object-utils.js'
+import type { AliasNode } from './alias-node.js'
 import type { ColumnNode } from './column-node.js'
 import type { ExplainNode } from './explain-node.js'
 import type { OnConflictNode } from './on-conflict-node.js'
@@ -15,7 +16,7 @@ export type InsertQueryNodeProps = Omit<InsertQueryNode, 'kind' | 'into'>
 
 export interface InsertQueryNode extends OperationNode {
   readonly kind: 'InsertQueryNode'
-  readonly into?: TableNode
+  readonly into?: TableNode | AliasNode
   readonly columns?: ReadonlyArray<ColumnNode>
   readonly values?: OperationNode
   readonly returning?: ReturningNode
@@ -37,7 +38,7 @@ export interface InsertQueryNode extends OperationNode {
 type InsertQueryNodeFactory = Readonly<{
   is(node: OperationNode): node is InsertQueryNode
   create(
-    into: TableNode,
+    into: TableNode | AliasNode,
     withNode?: WithNode,
     replace?: boolean,
   ): Readonly<InsertQueryNode>
@@ -45,6 +46,10 @@ type InsertQueryNodeFactory = Readonly<{
   cloneWith(
     insertQuery: InsertQueryNode,
     props: InsertQueryNodeProps,
+  ): Readonly<InsertQueryNode>
+  cloneWithInto(
+    insertQuery: InsertQueryNode,
+    into: TableNode | AliasNode,
   ): Readonly<InsertQueryNode>
 }>
 
@@ -76,6 +81,13 @@ export const InsertQueryNode: InsertQueryNodeFactory =
       return freeze({
         ...insertQuery,
         ...props,
+      })
+    },
+
+    cloneWithInto(insertQuery, into) {
+      return freeze({
+        ...insertQuery,
+        into,
       })
     },
   })

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -67,6 +67,8 @@ import type {
   SelectExpressionFromOutputExpression,
 } from './output-interface.js'
 import { OrActionNode } from '../operation-node/or-action-node.js'
+import { AliasNode } from '../operation-node/alias-node.js'
+import { IdentifierNode } from '../operation-node/identifier-node.js'
 
 export class InsertQueryBuilder<DB, TB extends keyof DB, O>
   implements
@@ -81,6 +83,43 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
 
   constructor(props: InsertQueryBuilderProps) {
     this.#props = freeze(props)
+  }
+
+  /**
+   * Adds an alias for the inserted table.
+   *
+   * This is useful when using `ON CONFLICT DO UPDATE` to reference
+   * the row being inserted via its alias.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * const result = await db.insertInto('person')
+   *   .as('p')
+   *   .values({ first_name: 'Jennifer', last_name: 'Aniston', age: 40 })
+   *   .onConflict((oc) => oc
+   *     .column('first_name')
+   *     .doUpdateSet((eb) => ({ age: eb.ref('p.age') }))
+   *   )
+   *   .executeTakeFirst()
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * insert into "person" as "p" ("first_name", "last_name", "age") values ($1, $2, $3) on conflict ("first_name") do update set "age" = "p"."age"
+   * ```
+   */
+  as(alias: string): InsertQueryBuilder<DB, TB, O> {
+    const { queryNode } = this.#props
+
+    return new InsertQueryBuilder({
+      ...this.#props,
+      queryNode: InsertQueryNode.cloneWithInto(
+        queryNode,
+        AliasNode.create(queryNode.into!, IdentifierNode.create(alias)),
+      ),
+    })
   }
 
   /**

--- a/test/node/src/insert.test.ts
+++ b/test/node/src/insert.test.ts
@@ -668,6 +668,31 @@ for (const dialect of DIALECTS) {
           name: 'Catto',
         })
       })
+
+      it('should alias the inserted table using `as`', async () => {
+        const query = ctx.db
+          .insertInto('pet')
+          .as('p')
+          .values({
+            name: 'Hammy',
+            owner_id: 1,
+            species: 'hamster',
+          })
+          .onConflict((oc) => oc.column('name').doNothing())
+
+        testSql(query, dialect, {
+          postgres: {
+            sql: 'insert into "pet" as "p" ("name", "owner_id", "species") values ($1, $2, $3) on conflict ("name") do nothing',
+            parameters: ['Hammy', 1, 'hamster'],
+          },
+          mysql: NOT_SUPPORTED,
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: 'insert into "pet" as "p" ("name", "owner_id", "species") values (?, ?, ?) on conflict ("name") do nothing',
+            parameters: ['Hammy', 1, 'hamster'],
+          },
+        })
+      })
     }
 
     it('should insert multiple rows', async () => {


### PR DESCRIPTION
Fixes #731

Adds an `.as(alias)` method to `InsertQueryBuilder` so you can alias the target table in an INSERT statement. This is particularly useful with `ON CONFLICT DO UPDATE` where you need to reference the row being inserted via a stable alias rather than the `excluded` pseudo-table.

```ts
await db.insertInto('person')
  .as('p')
  .values({ first_name: 'Jennifer', last_name: 'Aniston', age: 40 })
  .onConflict((oc) => oc
    .column('first_name')
    .doUpdateSet((eb) => ({ age: eb.ref('p.age') }))
  )
  .executeTakeFirst()
// insert into "person" as "p" ("first_name", "last_name", "age") values ($1, $2, $3) on conflict ("first_name") do update set "age" = "p"."age"
```

### Changes
- `InsertQueryNode.into` type widened to `TableNode | AliasNode` (mirrors how `MergeQueryNode` handles aliases)
- `InsertQueryNode.cloneWithInto()` factory helper added
- `InsertQueryBuilder.as(alias)` method added
- Test case added covering PostgreSQL and SQLite

The query compiler's existing `visitAlias` already emits `node as alias`, so no compiler changes are needed.