### PR TITLE
test: fix TypeScript 5.4.0 test following `target` bump to `es2023`.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,8 +273,11 @@ jobs:
       - name: Install Typescript (${{ env.TS_VERSION }}) and TSD (${{ env.TSD_VERSION }})
         run: pnpm i -D typescript@${{ env.TS_VERSION }} tsd@${{ env.TSD_VERSION }}
 
+        name: Make `tsconfig` backwards compatible.
+      - run: pnpm script:override-tsconfig-target
+
       - name: Run tests with older TypeScript version
-        run: pnpm test:typings && pnpm tsc -p test/node${{ env.TS_VERSION == '~5.4.0' && '/tsconfig-5.4.json' || '' }}
+        run: pnpm test:typings && pnpm test:node:build
 
   jsdocs:
     name: JSDocs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,7 +276,7 @@ jobs:
         run: pnpm i -D typescript@${{ env.TS_VERSION }} tsd@${{ env.TSD_VERSION }}
 
       - name: Run tests with older TypeScript version
-        run: pnpm test:typings && pnpm test:node:build -- --lib=${{ env.TS_TARGET }} --target=${{ env.TS_TARGET }}
+        run: pnpm test:typings && pnpm test:node:build --lib=${{ env.TS_TARGET }} --target=${{ env.TS_TARGET }}
 
   jsdocs:
     name: JSDocs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,14 +269,12 @@ jobs:
           echo "TS_VERSION=$TS_VERSION" >> $GITHUB_ENV
           TSD_VERSION=$(echo '{"~5.4.0":"0.31.2", "~5.8.0":"0.32.0", "~5.9.0":"0.33.0"}' | jq -r --arg key "$TS_VERSION" '.[$key]')
           echo "TSD_VERSION=$TSD_VERSION" >> $GITHUB_ENV
-          TS_TARGET=$(echo '{"~5.4.0":"es2022", "~5.8.0":"es2023", "~5.9.0":"es2023"}' | jq -r --arg key "$TS_VERSION" '.[$key]')
-          echo "TS_TARGET=$TS_TARGET" >> $GITHUB_ENV
 
       - name: Install Typescript (${{ env.TS_VERSION }}) and TSD (${{ env.TSD_VERSION }})
         run: pnpm i -D typescript@${{ env.TS_VERSION }} tsd@${{ env.TSD_VERSION }}
 
       - name: Run tests with older TypeScript version
-        run: pnpm test:typings && pnpm test:node:build --lib ${{ env.TS_TARGET }} --target ${{ env.TS_TARGET }}
+        run: pnpm test:typings && pnpm tsc -p test/node${{ env.TS_VERSION == '~5.4.0' && '/tsconfig-5.4.json' || '' }}
 
   jsdocs:
     name: JSDocs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,8 +273,8 @@ jobs:
       - name: Install Typescript (${{ env.TS_VERSION }}) and TSD (${{ env.TSD_VERSION }})
         run: pnpm i -D typescript@${{ env.TS_VERSION }} tsd@${{ env.TSD_VERSION }}
 
-        name: Make `tsconfig` backwards compatible.
-      - run: pnpm script:override-tsconfig-target
+      - name: Make `tsconfig` backwards compatible
+        run: pnpm script:override-tsconfig-target
 
       - name: Run tests with older TypeScript version
         run: pnpm test:typings && pnpm test:node:build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,7 +269,7 @@ jobs:
           echo "TS_VERSION=$TS_VERSION" >> $GITHUB_ENV
           TSD_VERSION=$(echo '{"~5.4.0":"0.31.2", "~5.8.0":"0.32.0", "~5.9.0":"0.33.0"}' | jq -r --arg key "$TS_VERSION" '.[$key]')
           echo "TSD_VERSION=$TSD_VERSION" >> $GITHUB_ENV
