### PR TITLE
feat(fn): add jsonArrayAgg aggregate function

### DIFF
--- a/src/query-builder/function-module.ts
+++ b/src/query-builder/function-module.ts
@@ -739,6 +739,77 @@ export interface FunctionModule<DB, TB extends keyof DB> {
   >
 
   /**
+   * Creates a `json_arrayagg` function call.
+   *
+   * This is only supported by MySQL.
+   *
+   * ### Examples
+   *
+   * You can use it on table expressions:
+   *
+   * ```ts
+   * await db.selectFrom('person')
+   *   .innerJoin('pet', 'pet.owner_id', 'person.id')
+   *   .select((eb) => ['first_name', eb.fn.jsonArrayAgg('pet').as('pets')])
+   *   .groupBy('person.first_name')
+   *   .execute()
+   * ```
+   *
+   * The generated SQL (MySQL):
+   *
+   * ```sql
+   * select `first_name`, json_arrayagg(`pet`) as `pets`
+   * from `person`
+   * inner join `pet` on `pet`.`owner_id` = `person`.`id`
+   * group by `person`.`first_name`
+   * ```
+   *
+   * or on columns:
+   *
+   * ```ts
+   * await db.selectFrom('person')
+   *   .innerJoin('pet', 'pet.owner_id', 'person.id')
+   *   .select((eb) => [
+   *     'first_name',
+   *     eb.fn.jsonArrayAgg('pet.name').as('pet_names'),
+   *   ])
+   *   .groupBy('person.first_name')
+   *   .execute()
+   * ```
+   *
+   * The generated SQL (MySQL):
+   *
+   * ```sql
+   * select `first_name`, json_arrayagg(`pet`.`name`) AS `pet_names`
+   * from `person`
+   * inner join `pet` ON `pet`.`owner_id` = `person`.`id`
+   * group by `person`.`first_name`
+   * ```
+   */
+  jsonArrayAgg<T extends (TB & string) | Expression<unknown>>(
+    table: T,
+  ): AggregateFunctionBuilder<
+    DB,
+    TB,
+    T extends TB
+      ? Simplify<ShallowDehydrateObject<Selectable<DB[T]>>>[]
+      : T extends Expression<infer O>
+        ? Simplify<ShallowDehydrateObject<O>>[]
+        : never
+  >
+
+  jsonArrayAgg<RE extends StringReference<DB, TB>>(
+    column: RE,
+  ): AggregateFunctionBuilder<
+    DB,
+    TB,
+    | ShallowDehydrateValue<
+        SelectType<ExtractTypeFromStringReference<DB, TB, RE>>
+      >[]
+    | null
+  >
+
+  /**
    * Creates a to_json function call.
    *
    * This function is only available on PostgreSQL.
@@ -850,6 +921,15 @@ export function createFunctionModule<DB, TB extends keyof DB>(): FunctionModule<
         aggregateFunctionNode: AggregateFunctionNode.create('json_agg', [
           isString(table) ? parseTable(table) : table.toOperationNode(),
         ]),
+      })
+    },
+
+    jsonArrayAgg(table: string | Expression<unknown>): any {
+      return new AggregateFunctionBuilder({
+        aggregateFunctionNode: AggregateFunctionNode.create(
+          'json_arrayagg',
+          [isString(table) ? parseTable(table) : table.toOperationNode()],
+        ),
       })
     },
 

--- a/test/node/src/json.test.ts
+++ b/test/node/src/json.test.ts
@@ -377,6 +377,36 @@ for (const dialect of DIALECTS) {
       })
     }
 
+    if (dialect === 'mysql') {
+      it('should aggregate a column using json_arrayagg', async () => {
+        const res = await db
+          .selectFrom('pet')
+          .leftJoin('person', 'person.id', 'pet.owner_id')
+          .select((eb) => [
+            eb.fn.jsonArrayAgg('pet.name').as('petName'),
+            'person.first_name',
+          ])
+          .groupBy('person.first_name')
+          .execute()
+
+        expect(res).to.have.length(3)
+        expect(res).to.containSubset([
+          {
+            first_name: 'Jennifer',
+            petName: ['Catto'],
+          },
+          {
+            first_name: 'Arnold',
+            petName: ['Doggo'],
+          },
+          {
+            first_name: 'Sylvester',
+            petName: ['Hammo'],
+          },
+        ])
+      })
+    }
+
     it('should select subqueries as nested json objects', async () => {
       const query = db.selectFrom('person').select((eb) => [
         'person.first_name',

--- a/test/typings/test-d/mysql-json.test-d.ts
+++ b/test/typings/test-d/mysql-json.test-d.ts
@@ -1,0 +1,45 @@
+import { type Kysely } from '..'
+import type { Database } from '../shared'
+import { expectType } from 'tsd'
+
+async function testMysqlJsonArrayAgg(db: Kysely<Database>) {
+  const r1 = await db
+    .selectFrom('pet')
+    .innerJoin('person', 'pet.owner_id', 'person.id')
+    .select((eb) => ['pet.name', eb.fn.jsonArrayAgg('person').as('people')])
+    .groupBy('pet.name')
+    .execute()
+
+  expectType<
+    {
+      name: string
+      people: {
+        id: number
+        first_name: string
+        last_name: string | null
+        age: number
+        gender: 'male' | 'female' | 'other'
+        marital_status: 'single' | 'married' | 'divorced' | 'widowed' | null
+        modified_at: string
+        deleted_at: string | null
+      }[]
+    }[]
+  >(r1)
+
+  const r2 = await db
+    .selectFrom('pet')
+    .innerJoin('person', 'pet.owner_id', 'person.id')
+    .select((eb) => [
+      'name',
+      eb.fn.jsonArrayAgg('person.modified_at').as('modified_at'),
+    ])
+    .groupBy('name')
+    .execute()
+
+  expectType<
+    {
+      name: string
+      modified_at: string[] | null
+    }[]
+  >(r2)
+}


### PR DESCRIPTION
Closes #1665

Exposes MySQL's `json_arrayagg` as a first-class `fn.jsonArrayAgg()` function, mirroring the existing `fn.jsonAgg()` API for PostgreSQL.

The function was already used internally in `src/helpers/mysql.ts` via raw SQL. This makes it available to users directly.

```ts
// On a table reference
eb.fn.jsonArrayAgg('pet').as('pets')
// → json_arrayagg(`pet`)

// On a column reference
eb.fn.jsonArrayAgg('pet.name').as('pet_names')
// → json_arrayagg(`pet`.`name`)
```

Both type overloads match the `jsonAgg` signatures. Added typing tests in `test/typings/test-d/mysql-json.test-d.ts` and a runtime SQL generation test in `test/node/src/json.test.ts` (MySQL-only).