### PR TITLE
refactor: remove long deprecated things.

### DIFF
--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -11,13 +11,6 @@ export interface DatabaseIntrospector {
    * Get tables and views metadata.
    */
   getTables(options?: DatabaseMetadataOptions): Promise<TableMetadata[]>
-
-  /**
-   * Get the database metadata such as table and column names.
-   *
-   * @deprecated Use getTables() instead.
-   */
-  getMetadata(options?: DatabaseMetadataOptions): Promise<DatabaseMetadata>
 }
 
 export interface DatabaseMetadataOptions {
@@ -30,14 +23,6 @@ export interface DatabaseMetadataOptions {
 
 export interface SchemaMetadata {
   readonly name: string
-}
-
-export interface DatabaseMetadata {
-  /**
-   * The tables and views found in the database.
-   * The propery isView can be used to tell them apart.
-   */
-  readonly tables: TableMetadata[]
 }
 
 export interface TableMetadata {

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -79,11 +79,6 @@ export interface Tedious {
   connectionFactory: () => TediousConnection | Promise<TediousConnection>
   ISOLATION_LEVEL: TediousIsolationLevel
   Request: TediousRequestClass
-  // TODO: remove in v0.29.0
-  /**
-   * @deprecated use {@link MssqlDialectConfig.resetConnectionsOnRelease} instead.
-   */
-  resetConnectionOnRelease?: KyselyTypeError<'deprecated: use `MssqlDialectConfig.resetConnectionsOnRelease` instead'>
   TYPES: TediousTypes
 }
 
@@ -180,13 +175,7 @@ export interface Tarn {
    * Tarn.js' pool options, excluding `create`, `destroy` and `validate` functions,
    * which must be implemented by this dialect.
    */
-  options: Omit<TarnPoolOptions<any>, 'create' | 'destroy' | 'validate'> & {
-    // TODO: remove in v0.29.0
-    /**
-     * @deprecated use {@link MssqlDialectConfig.validateConnections} instead.
-     */
-    validateConnections?: KyselyTypeError<'deprecated: use `MssqlDialectConfig.validateConnections` instead'>
-  }
+  options: Omit<TarnPoolOptions<any>, 'create' | 'destroy' | 'validate'>
 
   /**
    * Tarn.js' Pool class.

--- a/src/dialect/mssql/mssql-dialect-config.ts
+++ b/src/dialect/mssql/mssql-dialect-config.ts
@@ -1,5 +1,3 @@
-import type { KyselyTypeError } from '../../util/type-error.js'
-
 export interface MssqlDialectConfig {
   /**
    * When `true`, connections are reset to their initial states when released

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -118,7 +118,6 @@ class MssqlConnection implements DatabaseConnection {
   #hasSocketError: boolean
   readonly #tedious: Tedious
   #inflightRequest: MssqlRequest<any> | undefined
-  #sessionId: unknown
 
   constructor(connection: TediousConnection, tedious: Tedious) {
     this.#connection = connection

--- a/src/dialect/mssql/mssql-driver.ts
+++ b/src/dialect/mssql/mssql-driver.ts
@@ -43,13 +43,9 @@ export class MssqlDriver implements Driver {
     this.#config = freeze({ ...config })
 
     const { tarn, tedious, validateConnections } = this.#config
-    const {
-      validateConnections: deprecatedValidateConnections,
-      ...poolOptions
-    } = tarn.options
 
     this.#pool = new tarn.Pool({
-      ...poolOptions,
+      ...tarn.options,
       create: async () => {
         const connection = await tedious.connectionFactory()
 
@@ -61,8 +57,7 @@ export class MssqlDriver implements Driver {
       // @ts-ignore `tarn` accepts a function that returns a promise here, but
       // the types are not aligned and it type errors.
       validate:
-        validateConnections === false ||
-        (deprecatedValidateConnections as any) === false
+        validateConnections === false
           ? undefined
           : (connection) => connection[PRIVATE_VALIDATE_METHOD](),
     })
@@ -106,10 +101,7 @@ export class MssqlDriver implements Driver {
   }
 
   async releaseConnection(connection: MssqlConnection): Promise<void> {
-    if (
-      this.#config.resetConnectionsOnRelease ||
-      this.#config.tedious.resetConnectionOnRelease
-    ) {
+    if (this.#config.resetConnectionsOnRelease) {
       await connection[PRIVATE_RESET_METHOD]()
     }
 

--- a/src/dialect/mssql/mssql-introspector.ts
+++ b/src/dialect/mssql/mssql-introspector.ts
@@ -1,7 +1,6 @@
 import type { Kysely } from '../../kysely.js'
 import type {
   DatabaseIntrospector,
-  DatabaseMetadata,
   DatabaseMetadataOptions,
   SchemaMetadata,
   TableMetadata,
@@ -168,14 +167,6 @@ export class MssqlIntrospector implements DatabaseIntrospector {
     }
 
     return Object.values(tableDictionary)
-  }
-
-  async getMetadata(
-    options?: DatabaseMetadataOptions,
-  ): Promise<DatabaseMetadata> {
-    return {
-      tables: await this.getTables(options),
-    }
   }
 }
 

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -1,6 +1,5 @@
 import type {
   DatabaseIntrospector,
-  DatabaseMetadata,
   DatabaseMetadataOptions,
   SchemaMetadata,
   TableMetadata,
@@ -66,14 +65,6 @@ export class MysqlIntrospector implements DatabaseIntrospector {
 
     const rawColumns = await query.execute()
     return this.#parseTableMetadata(rawColumns)
-  }
-
-  async getMetadata(
-    options?: DatabaseMetadataOptions,
-  ): Promise<DatabaseMetadata> {
-    return {
-      tables: await this.getTables(options),
-    }
   }
 
   #parseTableMetadata(columns: RawColumnMetadata[]): TableMetadata[] {

--- a/src/dialect/postgres/postgres-driver.ts
+++ b/src/dialect/postgres/postgres-driver.ts
@@ -7,10 +7,7 @@ import type { Driver, TransactionSettings } from '../../driver/driver.js'
 import { parseSavepointCommand } from '../../parser/savepoint-parser.js'
 import { CompiledQuery } from '../../query-compiler/compiled-query.js'
 import type { QueryCompiler } from '../../query-compiler/query-compiler.js'
-import type {
-  AbortableOperationOptions,
-  AbortableQueryOptions,
-} from '../../util/abort.js'
+import type { AbortableOperationOptions } from '../../util/abort.js'
 import { isFunction, freeze } from '../../util/object-utils.js'
 import { createQueryId, type QueryId } from '../../util/query-id.js'
 import { extendStackTrace } from '../../util/stack-trace-utils.js'

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -1,6 +1,5 @@
 import type {
   DatabaseIntrospector,
-  DatabaseMetadata,
   DatabaseMetadataOptions,
   SchemaMetadata,
   TableMetadata,
@@ -95,14 +94,6 @@ export class PostgresIntrospector implements DatabaseIntrospector {
     const rawColumns = await query.execute()
 
     return this.#parseTableMetadata(rawColumns)
-  }
-
-  async getMetadata(
-    options?: DatabaseMetadataOptions,
-  ): Promise<DatabaseMetadata> {
-    return {
-      tables: await this.getTables(options),
-    }
   }
 
   #parseTableMetadata(columns: RawColumnMetadata[]): TableMetadata[] {

--- a/src/dialect/sqlite/sqlite-introspector.ts
+++ b/src/dialect/sqlite/sqlite-introspector.ts
@@ -1,6 +1,5 @@
 import type {
   DatabaseIntrospector,
-  DatabaseMetadata,
   DatabaseMetadataOptions,
   SchemaMetadata,
   TableMetadata,
@@ -53,14 +52,6 @@ export class SqliteIntrospector implements DatabaseIntrospector {
     options: DatabaseMetadataOptions = { withInternalKyselyTables: false },
   ): Promise<TableMetadata[]> {
     return await this.#getTableMetadata(options)
-  }
-
-  async getMetadata(
-    options?: DatabaseMetadataOptions,
-  ): Promise<DatabaseMetadata> {
-    return {
-      tables: await this.getTables(options),
-    }
   }
 
   #tablesQuery(

--- a/src/expression/expression-builder.ts
+++ b/src/expression/expression-builder.ts
@@ -8,7 +8,6 @@ import {
   type TableExpressionOrList,
   parseTable,
 } from '../parser/table-parser.js'
-import { WithSchemaPlugin } from '../plugin/with-schema/with-schema-plugin.js'
 import { createQueryId } from '../util/query-id.js'
 import {
   createFunctionModule,
@@ -1144,13 +1143,6 @@ export interface ExpressionBuilder<DB, TB extends keyof DB> {
     expr: RE,
     dataType: DataTypeExpression,
   ): ExpressionWrapper<DB, TB, T>
-
-  /**
-   * See {@link QueryCreator.withSchema}
-   *
-   * @deprecated Will be removed in kysely 0.25.0.
-   */
-  withSchema(schema: string): ExpressionBuilder<DB, TB>
 }
 
 export function createExpressionBuilder<DB, TB extends keyof DB>(
@@ -1367,12 +1359,6 @@ export function createExpressionBuilder<DB, TB extends keyof DB>(
           parseReferenceExpression(expr),
           parseDataTypeExpression(dataType),
         ),
-      )
-    },
-
-    withSchema(schema: string): ExpressionBuilder<DB, TB> {
-      return createExpressionBuilder(
-        executor.withPluginAtFront(new WithSchemaPlugin(schema)),
       )
     },
   })

