### PR TITLE
feat(case): add whenRef() to CaseBuilder and CaseWhenBuilder

### DIFF
--- a/src/query-builder/case-builder.ts
+++ b/src/query-builder/case-builder.ts
@@ -7,6 +7,7 @@ import { WhenNode } from '../operation-node/when-node.js'
 import {
   type ComparisonOperatorExpression,
   type OperandValueExpressionOrList,
+  parseReferentialBinaryOperation,
   parseValueBinaryOperationOrExpression,
 } from '../parser/binary-operation-parser.js'
 import {
@@ -15,6 +16,7 @@ import {
   parseSafeImmediateValue,
   parseValueExpression,
 } from '../parser/value-parser.js'
+import { parseReferenceExpression } from '../parser/reference-parser.js'
 import type { KyselyTypeError } from '../util/type-error.js'
 
 export class CaseBuilder<
@@ -54,6 +56,37 @@ export class CaseBuilder<
       node: CaseNode.cloneWithWhen(
         this.#props.node,
         WhenNode.create(parseValueBinaryOperationOrExpression(args)),
+      ),
+    })
+  }
+
+  whenRef<
+    LRE extends ReferenceExpression<DB, TB>,
+    RRE extends ReferenceExpression<DB, TB>,
+  >(
+    lhs: unknown extends W
+      ? LRE
+      : KyselyTypeError<'whenRef(lhs, op, rhs) is not supported when using case(value)'>,
+    op: ComparisonOperatorExpression,
+    rhs: RRE,
+  ): CaseThenBuilder<DB, TB, W, O>
+
+  whenRef<RE extends ReferenceExpression<DB, TB>>(
+    ref: unknown extends W
+      ? KyselyTypeError<'whenRef(ref) is only supported when using case(value)'>
+      : RE,
+  ): CaseThenBuilder<DB, TB, W, O>
+
+  whenRef(...args: any[]): any {
+    return new CaseThenBuilder({
+      ...this.#props,
+      node: CaseNode.cloneWithWhen(
+        this.#props.node,
+        WhenNode.create(
+          args.length === 3
+            ? parseReferentialBinaryOperation(args[0], args[1], args[2])
+            : parseReferenceExpression(args[0]),
+        ),
       ),
     })
   }
@@ -129,6 +162,37 @@ export class CaseWhenBuilder<DB, TB extends keyof DB, W, O>
       node: CaseNode.cloneWithWhen(
         this.#props.node,
         WhenNode.create(parseValueBinaryOperationOrExpression(args)),
+      ),
+    })
+  }
+
+  whenRef<
+    LRE extends ReferenceExpression<DB, TB>,
+    RRE extends ReferenceExpression<DB, TB>,
+  >(
+    lhs: unknown extends W
+      ? LRE
+      : KyselyTypeError<'whenRef(lhs, op, rhs) is not supported when using case(value)'>,
+    op: ComparisonOperatorExpression,
+    rhs: RRE,
+  ): CaseThenBuilder<DB, TB, W, O>
+
+  whenRef<RE extends ReferenceExpression<DB, TB>>(
+    ref: unknown extends W
+      ? KyselyTypeError<'whenRef(ref) is only supported when using case(value)'>
+      : RE,
+  ): CaseThenBuilder<DB, TB, W, O>
+
+  whenRef(...args: any[]): any {
+    return new CaseThenBuilder({
+      ...this.#props,
+      node: CaseNode.cloneWithWhen(
+        this.#props.node,
+        WhenNode.create(
+          args.length === 3
+            ? parseReferentialBinaryOperation(args[0], args[1], args[2])
+            : parseReferenceExpression(args[0]),
+        ),
       ),
     })
   }
@@ -215,6 +279,23 @@ interface Whenable<DB, TB extends keyof DB, W, O> {
     value: unknown extends W
       ? KyselyTypeError<'when(value) is only supported when using case(value)'>
       : W,
+  ): CaseThenBuilder<DB, TB, W, O>
+
+  whenRef<
+    LRE extends ReferenceExpression<DB, TB>,
+    RRE extends ReferenceExpression<DB, TB>,
+  >(
+    lhs: unknown extends W
+      ? LRE
+      : KyselyTypeError<'whenRef(lhs, op, rhs) is not supported when using case(value)'>,
+    op: ComparisonOperatorExpression,
+    rhs: RRE,
+  ): CaseThenBuilder<DB, TB, W, O>
+
+  whenRef<RE extends ReferenceExpression<DB, TB>>(
+    ref: unknown extends W
+      ? KyselyTypeError<'whenRef(ref) is only supported when using case(value)'>
+      : RE,
   ): CaseThenBuilder<DB, TB, W, O>
 }
 

--- a/test/node/src/case.test.ts
+++ b/test/node/src/case.test.ts
@@ -317,3 +317,95 @@ for (const dialect of DIALECTS) {
     })
   })
 }