-          TS_TARGET=$(echo '{"~5.4.0":"es2022", "~5.8.0":"es2023", "~5.9.0":"es2023"}' | jq -r --arg key key "$TS_VERSION" '.[$key]')
+          TS_TARGET=$(echo '{"~5.4.0":"es2022", "~5.8.0":"es2023", "~5.9.0":"es2023"}' | jq -r --arg key "$TS_VERSION" '.[$key]')
           echo "TS_TARGET=$TS_TARGET" >> $GITHUB_ENV
 
       - name: Install Typescript (${{ env.TS_VERSION }}) and TSD (${{ env.TSD_VERSION }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,12 +269,14 @@ jobs:
           echo "TS_VERSION=$TS_VERSION" >> $GITHUB_ENV
           TSD_VERSION=$(echo '{"~5.4.0":"0.31.2", "~5.8.0":"0.32.0", "~5.9.0":"0.33.0"}' | jq -r --arg key "$TS_VERSION" '.[$key]')
           echo "TSD_VERSION=$TSD_VERSION" >> $GITHUB_ENV
+          TS_TARGET=$(echo '{"~5.4.0":"es2022", "~5.8.0":"es2023", "~5.9.0":"es2023"}' | jq -r --arg key key "$TS_VERSION" '.[$key]')
+          echo "TS_TARGET=$TS_TARGET" >> $GITHUB_ENV
 
       - name: Install Typescript (${{ env.TS_VERSION }}) and TSD (${{ env.TSD_VERSION }})
         run: pnpm i -D typescript@${{ env.TS_VERSION }} tsd@${{ env.TSD_VERSION }}
 
       - name: Run tests with older TypeScript version
-        run: pnpm test:typings && pnpm test:node:build
+        run: pnpm test:typings && pnpm test:node:build -- --lib=${{ env.TS_TARGET }} --target=${{ env.TS_TARGET }}
 
   jsdocs:
     name: JSDocs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,7 +276,7 @@ jobs:
         run: pnpm i -D typescript@${{ env.TS_VERSION }} tsd@${{ env.TSD_VERSION }}
 
       - name: Run tests with older TypeScript version
-        run: pnpm test:typings && pnpm test:node:build --lib=${{ env.TS_TARGET }} --target=${{ env.TS_TARGET }}
+        run: pnpm test:typings && pnpm test:node:build --lib ${{ env.TS_TARGET }} --target ${{ env.TS_TARGET }}
 
   jsdocs:
     name: JSDocs

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "test:bun": "pnpm build && bun link && cd test/bun && bun install && bun run test",
     "test:cloudflare-workers": "pnpm build && pnpm -r test --filter kysely-cloudflare-workers-test",
     "test:deno": "deno run --allow-env --allow-read --allow-net --no-lock test/deno/local.test.ts && deno run --allow-env --allow-read --allow-net --no-lock test/deno/cdn.test.ts",
-    "test:typings": "cd test/typings && tsd && cd -",
+    "test:typings": "tsd test/typings",
     "test:esmimports": "node scripts/check-esm-imports.cjs",
     "test:esbuild": "esbuild --bundle --platform=node --external:pg-native dist/esm/index.js --outfile=/dev/null",
     "test:exports": "attw --pack . && node scripts/check-exports.cjs",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "script:add-deno-type-references": "node scripts/add-deno-type-references.cjs",
     "script:align-versions": "node --experimental-strip-types scripts/align-versions.mts",
     "script:generate-site-examples": "node scripts/generate-site-examples.cjs",
-    "script:exclude-test-files-for-backwards-compat": "node --experimental-strip-types scripts/exclude-test-files-for-backwards-compat.mts",
     "script:remove-global-augmentations": "node --experimental-strip-types scripts/remove-global-augmentations.mts",
     "prepublishOnly": "pnpm build && pnpm test:exports",
     "version": "pnpm script:align-versions && git add ."

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "test:bun": "pnpm build && bun link && cd test/bun && bun install && bun run test",
     "test:cloudflare-workers": "pnpm build && pnpm -r test --filter kysely-cloudflare-workers-test",
     "test:deno": "deno run --allow-env --allow-read --allow-net --no-lock test/deno/local.test.ts && deno run --allow-env --allow-read --allow-net --no-lock test/deno/cdn.test.ts",
-    "test:typings": "tsd test/typings",
+    "test:typings": "cd test/typings && tsd && cd -",
     "test:esmimports": "node scripts/check-esm-imports.cjs",
     "test:esbuild": "esbuild --bundle --platform=node --external:pg-native dist/esm/index.js --outfile=/dev/null",
     "test:exports": "attw --pack . && node scripts/check-exports.cjs",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "script:add-deno-type-references": "node scripts/add-deno-type-references.cjs",
     "script:align-versions": "node --experimental-strip-types scripts/align-versions.mts",
     "script:generate-site-examples": "node scripts/generate-site-examples.cjs",
+    "script:override-tsconfig-target": "node --experimental-strip-types scripts/override-tsconfig-target.mts",
     "script:remove-global-augmentations": "node --experimental-strip-types scripts/remove-global-augmentations.mts",
     "prepublishOnly": "pnpm build && pnpm test:exports",
     "version": "pnpm script:align-versions && git add ."

--- a/scripts/override-tsconfig-target.mts
+++ b/scripts/override-tsconfig-target.mts
@@ -1,0 +1,25 @@
+import { writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'pathe'
+import { lt } from 'semver'
+import packageJson from '../package.json'
+import tsconfig from '../tsconfig-base.json'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// <=5.4.0 supports target <= es2022.
+if (lt(packageJson.devDependencies.typescript.replace(/^[~^]/, ''), '5.5.0')) {
+  const { compilerOptions } = tsconfig
+
+  const originalTarget = compilerOptions.target
+
+  compilerOptions.target = 'es2022'
+
+  await writeFile(
+    join(__dirname, '../tsconfig-base.json'),
+    JSON.stringify(tsconfig),
+    { encoding: 'utf8' },
+  )
+
+  console.log(`tsconfig-base.json: target:${originalTarget}->target:es2022`)
+}

--- a/scripts/override-tsconfig-target.mts
+++ b/scripts/override-tsconfig-target.mts
@@ -2,8 +2,8 @@ import { writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'pathe'
 import { lt } from 'semver'
-import packageJson from '../package.json'
-import tsconfig from '../tsconfig-base.json'
+import packageJson from '../package.json' with { type: 'json' }
+import tsconfig from '../tsconfig-base.json' with { type: 'json' }
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../tsconfig-base.json",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true
   },
   "include": ["./"]

--- a/test/node/tsconfig-5.4.json
+++ b/test/node/tsconfig-5.4.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "lib": ["es2022"],
+    "target": "es2022"
+  }
+}

--- a/test/node/tsconfig-5.4.json
+++ b/test/node/tsconfig-5.4.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*"],
-  "compilerOptions": {
-    "lib": ["es2022"],
-    "target": "es2022"
-  }
-}

