### PR TITLE
fix: `FilterObject` allows any defined value when query context has no tables (`TB` is `never`).

### DIFF
--- a/src/parser/binary-operation-parser.ts
+++ b/src/parser/binary-operation-parser.ts
@@ -38,6 +38,8 @@ import { ParensNode } from '../operation-node/parens-node.js'
 import { OrNode } from '../operation-node/or-node.js'
 import type { WhenNode } from '../operation-node/when-node.js'
 import type { RawNode } from '../operation-node/raw-node.js'
+import type { IsNever } from '../util/type-utils.js'
+import type { KyselyTypeError } from '../util/type-error.js'
 
 export type OperandValueExpression<
   DB,
@@ -62,13 +64,16 @@ export type ComparisonOperatorExpression =
   | ComparisonOperator
   | Expression<unknown>
 
-export type FilterObject<DB, TB extends keyof DB> = {
-  [R in StringReference<DB, TB>]?: ValueExpressionOrList<
-    DB,
-    TB,
-    SelectType<ExtractTypeFromStringReference<DB, TB, R>>
-  >
-}
+export type FilterObject<DB, TB extends keyof DB> =
+  IsNever<TB> extends true
+    ? KyselyTypeError<'there are no tables in query context, so a filter object cannot be defined.'>
+    : {
+        [R in StringReference<DB, TB>]?: ValueExpressionOrList<
+          DB,
+          TB,
+          SelectType<ExtractTypeFromStringReference<DB, TB, R>>
+        >
+      }
 
 export function parseValueBinaryOperationOrExpression(
   args: any[],

--- a/src/parser/binary-operation-parser.ts
+++ b/src/parser/binary-operation-parser.ts
@@ -66,7 +66,7 @@ export type ComparisonOperatorExpression =
 
 export type FilterObject<DB, TB extends keyof DB> =
   IsNever<TB> extends true
-    ? KyselyTypeError<'there are no tables in query context, so a filter object cannot be defined.'>
+    ? KyselyTypeError<'there are no tables in query context, so a filter object cannot be defined. try passing an array instead.'>
     : {
         [R in StringReference<DB, TB>]?: ValueExpressionOrList<
           DB,

--- a/test/typings/test-d/expression.test-d.ts
+++ b/test/typings/test-d/expression.test-d.ts
@@ -311,3 +311,12 @@ function testExpressionBuilderConstructor(db: Kysely<Database>) {
   )
   expectType<ExpressionBuilder<Database, 'action' | 'pet'>>(eb3)
 }
+
+function testTablelessExpressionBuilder(
+  eb: ExpressionBuilder<Database, never>,
+) {
+  expectError(eb.and({}))
+  expectError(eb.or({}))
+  expectError(eb.and(eb.or([])))
+  expectError(eb.or(eb.and([])))
+}

--- a/test/typings/test-d/expression.test-d.ts
+++ b/test/typings/test-d/expression.test-d.ts
@@ -312,6 +312,7 @@ function testExpressionBuilderConstructor(db: Kysely<Database>) {
   expectType<ExpressionBuilder<Database, 'action' | 'pet'>>(eb3)
 }
 
+// See: https://github.com/kysely-org/kysely/issues/1783
 function testTablelessExpressionBuilder(
   eb: ExpressionBuilder<Database, never>,
 ) {

--- a/test/typings/test-d/expression.test-d.ts
+++ b/test/typings/test-d/expression.test-d.ts
@@ -316,6 +316,8 @@ function testExpressionBuilderConstructor(db: Kysely<Database>) {
 function testTablelessExpressionBuilder(
   eb: ExpressionBuilder<Database, never>,
 ) {
+  eb.and([eb.or([])])
+  eb.or([eb.and([])])
   expectError(eb.and({}))
   expectError(eb.or({}))
   expectError(eb.and(eb.or([])))


### PR DESCRIPTION
Hey 👋 

closes #1783.

This PR adds an extra check in `FilterObject<DB, TB>` to `KyselyTypeError` when `TB` is `never` to avoid `{}` which allows any defined values to be passed.