### PR TITLE
feat(mysql): database-side query cancellation.

### DIFF
--- a/src/dialect/mysql/mysql-dialect-config.ts
+++ b/src/dialect/mysql/mysql-dialect-config.ts
@@ -7,6 +7,13 @@ import type { DatabaseConnection } from '../../driver/database-connection.js'
  */
 export interface MysqlDialectConfig {
   /**
+   * The `mysql2` `createConnection` function or similar.
+   *
+   * TODO: ...
+   */
+  createConnection?: (opts: any) => MysqlConnection | Promise<MysqlConnection>
+
+  /**
    * A mysql2 Pool instance or a function that returns one.
    *
    * If a function is provided, it's called once when the first query is executed.
@@ -41,7 +48,10 @@ export interface MysqlPool {
   end(callback: (error: unknown) => void): void
 }
 
-export interface MysqlPoolConnection {
+export interface MysqlConnection {
+  config: unknown
+  connect(callback?: (error: unknown) => void): void
+  destroy(): void
   query(
     sql: string,
     parameters: Array<unknown>,
@@ -51,6 +61,12 @@ export interface MysqlPoolConnection {
     parameters: Array<unknown>,
     callback: (error: unknown, result: MysqlQueryResult) => void,
   ): void
+  threadId: number
+}
+
+export type MysqlConectionConstructor = new (opts?: object) => MysqlConnection
+
+export interface MysqlPoolConnection extends MysqlConnection {
   release(): void
 }
 

--- a/src/dialect/mysql/mysql-dialect-config.ts
+++ b/src/dialect/mysql/mysql-dialect-config.ts
@@ -1,17 +1,17 @@
 import type { DatabaseConnection } from '../../driver/database-connection.js'
+import type { AbortableOperationOptions } from '../../util/abort.js'
 
 /**
  * Config for the MySQL dialect.
- *
- * https://github.com/sidorares/node-mysql2#using-connection-pools
  */
 export interface MysqlDialectConfig {
   /**
-   * The `mysql2` `createConnection` function or similar.
+   * A `mysql2` `Client` constructor, to be used for connecting to the database
+   * outside of the `pool` to avoid waiting for an idle connection.
    *
-   * TODO: ...
+   * This is useful for cancelling queries on the database side.
    */
-  createConnection?: (opts: any) => MysqlConnection | Promise<MysqlConnection>
+  controlConnection?: (config: object) => MysqlConnection
 
   /**
    * A mysql2 Pool instance or a function that returns one.
@@ -20,17 +20,25 @@ export interface MysqlDialectConfig {
    *
    * https://github.com/sidorares/node-mysql2#using-connection-pools
    */
-  pool: MysqlPool | (() => Promise<MysqlPool>)
+  pool:
+    | MysqlPool
+    | ((options?: AbortableOperationOptions) => Promise<MysqlPool>)
 
   /**
    * Called once for each created connection.
    */
-  onCreateConnection?: (connection: DatabaseConnection) => Promise<void>
+  onCreateConnection?: (
+    connection: DatabaseConnection,
+    options?: AbortableOperationOptions,
+  ) => Promise<void>
 
   /**
-   * Called every time a connection is acquired from the connection pool.
+   * Called every time a connection is acquired from the pool.
    */
-  onReserveConnection?: (connection: DatabaseConnection) => Promise<void>
+  onReserveConnection?: (
+    connection: DatabaseConnection,
+    options?: AbortableOperationOptions,
+  ) => Promise<void>
 }
 
 /**
@@ -49,7 +57,7 @@ export interface MysqlPool {
 }
 
 export interface MysqlConnection {
-  config: unknown
+  config: object
   connect(callback?: (error: unknown) => void): void
   destroy(): void
   query(

--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -1,4 +1,5 @@
 import type {
+  ControlConnectionProvider,
   DatabaseConnection,
   QueryResult,
 } from '../../driver/database-connection.js'
@@ -39,7 +40,10 @@ export class MysqlDriver implements Driver {
     let connection = this.#connections.get(rawConnection)
 
     if (!connection) {
-      connection = new MysqlConnection(rawConnection)
+      connection = new MysqlConnection(
+        rawConnection,
+        this.#config.createConnection,
+      )
       this.#connections.set(rawConnection, connection)
 
       // The driver must take care of calling `onCreateConnection` when a new
@@ -55,18 +59,6 @@ export class MysqlDriver implements Driver {
     }
 
     return connection
-  }
-
-  async #acquireConnection(): Promise<MysqlPoolConnection> {
-    return new Promise((resolve, reject) => {
-      this.#pool!.getConnection(async (err, rawConnection) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(rawConnection)
-        }
-      })
-    })
   }
 
   async beginTransaction(
@@ -155,6 +147,18 @@ export class MysqlDriver implements Driver {
       })
     })
   }
+
+  async #acquireConnection(): Promise<MysqlPoolConnection> {
+    return new Promise((resolve, reject) => {
+      this.#pool!.getConnection(async (err, rawConnection) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(rawConnection)
+        }
+      })
+    })
+  }
 }
 
 function isOkPacket(obj: unknown): obj is MysqlOkPacket {
@@ -162,43 +166,91 @@ function isOkPacket(obj: unknown): obj is MysqlOkPacket {
 }
 
 class MysqlConnection implements DatabaseConnection {
+  readonly #createConnection: MysqlDialectConfig['createConnection']
   readonly #rawConnection: MysqlPoolConnection
 
-  constructor(rawConnection: MysqlPoolConnection) {
+  constructor(
+    rawConnection: MysqlPoolConnection,
+    createConnection: MysqlDialectConfig['createConnection'],
+  ) {
+    this.#createConnection = createConnection
     this.#rawConnection = rawConnection
+  }
+
+  async cancelQuery(
+    controlConnectionProvider: ControlConnectionProvider,
+  ): Promise<void> {
+    try {
+      // this removes the connection from the pool.
+      // this is done to avoid picking it up after the `kill` command next, which
+      // would cause an error when attempting to query.
+      this.#rawConnection.destroy()
+    } catch {
+      // noop
+    }
+
+    const { config, threadId } = this.#rawConnection
+
+    // this kills the query and the connection database-side.
+    // we're not using `kill query <connection_id>` here because it doesn't
+    // guarantee that the query is killed immediately. we saw that in tests,
+    // the query can still run for a while after - including registering writes.
+    const cancelQuery = `kill connection ${threadId}`
+
+    if (this.#createConnection && config) {
+      const controlConnection = await this.#createConnection({ ...config })
+
+      return await new Promise((resolve, reject) => {
+        controlConnection.connect((connectError) => {
+          if (connectError) {
+            return reject(connectError)
+          }
+
+          controlConnection.query(cancelQuery, [], (error) => {
+            controlConnection.destroy()
+
+            if (error) {
+              return reject(error)
+            }
+
+            resolve()
+          })
+        })
+      })
+    }
+
+    await controlConnectionProvider(async (controlConnection) => {
+      await controlConnection.executeQuery(CompiledQuery.raw(cancelQuery, []))
+    })
   }
 
   async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
     try {
       const result = await this.#executeQuery(compiledQuery)
 
-      if (isOkPacket(result)) {
-        const { insertId, affectedRows, changedRows } = result
-
+      if (!isOkPacket(result)) {
         return {
-          insertId:
-            insertId !== undefined &&
-            insertId !== null &&
-            insertId.toString() !== '0'
-              ? BigInt(insertId)
-              : undefined,
-          numAffectedRows:
-            affectedRows !== undefined && affectedRows !== null
-              ? BigInt(affectedRows)
-              : undefined,
-          numChangedRows:
-            changedRows !== undefined && changedRows !== null
-              ? BigInt(changedRows)
-              : undefined,
-          rows: [],
-        }
-      } else if (Array.isArray(result)) {
-        return {
-          rows: result as O[],
+          rows: (Array.isArray(result) ? result : []) as never,
         }
       }
 
+      const { insertId, affectedRows, changedRows } = result
+
       return {
+        insertId:
+          insertId !== undefined &&
+          insertId !== null &&
+          insertId.toString() !== '0'
+            ? BigInt(insertId)
+            : undefined,
+        numAffectedRows:
+          affectedRows !== undefined && affectedRows !== null
+            ? BigInt(affectedRows)
+            : undefined,
+        numChangedRows:
+          changedRows !== undefined && changedRows !== null
+            ? BigInt(changedRows)
+            : undefined,
         rows: [],
       }
     } catch (err) {
@@ -206,31 +258,13 @@ class MysqlConnection implements DatabaseConnection {
     }
   }
 
-  #executeQuery(compiledQuery: CompiledQuery): Promise<MysqlQueryResult> {
-    return new Promise((resolve, reject) => {
-      this.#rawConnection.query(
-        compiledQuery.sql,
-        compiledQuery.parameters as Array<unknown>,
-        (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        },
-      )
-    })
-  }
-
   async *streamQuery<O>(
     compiledQuery: CompiledQuery,
     _chunkSize: number,
   ): AsyncIterableIterator<QueryResult<O>> {
     const stream = this.#rawConnection
-      .query(compiledQuery.sql, compiledQuery.parameters as Array<unknown>)
-      .stream<O>({
-        objectMode: true,
-      })
+      .query(compiledQuery.sql, compiledQuery.parameters)
+      .stream<O>({ objectMode: true })
 
     try {
       for await (const row of stream) {
@@ -255,5 +289,21 @@ class MysqlConnection implements DatabaseConnection {
 
   [PRIVATE_RELEASE_METHOD](): void {
     this.#rawConnection.release()
+  }
+
+  #executeQuery(compiledQuery: CompiledQuery): Promise<MysqlQueryResult> {
+    return new Promise((resolve, reject) => {
+      this.#rawConnection.query(
+        compiledQuery.sql,
+        compiledQuery.parameters,
+        (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        },
+      )
+    })
   }
 }

--- a/src/dialect/mysql/mysql-driver.ts
+++ b/src/dialect/mysql/mysql-driver.ts
@@ -7,8 +7,12 @@ import type { Driver, TransactionSettings } from '../../driver/driver.js'
 import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
 import type { QueryCompiler } from '../../query-compiler/query-compiler.js'
+import {
+  waitOrAbort,
+  type AbortableOperationOptions,
+} from '../../util/abort.js'
 import { isFunction, isObject, freeze } from '../../util/object-utils.js'
-import { createQueryId } from '../../util/query-id.js'
+import { createQueryId, type QueryId } from '../../util/query-id.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
 import type {
   MysqlDialectConfig,
@@ -25,24 +29,27 @@ export class MysqlDriver implements Driver {
   readonly #connections = new WeakMap<MysqlPoolConnection, DatabaseConnection>()
   #pool?: MysqlPool
 
-  constructor(configOrPool: MysqlDialectConfig) {
-    this.#config = freeze({ ...configOrPool })
+  constructor(config: MysqlDialectConfig) {
+    this.#config = freeze({ ...config })
   }
 
-  async init(): Promise<void> {
+  async init(options?: AbortableOperationOptions): Promise<void> {
     this.#pool = isFunction(this.#config.pool)
-      ? await this.#config.pool()
+      ? await this.#config.pool(options)
       : this.#config.pool
   }
 
-  async acquireConnection(): Promise<DatabaseConnection> {
-    const rawConnection = await this.#acquireConnection()
+  async acquireConnection(
+    options?: AbortableOperationOptions,
+  ): Promise<DatabaseConnection> {
+    const rawConnection = await this.#acquireConnection(options)
+
     let connection = this.#connections.get(rawConnection)
 
     if (!connection) {
       connection = new MysqlConnection(
         rawConnection,
-        this.#config.createConnection,
+        this.#config.controlConnection,
       )
       this.#connections.set(rawConnection, connection)
 
@@ -50,12 +57,12 @@ export class MysqlDriver implements Driver {
       // connection is created. The `mysql2` module doesn't provide an async hook
       // for the connection creation. We need to call the method explicitly.
       if (this.#config?.onCreateConnection) {
-        await this.#config.onCreateConnection(connection)
+        await this.#config.onCreateConnection(connection, options)
       }
     }
 
     if (this.#config?.onReserveConnection) {
-      await this.#config.onReserveConnection(connection)
+      await this.#config.onReserveConnection(connection, options)
     }
 
     return connection
@@ -64,6 +71,7 @@ export class MysqlDriver implements Driver {
   async beginTransaction(
     connection: DatabaseConnection,
     settings: TransactionSettings,
+    options?: AbortableOperationOptions,
   ): Promise<void> {
     if (settings.isolationLevel || settings.accessMode) {
       const parts: string[] = []
@@ -79,30 +87,38 @@ export class MysqlDriver implements Driver {
       const sql = `set transaction ${parts.join(', ')}`
 
       // On MySQL this sets the isolation level of the next transaction.
-      await connection.executeQuery(CompiledQuery.raw(sql))
+      await connection.executeQuery(CompiledQuery.raw(sql), options)
     }
 
-    await connection.executeQuery(CompiledQuery.raw('begin'))
+    await connection.executeQuery(CompiledQuery.raw('begin'), options)
   }
 
-  async commitTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw('commit'))
+  async commitTransaction(
+    connection: DatabaseConnection,
+    options?: AbortableOperationOptions,
+  ): Promise<void> {
+    await connection.executeQuery(CompiledQuery.raw('commit'), options)
   }
 
-  async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw('rollback'))
+  async rollbackTransaction(
+    connection: DatabaseConnection,
+    options?: AbortableOperationOptions,
+  ): Promise<void> {
+    await connection.executeQuery(CompiledQuery.raw('rollback'), options)
   }
 
   async savepoint(
     connection: DatabaseConnection,
     savepointName: string,
     compileQuery: QueryCompiler['compileQuery'],
+    options?: AbortableOperationOptions,
   ): Promise<void> {
     await connection.executeQuery(
       compileQuery(
         parseSavepointCommand('savepoint', savepointName),
         createQueryId(),
       ),
+      options,
     )
   }
 
@@ -110,12 +126,14 @@ export class MysqlDriver implements Driver {
     connection: DatabaseConnection,
     savepointName: string,
     compileQuery: QueryCompiler['compileQuery'],
+    options?: AbortableOperationOptions,
   ): Promise<void> {
     await connection.executeQuery(
       compileQuery(
         parseSavepointCommand('rollback to', savepointName),
         createQueryId(),
       ),
+      options,
     )
   }
 
@@ -123,12 +141,14 @@ export class MysqlDriver implements Driver {
     connection: DatabaseConnection,
     savepointName: string,
     compileQuery: QueryCompiler['compileQuery'],
+    options?: AbortableOperationOptions,
   ): Promise<void> {
     await connection.executeQuery(
       compileQuery(
         parseSavepointCommand('release savepoint', savepointName),
         createQueryId(),
       ),
+      options,
     )
   }
 
@@ -148,16 +168,26 @@ export class MysqlDriver implements Driver {
     })
   }
 
-  async #acquireConnection(): Promise<MysqlPoolConnection> {
-    return new Promise((resolve, reject) => {
-      this.#pool!.getConnection(async (err, rawConnection) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(rawConnection)
-        }
-      })
-    })
+  async #acquireConnection(
+    options?: AbortableOperationOptions,
+  ): Promise<MysqlPoolConnection> {
+    const connectionPromise = new Promise<MysqlPoolConnection>(
+      (resolve, reject) => {
+        this.#pool!.getConnection(async (err, rawConnection) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(rawConnection)
+          }
+        })
+      },
+    )
+
+    return waitOrAbort(connectionPromise, options?.signal, 'pool connect', () =>
+      connectionPromise
+        .then((connection) => connection.release())
+        .catch(() => {}),
+    )
   }
 }
 
@@ -166,66 +196,31 @@ function isOkPacket(obj: unknown): obj is MysqlOkPacket {
 }
 
 class MysqlConnection implements DatabaseConnection {
-  readonly #createConnection: MysqlDialectConfig['createConnection']
-  readonly #rawConnection: MysqlPoolConnection
+  readonly #connection: MysqlPoolConnection
+  readonly #controlConnection: MysqlDialectConfig['controlConnection']
+  #queryId?: QueryId
 
   constructor(
-    rawConnection: MysqlPoolConnection,
-    createConnection: MysqlDialectConfig['createConnection'],
+    connection: MysqlPoolConnection,
+    controlConnection: MysqlDialectConfig['controlConnection'],
   ) {
-    this.#createConnection = createConnection
-    this.#rawConnection = rawConnection
+    this.#connection = connection
+    this.#controlConnection = controlConnection
   }
 
   async cancelQuery(
     controlConnectionProvider: ControlConnectionProvider,
   ): Promise<void> {
-    try {
-      // this removes the connection from the pool.
-      // this is done to avoid picking it up after the `kill` command next, which
-      // would cause an error when attempting to query.
-      this.#rawConnection.destroy()
-    } catch {
-      // noop
-    }
-
-    const { config, threadId } = this.#rawConnection
-
-    // this kills the query and the connection database-side.
-    // we're not using `kill query <connection_id>` here because it doesn't
-    // guarantee that the query is killed immediately. we saw that in tests,
-    // the query can still run for a while after - including registering writes.
-    const cancelQuery = `kill connection ${threadId}`
-
-    if (this.#createConnection && config) {
-      const controlConnection = await this.#createConnection({ ...config })
-
-      return await new Promise((resolve, reject) => {
-        controlConnection.connect((connectError) => {
-          if (connectError) {
-            return reject(connectError)
-          }
-
-          controlConnection.query(cancelQuery, [], (error) => {
-            controlConnection.destroy()
-
-            if (error) {
-              return reject(error)
-            }
-
-            resolve()
-          })
-        })
-      })
-    }
-
-    await controlConnectionProvider(async (controlConnection) => {
-      await controlConnection.executeQuery(CompiledQuery.raw(cancelQuery, []))
-    })
+    await this.#executeControlQuery(
+      `kill query ${this.#connection.threadId}`,
+      controlConnectionProvider,
+    )
   }
 
   async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
     try {
+      this.#queryId = compiledQuery.queryId
+
       const result = await this.#executeQuery(compiledQuery)
 
       if (!isOkPacket(result)) {
@@ -238,32 +233,45 @@ class MysqlConnection implements DatabaseConnection {
 
       return {
         insertId:
-          insertId !== undefined &&
-          insertId !== null &&
-          insertId.toString() !== '0'
+          insertId != null && insertId.toString() !== '0'
             ? BigInt(insertId)
             : undefined,
         numAffectedRows:
-          affectedRows !== undefined && affectedRows !== null
-            ? BigInt(affectedRows)
-            : undefined,
-        numChangedRows:
-          changedRows !== undefined && changedRows !== null
-            ? BigInt(changedRows)
-            : undefined,
+          affectedRows != null ? BigInt(affectedRows) : undefined,
+        numChangedRows: changedRows != null ? BigInt(changedRows) : undefined,
         rows: [],
       }
     } catch (err) {
       throw extendStackTrace(err, new Error())
+    } finally {
+      this.#queryId = undefined
     }
+  }
+
+  async killSession(
+    controlConnectionProvider: ControlConnectionProvider,
+  ): Promise<void> {
+    try {
+      // this removes the connection from the pool.
+      // this is done to avoid picking it up after the `kill` command next, which
+      // would cause an error when attempting to query.
+      this.#connection.destroy()
+    } catch {
+      // noop
+    }
+
+    await this.#executeControlQuery(
+      `kill connection ${this.#connection.threadId}`,
+      controlConnectionProvider,
+    )
   }
 
   async *streamQuery<O>(
     compiledQuery: CompiledQuery,
     _chunkSize: number,
   ): AsyncIterableIterator<QueryResult<O>> {
-    const stream = this.#rawConnection
-      .query(compiledQuery.sql, compiledQuery.parameters)
+    const stream = this.#connection
+      .query(compiledQuery.sql, [...compiledQuery.parameters])
       .stream<O>({ objectMode: true })
 
     try {
@@ -288,14 +296,14 @@ class MysqlConnection implements DatabaseConnection {
   }
 
   [PRIVATE_RELEASE_METHOD](): void {
-    this.#rawConnection.release()
+    this.#connection.release()
   }
 
   #executeQuery(compiledQuery: CompiledQuery): Promise<MysqlQueryResult> {
     return new Promise((resolve, reject) => {
-      this.#rawConnection.query(
+      this.#connection.query(
         compiledQuery.sql,
-        compiledQuery.parameters,
+        [...compiledQuery.parameters],
         (err, result) => {
           if (err) {
             reject(err)
@@ -305,5 +313,65 @@ class MysqlConnection implements DatabaseConnection {
         },
       )
     })
+  }
+
+  async #executeControlQuery(
+    query: string,
+    controlConnectionProvider: ControlConnectionProvider,
+  ): Promise<void> {
+    if (!this.#queryId) {
+      return
+    }
+
+    const { config } = this.#connection
+
+    const queryIdToCancel = this.#queryId
+
+    // we fallback to a pool connection, and execute a SQL query to cancel the
+    // query. this is not ideal, as we might have to wait for an idle connection.
+    if (!this.#controlConnection || !config) {
+      return await controlConnectionProvider(async (controlConnection) => {
+        // by the time we get the connection, another query might have been executed.
+        // we need to ensure we're not canceling the wrong query.
+        if (queryIdToCancel.queryId === this.#queryId?.queryId) {
+          await controlConnection.executeQuery(CompiledQuery.raw(query, []))
+        }
+      })
+    }
+
+    const {
+      // omitting these as they cause a warning and perhaps a future error when passed.
+      clientFlags: _,
+      maxPacketSize: __,
+      ...cfg
+    } = config as Record<string, unknown>
+
+    const controlConnection = this.#controlConnection(cfg)
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        controlConnection.connect((connectError) => {
+          if (connectError) {
+            return reject(connectError)
+          }
+
+          // by the time we get the connection, another query might have been executed.
+          // we need to ensure we're not canceling the wrong query.
+          if (queryIdToCancel.queryId !== this.#queryId?.queryId) {
+            return resolve()
+          }
+
+          controlConnection.query(query, [], (queryError) => {
+            if (queryError) {
+              return reject(queryError)
+            }
+
+            resolve()
+          })
+        })
+      })
+    } finally {
+      controlConnection.destroy()
+    }
   }
 }

--- a/src/dialect/postgres/postgres-dialect-config.ts
+++ b/src/dialect/postgres/postgres-dialect-config.ts
@@ -6,12 +6,12 @@ import type { AbortableOperationOptions } from '../../util/abort.js'
  */
 export interface PostgresDialectConfig {
   /**
-   * A postgres `Client` constructor, to be used for connecting to the database
+   * A `pg` `Client` constructor, to be used for connecting to the database
    * outside of the `pool` to avoid waiting for an idle connection.
    *
    * This is useful for cancelling queries on the database side.
    *
-   * Defaults to the pool's undocumented `Client` member, if it exists.
+   * Defaults to the `Pool`'s undocumented `Client` member, if it exists.
    */
   controlClient?: PostgresClientConstructor
 

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -7,7 +7,10 @@ import type { Driver, TransactionSettings } from '../../driver/driver.js'
 import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
 import type { QueryCompiler } from '../../query-compiler/query-compiler.js'
-import type { AbortableOperationOptions } from '../../util/abort.js'
+import {
+  waitOrAbort,
+  type AbortableOperationOptions,
+} from '../../util/abort.js'
 import { isFunction, freeze } from '../../util/object-utils.js'
 import { createQueryId, type QueryId } from '../../util/query-id.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'
@@ -39,12 +42,20 @@ export class PostgresDriver implements Driver {
   async acquireConnection(
     options?: AbortableOperationOptions,
   ): Promise<DatabaseConnection> {
-    const client = await this.#pool!.connect()
+    const clientPromise = this.#pool!.connect()
+
+    const client = await waitOrAbort(
+      clientPromise,
+      options?.signal,
+      'pool connect',
+      () => clientPromise.then((client) => client.release()).catch(() => {}),
+    )
+
     let connection = this.#connections.get(client)
 
     if (!connection) {
       connection = new PostgresConnection(client, {
-        Client: this.#config.controlClient || this.#pool!.Client,
+        controlClient: this.#config.controlClient || this.#pool!.Client,
         cursor: this.#config.cursor ?? null,
         poolOptions: this.#pool!.options,
       })
@@ -160,7 +171,7 @@ export class PostgresDriver implements Driver {
 }
 
 interface PostgresConnectionOptions {
-  Client?: PostgresClientConstructor
+  controlClient?: PostgresClientConstructor
   cursor: PostgresCursorConstructor | null
   poolOptions: object
 }
@@ -311,7 +322,7 @@ class PostgresConnection implements DatabaseConnection {
       return
     }
 
-    const { Client, poolOptions } = this.#options
+    const { controlClient: Client, poolOptions } = this.#options
 
     const queryIdToCancel = this.#queryId
 

--- a/src/driver/runtime-driver.ts
+++ b/src/driver/runtime-driver.ts
@@ -102,36 +102,36 @@ export class RuntimeDriver implements Driver {
     this.#connectionMutex?.unlock()
   }
 
-  beginTransaction(
+  async beginTransaction(
     connection: DatabaseConnection,
     settings: TransactionSettings,
     options?: AbortableOperationOptions,
   ): Promise<void> {
-    return this.#driver.beginTransaction(connection, settings, options)
+    return await this.#driver.beginTransaction(connection, settings, options)
   }
 
-  commitTransaction(
+  async commitTransaction(
     connection: DatabaseConnection,
     options?: AbortableOperationOptions,
   ): Promise<void> {
-    return this.#driver.commitTransaction(connection, options)
+    return await this.#driver.commitTransaction(connection, options)
   }
 
-  rollbackTransaction(
+  async rollbackTransaction(
     connection: DatabaseConnection,
     options?: AbortableOperationOptions,
   ): Promise<void> {
-    return this.#driver.rollbackTransaction(connection, options)
+    return await this.#driver.rollbackTransaction(connection, options)
   }
 
-  savepoint(
+  async savepoint(
     connection: DatabaseConnection,
     savepointName: string,
     compileQuery: QueryCompiler['compileQuery'],
     options?: AbortableOperationOptions,
   ): Promise<void> {
     if (this.#driver.savepoint) {
-      return this.#driver.savepoint(
+      return await this.#driver.savepoint(
         connection,
         savepointName,
         compileQuery,
@@ -142,14 +142,14 @@ export class RuntimeDriver implements Driver {
     throw new Error('The `savepoint` method is not supported by this driver')
   }
 
-  rollbackToSavepoint(
+  async rollbackToSavepoint(
     connection: DatabaseConnection,
     savepointName: string,
     compileQuery: QueryCompiler['compileQuery'],
     options?: AbortableOperationOptions,
   ): Promise<void> {
     if (this.#driver.rollbackToSavepoint) {
-      return this.#driver.rollbackToSavepoint(
+      return await this.#driver.rollbackToSavepoint(
         connection,
         savepointName,
         compileQuery,
@@ -162,14 +162,14 @@ export class RuntimeDriver implements Driver {
     )
   }
 
-  releaseSavepoint(
+  async releaseSavepoint(
     connection: DatabaseConnection,
     savepointName: string,
     compileQuery: QueryCompiler['compileQuery'],
     options?: AbortableOperationOptions,
   ): Promise<void> {
     if (this.#driver.releaseSavepoint) {
-      return this.#driver.releaseSavepoint(
+      return await this.#driver.releaseSavepoint(
         connection,
         savepointName,
         compileQuery,

--- a/src/util/abort.ts
+++ b/src/util/abort.ts
@@ -107,33 +107,41 @@ export function throwReasonWithTiming(reason: any, timing: string): never {
   throw reason
 }
 
+const ABORT_TOKEN = {} as symbol
+
 export async function waitOrAbort<T>(
   happyPromise: Promise<T> | (() => Promise<T>),
   signal: AbortSignal | undefined,
   name: string,
+  onAbort?: (happyPromise?: Promise<T>) => void | Promise<void>,
 ): Promise<T> {
   if (!signal) {
     return typeof happyPromise === 'function' ? happyPromise() : happyPromise
   }
 
-  assertNotAborted(signal, name)
+  const { promise: abortPromise, resolve } = new Deferred<typeof ABORT_TOKEN>()
 
-  const { promise: abortPromise, reject, resolve } = new Deferred<never>()
-
-  const abortListener = () => reject(decorateWithTiming(signal.reason, name))
+  const abortListener = () => resolve(ABORT_TOKEN)
 
   try {
-    assertNotAborted(signal, name)
+    assertNotAborted(signal, `before ${name}`, onAbort)
 
     signal.addEventListener('abort', abortListener)
 
-    return await Promise.race([
-      typeof happyPromise === 'function' ? happyPromise() : happyPromise,
-      abortPromise,
-    ])
+    happyPromise =
+      typeof happyPromise === 'function' ? happyPromise() : happyPromise
+
+    const result = await Promise.race([happyPromise, abortPromise])
+
+    if (result !== ABORT_TOKEN) {
+      return result as T
+    }
+
+    onAbort?.(happyPromise)
+    throwReasonWithTiming(signal.reason, `during ${name}`)
   } finally {
     signal.removeEventListener('abort', abortListener)
-    resolve(undefined as never)
+    resolve(ABORT_TOKEN)
   }
 }
 

--- a/test/node/src/cancellation.test.ts
+++ b/test/node/src/cancellation.test.ts
@@ -1,10 +1,6 @@
 import { setTimeout } from 'node:timers/promises'
 import { expect } from 'chai'
-import {
-  type InsertQueryBuilder,
-  type RawBuilder,
-  sql,
-} from '../../../dist/index.js'
+import { type RawBuilder, sql } from '../../../dist/index.js'
 import {
   clearDatabase,
   destroyTest,
@@ -12,7 +8,6 @@ import {
   initTest,
   insertDefaultDataSet,
   PG_ERRORS,
-  type Database,
   type TestContext,
 } from './test-setup.js'
 

--- a/test/node/src/cancellation.test.ts
+++ b/test/node/src/cancellation.test.ts
@@ -38,15 +38,14 @@ for (const dialect of DIALECTS) {
       await destroyTest(ctx)
     })
 
-    function getDelayedWriteQuery(
+    function getLongRunningWriteQuery(
       sqlSpec: Exclude<(typeof dialect)['sqlSpec'], 'sqlite'>,
-      writeQuery: InsertQueryBuilder<Database, any, any>,
     ) {
       return (
         {
-          postgres: sql`select pg_sleep(0.1); ${writeQuery};`,
-          mysql: sql`select sleep(0.1); ${writeQuery};`,
-          mssql: sql`waitfor delay '00:00:00.100'; ${writeQuery};`,
+          postgres: sql`with delayed as (select pg_sleep(0.1)) insert into person (gender) select 'woah' from delayed;`,
+          mysql: sql`insert into person (gender) select 'woah' from (select sleep(0.1)) as t;`,
+          mssql: sql`waitfor delay '00:00:00.100'; insert into person (gender) values ('woah');`,
         } as const satisfies Record<typeof sqlSpec, RawBuilder<any>>
       )[sqlSpec]
     }
@@ -77,12 +76,8 @@ for (const dialect of DIALECTS) {
 
     if (variant === 'mssql' || variant === 'mysql' || variant === 'postgres') {
       it('should throw an abort error when aborted during query execution', async () => {
-        const writeQuery = ctx.db
-          .insertInto('person')
-          .values({ gender: sql.lit('woah') as never })
-
         await expect(
-          getDelayedWriteQuery(sqlSpec, writeQuery).execute(ctx.db, {
+          getLongRunningWriteQuery(sqlSpec).execute(ctx.db, {
             signal: AbortSignal.timeout(10),
           }),
         )
@@ -95,7 +90,7 @@ for (const dialect of DIALECTS) {
             },
           )
 
-        await setTimeout(250) // long enough to ensure that if the query was not aborted, the write would have registered.
+        await setTimeout(250)
         await expect(
           ctx.db
             .selectFrom('person')
@@ -108,15 +103,10 @@ for (const dialect of DIALECTS) {
       })
     }
 
-    // database-side cancellation was only implemented in PostgresDialect thus far.
-    if (variant === 'postgres') {
+    if (variant === 'postgres' || variant === 'mysql') {
       it("should cancel query on database side when inflightQueryAbortStrategy is 'cancel query'", async () => {
-        const writeQuery = ctx.db
-          .insertInto('person')
-          .values({ gender: sql.lit('woah') as never })
-
         await expect(
-          getDelayedWriteQuery(sqlSpec, writeQuery).execute(ctx.db, {
+          getLongRunningWriteQuery(sqlSpec).execute(ctx.db, {
             inflightQueryAbortStrategy: 'cancel query',
             signal: AbortSignal.timeout(10),
           }),
@@ -130,7 +120,7 @@ for (const dialect of DIALECTS) {
             },
           )
 
-        await setTimeout(250) // long enough to ensure that if the query was not aborted, the write would have registered.
+        await setTimeout(250)
         await expect(
           ctx.db
             .selectFrom('person')
@@ -143,12 +133,8 @@ for (const dialect of DIALECTS) {
       })
 
       it("should kill session on database side when inflightQueryAbortStrategy is 'kill session'", async () => {
-        const writeQuery = ctx.db
-          .insertInto('person')
-          .values({ gender: sql.lit('woah') as never })
-
         await expect(
-          getDelayedWriteQuery(sqlSpec, writeQuery).execute(ctx.db, {
+          getLongRunningWriteQuery(sqlSpec).execute(ctx.db, {
             inflightQueryAbortStrategy: 'kill session',
             signal: AbortSignal.timeout(10),
           }),
@@ -162,7 +148,7 @@ for (const dialect of DIALECTS) {
             },
           )
 
-        await setTimeout(250) // long enough to ensure that if the query was not aborted, the write would have registered.
+        await setTimeout(250)
         await expect(
           ctx.db
             .selectFrom('person')
@@ -172,6 +158,7 @@ for (const dialect of DIALECTS) {
         ).to.eventually.satisfy((result: { count: unknown }) =>
           expect(Number(result.count)).to.equal(0),
         )
+
         if (variant === 'postgres') {
           expect(PG_ERRORS.at(-1)?.message).to.equal(
             'Connection terminated unexpectedly',

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -203,6 +203,7 @@ export const DB_CONFIGS: PerDialectVariant<KyselyConfig> = {
 
   mysql: {
     dialect: new MysqlDialect({
+      createConnection,
       pool: async () => createPool(DIALECT_CONFIGS.mysql),
     }),
     plugins: PLUGINS,

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -2,7 +2,7 @@ import * as chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import Cursor from 'pg-cursor'
 import { Client, Pool, type PoolConfig } from 'pg'
-import { createPool } from 'mysql2'
+import { createConnection, createPool } from 'mysql2'
 import Database from 'better-sqlite3'
 import * as Tarn from 'tarn'
 import * as Tedious from 'tedious'
@@ -203,7 +203,7 @@ export const DB_CONFIGS: PerDialectVariant<KyselyConfig> = {
 
   mysql: {
     dialect: new MysqlDialect({
-      createConnection,
+      controlConnection: createConnection,
       pool: async () => createPool(DIALECT_CONFIGS.mysql),
     }),
     plugins: PLUGINS,


### PR DESCRIPTION
Hey 👋 

This PR implements database-side query cancellation in the MySQL dialect. It also passes the signal around everything async in that dialect.

You can optionally pass a `createConnection` function to the dialect config and it'll be the control connection creator that'll run `kill <query | connection> <thread_id>` queries to cancel your queries when using the database-side cancellation abort strategies.