--- a/src/operation-node/drop-table-node.ts
+++ b/src/operation-node/drop-table-node.ts
@@ -2,10 +2,14 @@ import { freeze } from '../util/object-utils.js'
 import type { OperationNode } from './operation-node.js'
 import type { TableNode } from './table-node.js'
 
-export type DropTablexNodeParams = Omit<
-  Partial<DropTableNode>,
-  'kind' | 'table'
->
+export type DropTableNodeParams = Omit<Partial<DropTableNode>, 'kind' | 'table'>
+
+// TODO: remove in 0.30
+/**
+ * @deprecated use {@link DropTableNodeParams} instead.
+ */
+export type DropTablexNodeParams = DropTableNodeParams
+
 export interface DropTableNode extends OperationNode {
   readonly kind: 'DropTableNode'
   readonly table: TableNode
@@ -18,11 +22,11 @@ type DropTableNodeFactory = Readonly<{
   is(node: OperationNode): node is DropTableNode
   create(
     table: TableNode,
-    params?: DropTablexNodeParams,
+    params?: DropTableNodeParams,
   ): Readonly<DropTableNode>
   cloneWith(
     dropIndex: DropTableNode,
-    params: DropTablexNodeParams,
+    params: DropTableNodeParams,
   ): Readonly<DropTableNode>
 }>
 

--- a/src/operation-node/insert-query-node.ts
+++ b/src/operation-node/insert-query-node.ts
@@ -22,9 +22,6 @@ export interface InsertQueryNode extends OperationNode {
   readonly onConflict?: OnConflictNode
   readonly onDuplicateKey?: OnDuplicateKeyNode
   readonly with?: WithNode
-  // TODO: remove in 0.29
-  /** @deprecated use {@link orAction} instead. */
-  readonly ignore?: boolean
   readonly orAction?: OrActionNode
   readonly replace?: boolean
   readonly explain?: ExplainNode

--- a/src/operation-node/operation-node-transformer.ts
+++ b/src/operation-node/operation-node-transformer.ts
@@ -429,7 +429,6 @@ export class OperationNodeTransformer {
       onDuplicateKey: this.transformNode(node.onDuplicateKey, queryId),
       endModifiers: this.transformNodeList(node.endModifiers, queryId),
       with: this.transformNode(node.with, queryId),
-      ignore: node.ignore,
       orAction: this.transformNode(node.orAction, queryId),
       replace: node.replace,
       explain: this.transformNode(node.explain, queryId),

--- a/src/operation-node/primary-key-constraint-node.ts
+++ b/src/operation-node/primary-key-constraint-node.ts
@@ -51,10 +51,3 @@ export const PrimaryKeyConstraintNode: PrimaryKeyConstraintNodeFactory =
       return freeze({ ...node, ...props })
     },
   })
