### PR TITLE
docs: warn against running transactions in parallel

### DIFF
--- a/site/docs/examples/transactions/0010-simple-transaction.mdx
+++ b/site/docs/examples/transactions/0010-simple-transaction.mdx
@@ -11,6 +11,27 @@ the callback passed to the `execute` method,
 3. the exception is thrown again.
 Otherwise the transaction is committed.
 
+:::warning[Parallel transactions not supported]
+Running multiple transactions in parallel (e.g. with `Promise.all`) is not
+supported. A transaction uses a single dedicated database connection and all
+operations within it must run sequentially on that connection. Attempting to
+run two transactions concurrently — or to run queries inside a transaction
+and in the main connection at the same time — will cause them to interleave
+on the connection, leading to undefined behavior or errors.
+
+```ts
+// ❌ Don't do this — transactions cannot be parallelized
+await Promise.all([
+  db.transaction().execute(async (trx) => { /* ... */ }),
+  db.transaction().execute(async (trx) => { /* ... */ }),
+])
+
+// ✅ Run transactions sequentially instead
+await db.transaction().execute(async (trx) => { /* ... */ })
+await db.transaction().execute(async (trx) => { /* ... */ })
+```
+:::
+
 import { Playground } from '../../../src/components/Playground'
 
 import {

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -302,6 +302,26 @@ export class Kysely<DB>
    *   // ...
    * }
    * ```
+   *
+   * ### Parallel transactions
+   *
+   * Running multiple transactions in parallel (e.g. with `Promise.all`) is **not**
+   * supported. A transaction occupies a single dedicated database connection and all
+   * operations within it must run sequentially on that connection. Concurrent
+   * transactions would interleave on the same connection, causing undefined behavior.
+   *
+   * ```ts
+   * // ❌ Don't do this — transactions cannot be parallelized
+   * await Promise.all([
+   *   db.transaction().execute(async (trx) => { ... }),
+   *   db.transaction().execute(async (trx) => { ... }),
+   * ])
+   *
+   * // ✅ Run transactions sequentially instead
+   * for (const item of items) {
+   *   await db.transaction().execute(async (trx) => { ... })
+   * }
+   * ```
    */
   transaction(): TransactionBuilder<DB> {
     return new TransactionBuilder({ ...this.#props })


### PR DESCRIPTION
## Summary

Running multiple Kysely transactions concurrently with `Promise.all` or similar constructs is not supported and leads to undefined behavior, but this wasn't documented anywhere. This PR adds clear documentation about this limitation.

## Changes

### Site documentation
Added a `:::warning` admonition to the Simple Transaction docs page explaining why parallel transactions are not supported, with a clear ❌/✅ code example.

### JSDoc (inline API docs)
Added a "Parallel transactions" section to the `transaction()` method's JSDoc comment so the warning surfaces in IDE hover documentation for users who don't visit the docs site.

## Why parallel transactions don't work

A transaction occupies a single dedicated database connection and requires all its operations to run sequentially on that connection. When you start multiple transactions concurrently (e.g. via `Promise.all`), their queries interleave on the same connection, causing the BEGIN/COMMIT/ROLLBACK statements and data operations to mix — resulting in data corruption or errors.

## Related

Closes #1711