### PR TITLE
fix: allow columns with never update type in onConflict WHERE clauses

### DIFF
--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -51,6 +51,7 @@ import {
   type OnConflictDoNothingBuilder,
   type OnConflictTables,
   type OnConflictUpdateBuilder,
+  type OnConflictWhereDatabase,
 } from './on-conflict-builder.js'
 import { OnConflictNode } from '../operation-node/on-conflict-node.js'
 import type { Selectable } from '../util/column-type.js'
@@ -884,7 +885,8 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, O>
     ) =>
       | OnConflictUpdateBuilder<
           OnConflictDatabase<DB, TB>,
-          OnConflictTables<TB>
+          OnConflictTables<TB>,
+          OnConflictWhereDatabase<DB, TB>
         >
       | OnConflictDoNothingBuilder<DB, TB>,
   ): InsertQueryBuilder<DB, TB, O> {

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -15,7 +15,7 @@ import {
   type UpdateObjectExpression,
   parseUpdateObjectExpression,
 } from '../parser/update-set-parser.js'
-import type { Updateable } from '../util/column-type.js'
+import type { Selectable, Updateable } from '../util/column-type.js'
 import { freeze } from '../util/object-utils.js'
 import type { AnyColumn, SqlBool } from '../util/type-utils.js'
 import type { WhereInterface } from './where-interface.js'
@@ -254,7 +254,7 @@ export class OnConflictBuilder<
       OnConflictTables<TB>,
       OnConflictTables<TB>
     >,
-  ): OnConflictUpdateBuilder<OnConflictDatabase<DB, TB>, OnConflictTables<TB>> {
+  ): OnConflictUpdateBuilder<OnConflictDatabase<DB, TB>, OnConflictTables<TB>, OnConflictWhereDatabase<DB, TB>> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWith(this.#props.onConflictNode, {
@@ -280,6 +280,15 @@ export type OnConflictDatabase<DB, TB extends keyof DB> = {
   [K in keyof DB | 'excluded']: Updateable<K extends keyof DB ? DB[K] : DB[TB]>
 }
 
+/**
+ * Like {@link OnConflictDatabase} but preserves all selectable columns.
+ * Used for WHERE clauses in ON CONFLICT DO UPDATE, which are read-only
+ * and should not be restricted to updateable columns.
+ */
+export type OnConflictWhereDatabase<DB, TB extends keyof DB> = {
+  [K in keyof DB | 'excluded']: Selectable<K extends keyof DB ? DB[K] : DB[TB]>
+}
+
 export type OnConflictTables<TB> = TB | 'excluded'
 
 export class OnConflictDoNothingBuilder<
@@ -297,8 +306,8 @@ export class OnConflictDoNothingBuilder<
   }
 }
 
-export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
-  implements WhereInterface<DB, TB>, OperationNodeSource
+export class OnConflictUpdateBuilder<DB, TB extends keyof DB, WDB = DB>
+  implements OperationNodeSource
 {
   readonly #props: OnConflictBuilderProps
 
@@ -312,19 +321,19 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
    * See {@link WhereInterface.where} for more info.
    */
   where<
-    RE extends ReferenceExpression<DB, TB>,
-    VE extends OperandValueExpressionOrList<DB, TB, RE>,
+    RE extends ReferenceExpression<WDB, TB & keyof WDB>,
+    VE extends OperandValueExpressionOrList<WDB, TB & keyof WDB, RE>,
   >(
     lhs: RE,
     op: ComparisonOperatorExpression,
     rhs: VE,
-  ): OnConflictUpdateBuilder<DB, TB>
+  ): OnConflictUpdateBuilder<DB, TB, WDB>
 
-  where<E extends ExpressionOrFactory<DB, TB, SqlBool>>(
+  where<E extends ExpressionOrFactory<WDB, TB & keyof WDB, SqlBool>>(
     expression: E,
-  ): OnConflictUpdateBuilder<DB, TB>
+  ): OnConflictUpdateBuilder<DB, TB, WDB>
 