-
-/**
- * Backwards compatibility for a typo in the codebase.
- *
- * @deprecated Use {@link PrimaryKeyConstraintNode} instead.
- */
-export const PrimaryConstraintNode = PrimaryKeyConstraintNode

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -49,11 +49,7 @@ import { UpdateResult } from './update-result.js'
 import type { KyselyPlugin } from '../plugin/kysely-plugin.js'
 import type { WhereInterface } from './where-interface.js'
 import type { MultiTableReturningInterface } from './returning-interface.js'
-import {
-  isNoResultErrorConstructor,
-  NoResultError,
-  type NoResultErrorConstructor,
-} from './no-result-error.js'
+import { isNoResultErrorConstructor, NoResultError } from './no-result-error.js'
 import type { Explainable, ExplainFormat } from '../util/explainable.js'
 import type { AliasedExpression, Expression } from '../expression/expression.js'
 import {

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -112,7 +112,6 @@ import type { TopNode } from '../operation-node/top-node.js'
 import type { OutputNode } from '../operation-node/output-node.js'
 import type { RefreshMaterializedViewNode } from '../operation-node/refresh-materialized-view-node.js'
 import type { OrActionNode } from '../operation-node/or-action-node.js'
-import { logOnce } from '../util/log-once.js'
 import type { CollateNode } from '../operation-node/collate-node.js'
 import type { QueryId } from '../util/query-id.js'
 import type { RenameConstraintNode } from '../operation-node/rename-constraint-node.js'
@@ -324,14 +323,6 @@ export class DefaultQueryCompiler
     }
 
     this.append(node.replace ? 'replace' : 'insert')
