### PR TITLE
feat: support expressions in partitionBy

### DIFF
--- a/src/operation-node/partition-by-item-node.ts
+++ b/src/operation-node/partition-by-item-node.ts
@@ -1,17 +1,14 @@
 import { freeze } from '../util/object-utils.js'
 import type { OperationNode } from './operation-node.js'
-import type { SimpleReferenceExpressionNode } from './simple-reference-expression-node.js'
 
 export interface PartitionByItemNode extends OperationNode {
   readonly kind: 'PartitionByItemNode'
-  readonly partitionBy: SimpleReferenceExpressionNode
+  readonly partitionBy: OperationNode
 }
 
 type PartitionByItemNodeFactory = Readonly<{
   is(node: OperationNode): node is PartitionByItemNode
-  create(
-    partitionBy: SimpleReferenceExpressionNode,
-  ): Readonly<PartitionByItemNode>
+  create(partitionBy: OperationNode): Readonly<PartitionByItemNode>
 }>
 
 /**

--- a/src/parser/partition-by-parser.ts
+++ b/src/parser/partition-by-parser.ts
@@ -1,14 +1,19 @@
 import type { DynamicReferenceBuilder } from '../dynamic/dynamic-reference-builder.js'
 import { PartitionByItemNode } from '../operation-node/partition-by-item-node.js'
-import type { SimpleReferenceExpressionNode } from '../operation-node/simple-reference-expression-node.js'
 import {
-  parseReferenceExpressionOrList,
+  type ExpressionOrFactory,
+  isExpressionOrFactory,
+  parseExpression,
+} from './expression-parser.js'
+import {
+  parseSimpleReferenceExpression,
   type StringReference,
 } from './reference-parser.js'
 
 export type PartitionByExpression<DB, TB extends keyof DB> =
   | StringReference<DB, TB>
   | DynamicReferenceBuilder<any>
+  | ExpressionOrFactory<DB, TB, any>
 
 export type PartitionByExpressionOrList<DB, TB extends keyof DB> =
   | ReadonlyArray<PartitionByExpression<DB, TB>>
@@ -17,9 +22,11 @@ export type PartitionByExpressionOrList<DB, TB extends keyof DB> =
 export function parsePartitionBy(
   partitionBy: PartitionByExpressionOrList<any, any>,
 ): PartitionByItemNode[] {
-  return (
-    parseReferenceExpressionOrList(
-      partitionBy,
-    ) as SimpleReferenceExpressionNode[]
-  ).map(PartitionByItemNode.create)
+  const items = Array.isArray(partitionBy) ? partitionBy : [partitionBy]
+  return items.map((item) => {
+    if (isExpressionOrFactory(item)) {
+      return PartitionByItemNode.create(parseExpression(item))
+    }
+    return PartitionByItemNode.create(parseSimpleReferenceExpression(item))
+  })
 }

--- a/test/node/src/aggregate-function.test.ts
+++ b/test/node/src/aggregate-function.test.ts
@@ -412,6 +412,53 @@ for (const dialect of DIALECTS) {
           await query.execute()
         })
 
+        it(`should execute a query with ${funcName}(column) over(partition by expression) in select clause`, async () => {
+          const query = ctx.db.selectFrom('person').select((eb) =>
+            func('id')
+              .over((ob) =>
+                ob.partitionBy([eb.fn.coalesce('first_name', 'last_name')]),
+              )
+              .as(funcName),
+          )
+
+          testSql(query, dialect, {
+            postgres: {
+              sql: [
+                `select ${funcName}("id")`,
+                `over(partition by coalesce("first_name", "last_name")) as "${funcName}"`,
+                `from "person"`,
+              ],
+              parameters: [],
+            },
+            mysql: {
+              sql: [
+                `select ${funcName}(\`id\`)`,
+                `over(partition by coalesce(\`first_name\`, \`last_name\`)) as \`${funcName}\``,
+                `from \`person\``,
+              ],
+              parameters: [],
+            },
+            mssql: {
+              sql: [
+                `select ${funcName}("id")`,
+                `over(partition by coalesce("first_name", "last_name")) as "${funcName}"`,
+                `from "person"`,
+              ],
+              parameters: [],
+            },
+            sqlite: {
+              sql: [
+                `select ${funcName}("id")`,
+                `over(partition by coalesce("first_name", "last_name")) as "${funcName}"`,
+                `from "person"`,
+              ],
+              parameters: [],
+            },
+          })
+
+          await query.execute()
+        })
+
         it(`should execute a query with ${funcName}(column) in having clause`, async () => {
           const query = ctx.db
             .selectFrom('person')

--- a/test/typings/test-d/aggregate-function.test-d.ts
+++ b/test/typings/test-d/aggregate-function.test-d.ts
@@ -1158,3 +1158,32 @@ async function testIssue764(db: Kysely<DB764>) {
     ])
     .execute()
 }
+
+async function testSelectWithOverAndPartitionByExpression(db: Kysely<Database>) {
+  const { avg } = db.fn
+
+  const result = await db
+    .selectFrom('person')
+    .select((eb) =>
+      avg('age')
+        .over((ob) => ob.partitionBy(eb.fn.coalesce('gender', 'first_name')))
+        .as('avg_age'),
+    )
+    .executeTakeFirstOrThrow()
+
+  expectAssignable<string | number>(result.avg_age)
+
+  await db
+    .selectFrom('person')
+    .select((eb) =>
+      avg('age')
+        .over((ob) =>
+          ob.partitionBy([
+            eb.fn.coalesce('gender', 'first_name'),
+            sql`lower(${sql.ref('last_name')})`,
+          ]),
+        )
+        .as('avg_age'),
+    )
+    .execute()
+}


### PR DESCRIPTION
Fixes #1712

`partitionBy` now accepts arbitrary expressions (via `ExpressionOrFactory`) in addition to string column references and `DynamicReferenceBuilder`. This enables use cases like:

```ts
db.selectFrom('orders').select((eb) =>
  eb.fn
    .sum('amount')
    .over((ob) =>
      ob
        .partitionBy([
          eb.fn.coalesce('category', 'fallback_category'), // ← no longer requires `as any`
          sql`lower(${sql.ref('category')})`,
        ])
        .orderBy('created_at')
    )
    .as('running_total')
)
// select sum("amount") over(partition by coalesce("category", "fallback_category"), lower("category")) as "running_total" from "orders"
```

### Changes
- `PartitionByItemNode.partitionBy` widened from `SimpleReferenceExpressionNode` to `OperationNode` — the compiler's `visitPartitionByItem` already calls `visitNode`, so no compiler changes needed
- `PartitionByExpression` type union now includes `ExpressionOrFactory<DB, TB, any>`
- `parsePartitionBy` updated to route through `parseExpression` for non-reference expressions
- Node and typing tests added