-  where(...args: any[]): OnConflictUpdateBuilder<DB, TB> {
+  where(...args: any[]): OnConflictUpdateBuilder<DB, TB, WDB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithUpdateWhere(
@@ -340,13 +349,13 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
    * See {@link WhereInterface.whereRef} for more info.
    */
   whereRef<
-    LRE extends ReferenceExpression<DB, TB>,
-    RRE extends ReferenceExpression<DB, TB>,
+    LRE extends ReferenceExpression<WDB, TB & keyof WDB>,
+    RRE extends ReferenceExpression<WDB, TB & keyof WDB>,
   >(
     lhs: LRE,
     op: ComparisonOperatorExpression,
     rhs: RRE,
-  ): OnConflictUpdateBuilder<DB, TB> {
+  ): OnConflictUpdateBuilder<DB, TB, WDB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithUpdateWhere(
@@ -356,7 +365,7 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
     })
   }
 
-  clearWhere(): OnConflictUpdateBuilder<DB, TB> {
+  clearWhere(): OnConflictUpdateBuilder<DB, TB, WDB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithoutUpdateWhere(

--- a/test/typings/test-d/insert.test-d.ts
+++ b/test/typings/test-d/insert.test-d.ts
@@ -105,6 +105,19 @@ async function testInsert(db: Kysely<Database>) {
       ),
   )
 
+  // Columns with `never` update type (GeneratedAlways) should be referenceable
+  // in onConflict WHERE clauses since WHERE is read-only (#1409)
+  await db
+    .insertInto('book')
+    .values({ name: 'foo' })
+    .onConflict((oc) =>
+      oc
+        .column('name')
+        .doUpdateSet({ name: 'bar' })
+        .where('id', '=', 1),
+    )
+    .execute()
+
   // GeneratedAlways column is not allowed to be inserted
   expectError(db.insertInto('book').values({ id: 1, name: 'foo' }))
 


### PR DESCRIPTION
## Problem

Fixes #1409

Columns with `never` update type (e.g., `GeneratedAlways<number>` or `ColumnType<Date, never, never>`) cannot be referenced in `.where()` clauses after `.doUpdateSet()` in ON CONFLICT callbacks, even though WHERE clauses are read-only.

```ts
// id is GeneratedAlways<number> (update type = never)
db.insertInto('book')
  .values({ name: 'foo' })
  .onConflict((oc) => oc
    .column('name')
    .doUpdateSet({ name: 'bar' })
    .where('id', '=', 1)  // ERROR: 'id' not in type
  )
```

Reproduction: https://kyse.link/JpiqY

## Root Cause

`OnConflictDatabase` wraps all table types through `Updateable`, which uses `UpdateKeys` to filter out any column whose `UpdateType` is `never`:

```ts
export type OnConflictDatabase<DB, TB extends keyof DB> = {
  [K in keyof DB | 'excluded']: Updateable<K extends keyof DB ? DB[K] : DB[TB]>
}
```

`OnConflictUpdateBuilder` receives this filtered DB as its only type parameter. Since `.where()` uses `ReferenceExpression<DB, TB>` with the same filtered DB, columns like `id: GeneratedAlways<number>` are invisible to WHERE clauses even though they're perfectly valid to read.

## Fix

Added a third generic parameter `WDB` to `OnConflictUpdateBuilder` that preserves the full selectable schema for WHERE clause type resolution:

- **`OnConflictWhereDatabase<DB, TB>`** — new type using `Selectable` instead of `Updateable`, preserving all readable columns including those with `never` update type
- **`OnConflictUpdateBuilder<DB, TB, WDB>`** — `WDB` defaults to `DB` for backwards compatibility; WHERE methods use `WDB` while SET methods continue using the `Updateable`-filtered `DB`
- **`doUpdateSet()`** now passes `OnConflictWhereDatabase<DB, TB>` as `WDB`

This separates the concern: SET clauses correctly restrict to updateable columns, WHERE clauses correctly allow all selectable columns.

## Tests

Added type-level test using `tsd` verifying that `GeneratedAlways` columns (which resolve to `ColumnType<T, never, never>`) are referenceable in onConflict WHERE clauses.

Build, typecheck, and `tsd test/typings` all pass.