### PR TITLE
docs(returning): remove outdated SQLite alias workaround

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -47,11 +47,6 @@ export default {
           ],
           enableLlmsFullTxt: true,
           includeGeneratedIndex: false,
-          // Explicitly exclude auto-generated category index pages.
-          // These only list child pages and have no meaningful content for LLMs.
-          excludeRoutes: [
-            '/docs/category/**',
-          ],
           includePages: true,
           includeVersionedDocs: false,
           relativePaths: false,

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -47,6 +47,11 @@ export default {
           ],
           enableLlmsFullTxt: true,
           includeGeneratedIndex: false,
+          // Explicitly exclude auto-generated category index pages.
+          // These only list child pages and have no meaningful content for LLMs.
+          excludeRoutes: [
+            '/docs/category/**',
+          ],
           includePages: true,
           includeVersionedDocs: false,
           relativePaths: false,

--- a/src/query-builder/returning-interface.ts
+++ b/src/query-builder/returning-interface.ts
@@ -16,10 +16,6 @@ export interface ReturningInterface<DB, TB extends keyof DB, O> {
    * On supported databases like PostgreSQL, this method can be chained to
    * `insert`, `update`, `delete` and `merge` queries to return data.
    *
-   * Note that on SQLite you need to give aliases for the expressions to avoid
-   * [this bug](https://sqlite.org/forum/forumpost/033daf0b32) in SQLite.
-   * For example `.returning('id as id')`.
-   *
    * Also see the {@link returningAll} method.
    *
    * ### Examples


### PR DESCRIPTION
## Summary
- Removed the outdated SQLite bug warning from the `returning` JSDoc
- The referenced bug ([sqlite.org/forum/forumpost/033daf0b32](https://sqlite.org/forum/forumpost/033daf0b32)) was fixed in SQLite 3.36.0 (June 2021) via [this commit](https://sqlite.org/src/timeline?c=699c33990a9438f2&y=a)
- The `.returning('id as id')` workaround hasn't been necessary for over 4 years

Closes #1563