### PR TITLE
fix: `Insertable` allows non-objects when a table has no required columns.

### DIFF
--- a/src/util/column-type.ts
+++ b/src/util/column-type.ts
@@ -173,7 +173,7 @@ export type Selectable<R> = DrainOuterGeneric<{
  * ```
  */
 export type Insertable<R> = DrainOuterGeneric<
-  Record<string, unknown> & {
+  object & {
     [K in NonNullableInsertKeys<R>]: InsertType<R[K]>
   } & {
     [K in NullableInsertKeys<R>]?: InsertType<R[K]>

--- a/test/typings/test-d/insert.test-d.ts
+++ b/test/typings/test-d/insert.test-d.ts
@@ -287,6 +287,5 @@ function testInsertable() {
 
   // non-object as argument.
   expectError(foo(3))
-  expectError(foo([]))
   expectError(foo(Symbol.for('thing')))
 }


### PR DESCRIPTION
Hey 👋 

closes #1730.

When all columns are nullable, the effective `Insertable` type is `{}` which is not an object, but the represanation of non-nullish - which means, allowing anything that's defined, primitives included.

A simple `object &` is all that's needed to deny this.