--- a/test/node/tsconfig.json
+++ b/test/node/tsconfig.json
@@ -3,9 +3,10 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["esnext"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "dist",
     "rootDir": "./src",
-    "types": ["mocha", "node"],
+    "types": ["mocha", "node"]
   }
 }

--- a/test/typings/package.json
+++ b/test/typings/package.json
@@ -1,12 +1,4 @@
 {
   "type": "module",
-  "types": "index.d.ts",
-  "tsd": {
-    "compilerOptions": {
-      "exactOptionalPropertyTypes": true,
-      "module": "node16",
-      "moduleResolution": "node16",
-      "target": "es2022"
-    }
-  }
+  "types": "index.d.ts"
 }

--- a/test/typings/package.json
+++ b/test/typings/package.json
@@ -5,7 +5,8 @@
     "compilerOptions": {
       "exactOptionalPropertyTypes": true,
       "module": "node16",
-      "moduleResolution": "node16"
+      "moduleResolution": "node16",
+      "target": "es2022"
     }
   }
 }

--- a/test/typings/tsconfig.json
+++ b/test/typings/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig-base.json",
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,
     "target": "es2022"

--- a/test/typings/tsconfig.json
+++ b/test/typings/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "target": "es2022"
+  }
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "lib": ["es2023"],
     "moduleResolution": "node16",
     "module": "node16",
     "noImplicitAny": true,


### PR DESCRIPTION
Hey 👋 

TypeScript 5.4.0 doesn't support targetting `es2023`, which breaks the tests given we moved recently to that target.

This PR, after long trial and error, went with a dirty ad-hoc script that replaces the target property in `tsconfig-base.json` in-place, as nothing seemed to please `tsd`.