### PR TITLE
fix: missing `sideEffects: false` in root `package.json` resulting in bigger bundles in various bundlers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
       "default": "./dist/cjs/helpers/sqlite.js"
     }
   },
+  "sideEffects": false,
   "scripts": {
     "clean": "rm -rf dist & rm -rf test/node/dist & rm -rf test/browser/bundle.js & rm -rf helpers",
     "bench:ts": "pnpm build && cd ./test/ts-benchmarks && node --experimental-strip-types ./index.ts",


### PR DESCRIPTION
Hey 👋 

closes #1743.

This PR adds `sideEffects: false` to the main `package.json` file as suggested in the issue.

Seems to be legit.