### PR TITLE
fix(site): suppress llms-txt plugin warning for excluded routes

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -47,6 +47,11 @@ export default {
           ],
           enableLlmsFullTxt: true,
           includeGeneratedIndex: false,
+          // Explicitly exclude auto-generated category index pages.
+          // These only list child pages and have no meaningful content for LLMs.
+          excludeRoutes: [
+            '/docs/category/**',
+          ],
           includePages: true,
           includeVersionedDocs: false,
           relativePaths: false,


### PR DESCRIPTION
## Summary

- Add explicit `excludeRoutes: ['/docs/category/**']` to the `docusaurus-plugin-llms-txt` config
- The 13 auto-generated category index pages (from `_category_.json` files in `examples/`, `recipes/`, `runtimes/`, `integrations/`, etc.) were already excluded by `includeGeneratedIndex: false`, but the plugin warns about implicit exclusions
- Making the exclusion explicit via `excludeRoutes` suppresses the `Excluded 13 routes by current config` warning

These pages only list child pages and have no meaningful content for LLMs, so excluding them is the right behavior — this just makes it explicit.

Closes #1786