-
-    // TODO: remove in 0.29.
-    if (node.ignore) {
-      logOnce(
-        '`InsertQueryNode.ignore` is deprecated. Use `InsertQueryNode.orAction` instead.',
-      )
-      this.append(' ignore')
-    }
 
     if (node.orAction) {
       this.append(' ')

--- a/src/schema/create-index-builder.ts
+++ b/src/schema/create-index-builder.ts
@@ -24,10 +24,7 @@ import { QueryNode } from '../operation-node/query-node.js'
 import type { ExpressionBuilder } from '../expression/expression-builder.js'
 import type { ShallowRecord, SqlBool } from '../util/type-utils.js'
 import { ImmediateValueTransformer } from '../plugin/immediate-value/immediate-value-transformer.js'
-import type {
-  AbortableOperationOptions,
-  AbortableQueryOptions,
-} from '../util/abort.js'
+import type { AbortableQueryOptions } from '../util/abort.js'
 
 export class CreateIndexBuilder<C = never>
   implements OperationNodeSource, Compilable

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -582,16 +582,8 @@ export function orderBy<QB extends SelectQueryBuilder<any, any, any>>(
   direction: OrderByDirection | undefined,
   dialect: DialectDescriptor,
 ): (qb: QB) => QB {
-  return (qb) => {
-    if (dialect.sqlSpec === 'mssql') {
-      return qb.orderBy(
-        orderBy,
-        sql`${sql.raw(direction ? `${direction} ` : '')}${sql.raw(
-          'offset 0 rows',
-        )}`,
-      ) as QB
-    }
-
-    return qb.orderBy(orderBy, direction) as QB
-  }
+  return (qb) =>
+    qb
+      .orderBy(orderBy, direction)
+      .$if(dialect.sqlSpec === 'mssql', (qb) => qb.offset(0)) as QB
 }

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -216,16 +216,12 @@ export const DB_CONFIGS: PerDialectVariant<KyselyConfig> = {
         options: {
           max: POOL_SIZE,
           min: 0,
-          // @ts-expect-error making sure people see the deprecation warning
-          validateConnections: true,
         },
         ...Tarn,
       },
       tedious: {
         ...Tedious,
         connectionFactory: () => new Tedious.Connection(DIALECT_CONFIGS.mssql),
-        // @ts-expect-error making sure people see the deprecation warning
-        resetConnectionOnRelease: true,
       },
       validateConnections: false,
     }),

--- a/test/node/src/with-schema.test.ts
+++ b/test/node/src/with-schema.test.ts
@@ -193,45 +193,6 @@ for (const dialect of DIALECTS) {
         await query.execute()
       })
 
-      it('subqueries should use their own schema if specified', async () => {
-        const query = ctx.db
-          .withSchema('mammals')
-          .selectFrom('pet')
-          .select([
-            'pet.name',
-            (qb) =>
-              qb
-                .withSchema(sqlSpec === 'postgres' ? 'public' : 'dbo')
-                .selectFrom('person')
-                .select('first_name')
-                .whereRef('pet.owner_id', '=', 'person.id')
-                .as('owner_first_name'),
-          ])
-
-        testSql(query, dialect, {
-          postgres: {
-            sql: [
-              'select "mammals"."pet"."name",',
-              '(select "first_name" from "public"."person" where "mammals"."pet"."owner_id" = "public"."person"."id") as "owner_first_name"',
-              'from "mammals"."pet"',
-            ],
-            parameters: [],
-          },
-          mysql: NOT_SUPPORTED,
-          mssql: {
-            sql: [
-              'select "mammals"."pet"."name",',
-              '(select "first_name" from "dbo"."person" where "mammals"."pet"."owner_id" = "dbo"."person"."id") as "owner_first_name"',
-              'from "mammals"."pet"',
-            ],
-            parameters: [],
-          },
-          sqlite: NOT_SUPPORTED,
-        })
-
-        await query.execute()
-      })
-
       if (sqlSpec === 'postgres') {
         it('should not add schema for json_agg parameters', async () => {
           const query = ctx.db


### PR DESCRIPTION
Hey :wave:

This PR removes a few long deprecated (over a year) things:

- `ExpressionBuilder.withSchema`.
- `DatabaseIntrospector.getMetadata`.
- `Tedious.resetConnectionOnRelease`.
- `Tarn.options.validateConnections`.
- `InsertQueryNode.ignore`.
- `PrimaryConstraintNode`.