### PR TITLE
fix(plugins): make CamelCasePlugin logic extensible

### DIFF
--- a/src/plugin/camel-case/camel-case-plugin.ts
+++ b/src/plugin/camel-case/camel-case-plugin.ts
@@ -154,8 +154,8 @@ export class CamelCasePlugin implements KyselyPlugin {
       let value = row[key]
 
       if (Array.isArray(value)) {
-        value = value.map((it) => (canMap(it, this.opt) ? this.mapRow(it) : it))
-      } else if (canMap(value, this.opt)) {
+        value = value.map((it) => (this.canMap(key, it, this.opt) ? this.mapRow(it) : it))
+      } else if (this.canMap(key, value, this.opt)) {
         value = this.mapRow(value)
       }
 
@@ -171,11 +171,10 @@ export class CamelCasePlugin implements KyselyPlugin {
   protected camelCase(str: string): string {
     return this.#camelCase(str)
   }
+
+  protected canMap(key: string, obj: unknown, opt: CamelCasePluginOptions): obj is Record<string, unknown> {
+    return isPlainObject(obj) && !opt?.maintainNestedObjectKeys
+  }
 }
 
-function canMap(
-  obj: unknown,
-  opt: CamelCasePluginOptions,
-): obj is Record<string, unknown> {
-  return isPlainObject(obj) && !opt?.maintainNestedObjectKeys
-}
+


### PR DESCRIPTION
- make CamelCasePlugin logic extensible by moving the canMap logic into the class
- give canMap function access to key property to be used for canMap extension

This allows plugin class to be extended by standard oop means, e.g. adding new construct options and overwriting with own canMap implemenation

 closes #1719 