+
+for (const dialect of DIALECTS) {
+  describe(`${dialect}: case whenRef`, () => {
+    let ctx: TestContext
+
+    before(async function () {
+      ctx = await initTest(this, dialect)
+    })
+
+    beforeEach(async () => {
+      await insertDefaultDataSet(ctx)
+    })
+
+    afterEach(async () => {
+      await clearDatabase(ctx)
+    })
+
+    after(async () => {
+      await destroyTest(ctx)
+    })
+
+    it('should execute a query with case...whenRef(lhs, op, ref)...then...end', async () => {
+      const query = ctx.db
+        .selectFrom('person')
+        .select((eb) =>
+          eb
+            .case()
+            .whenRef('first_name', '=', 'last_name')
+            .then('same')
+            .else('different')
+            .end()
+            .as('name_match'),
+        )
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: `select case when "first_name" = "last_name" then $1 else $2 end as "name_match" from "person"`,
+          parameters: ['same', 'different'],
+        },
+        mysql: {
+          sql: 'select case when `first_name` = `last_name` then ? else ? end as `name_match` from `person`',
+          parameters: ['same', 'different'],
+        },
+        mssql: {
+          sql: `select case when "first_name" = "last_name" then @1 else @2 end as "name_match" from "person"`,
+          parameters: ['same', 'different'],
+        },
+        sqlite: {
+          sql: `select case when "first_name" = "last_name" then ? else ? end as "name_match" from "person"`,
+          parameters: ['same', 'different'],
+        },
+      })
+
+      await query.execute()
+    })
+
+    it('should execute a query with case(value)...whenRef(ref)...then...end', async () => {
+      const query = ctx.db
+        .selectFrom('person')
+        .select((eb) =>
+          eb
+            .case('first_name')
+            .whenRef('last_name')
+            .then('same')
+            .else('different')
+            .end()
+            .as('name_match'),
+        )
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: `select case "first_name" when "last_name" then $1 else $2 end as "name_match" from "person"`,
+          parameters: ['same', 'different'],
+        },
+        mysql: {
+          sql: 'select case `first_name` when `last_name` then ? else ? end as `name_match` from `person`',
+          parameters: ['same', 'different'],
+        },
+        mssql: {
+          sql: `select case "first_name" when "last_name" then @1 else @2 end as "name_match" from "person"`,
+          parameters: ['same', 'different'],
+        },
+        sqlite: {
+          sql: `select case "first_name" when "last_name" then ? else ? end as "name_match" from "person"`,
+          parameters: ['same', 'different'],
+        },
+      })
+
+      await query.execute()
+    })
+  })
+}

--- a/test/typings/test-d/case.test-d.ts
+++ b/test/typings/test-d/case.test-d.ts
@@ -155,3 +155,35 @@ function testCaseValue(eb: ExpressionBuilder<Database, 'person'>) {
   expectError(eb.case('gender').when('robot').then('Mr.').end())
   expectError(eb.case('gender').when('gender', '=', 'male').then('Mr.').end())
 }
+
+function testCaseWhenRef(eb: ExpressionBuilder<Database, 'person'>) {
+  // case().whenRef(lhs, op, rhs)...end — both sides as column refs
+  expectType<ExpressionWrapper<Database, 'person', 'same' | null>>(
+    eb
+      .case()
+      .whenRef('first_name', '=', 'last_name')
+      .then('same' as const)
+      .end(),
+  )
+
+  // chained whenRef on CaseWhenBuilder
+  expectType<ExpressionWrapper<Database, 'person', 'same' | 'different' | null>>(
+    eb
+      .case()
+      .whenRef('first_name', '=', 'last_name')
+      .then('same' as const)
+      .whenRef('first_name', '!=', 'last_name')
+      .then('different' as const)
+      .end(),
+  )
+
+  // case(value).whenRef(ref) — compare case subject to a column ref
+  expectType<ExpressionWrapper<Database, 'person', 'same' | null>>(
+    eb.case('first_name').whenRef('last_name').then('same' as const).end(),
+  )
+
+  // errors
+  expectError(eb.case().whenRef('no_such_column', '=', 'first_name').then('x').end())
+  expectError(eb.case('gender').whenRef('first_name', '=', 'last_name').then('x').end())
+  expectError(eb.case().whenRef('first_name').then('x').end())
+}


### PR DESCRIPTION
Closes #1602

## Summary

Adds `whenRef()` overloads to both `CaseBuilder` and `CaseWhenBuilder` (and the `Whenable` interface):

**`whenRef(ref)`** — for the `case(value)` form, compares the case subject against a column reference:
```ts
eb.case('is_ready')
  .when(false)
  .then('abort')
  .whenRef('is_set')
  .then('go!')
  .else('abort')
  .end()
// → CASE "is_ready" WHEN false THEN 'abort' WHEN "is_set" THEN 'go!' ELSE 'abort' END
```

**`whenRef(lhs, op, rhs)`** — for the `case()` form, compares two column references:
```ts
eb.case()
  .whenRef('first_name', '=', 'last_name')
  .then('same')
  .else('different')
  .end()
// → CASE WHEN "first_name" = "last_name" THEN 'same' ELSE 'different' END
```

Both overloads enforce the same type-level constraints as `when()`:
- `whenRef(lhs, op, rhs)` is only allowed in the `case()` form (raises a `KyselyTypeError` when used with `case(value)`)
- `whenRef(ref)` is only allowed in the `case(value)` form (raises a `KyselyTypeError` when used with `case()`)

## Changes
- `src/query-builder/case-builder.ts` — added `whenRef` to `CaseBuilder`, `CaseWhenBuilder`, and `Whenable` interface
- `test/node/src/case.test.ts` — added SQL-level tests for both overloads across all 4 dialects
- `test/typings/test-d/case.test-d.ts` — added type-level tests including error cases