### PR TITLE
fix: further harden JSON path `.key(...)` and `.at(...)` against SQL injections and exfiltrations.

### DIFF
--- a/src/dialect/mysql/mysql-query-compiler.ts
+++ b/src/dialect/mysql/mysql-query-compiler.ts
@@ -51,9 +51,14 @@ export class MysqlQueryCompiler extends DefaultQueryCompiler {
     )
   }
 
+  /**
+   * Member values appear inside `"..."` in the JSON path, which itself sits
+   * inside a SQL string literal. They must therefore be escaped twice — once
+   * for the JSON path grammar, then again for MySQL's string literal parser.
+   */
   protected override sanitizeJSONPathMemberValue(value: string): string {
     return value.replace(JSON_PATH_MEMBER_ESCAPE_REGEX, (char) =>
-      char === '\\' ? '\\\\' : char === "'" ? "''" : '\\"',
+      char === '\\' ? '\\\\\\\\' : char === "'" ? "''" : '\\\\"',
     )
   }
 

--- a/src/dialect/mysql/mysql-query-compiler.ts
+++ b/src/dialect/mysql/mysql-query-compiler.ts
@@ -1,8 +1,9 @@
 import type { CreateIndexNode } from '../../operation-node/create-index-node.js'
 import { DefaultQueryCompiler } from '../../query-compiler/default-query-compiler.js'
 
-const LITERAL_ESCAPE_REGEX = /\\|'/g
+const LITERAL_ESCAPE_REGEX = /[\\']/g
 const ID_WRAP_REGEX = /`/g
+const JSON_PATH_MEMBER_ESCAPE_REGEX = /[\\'"]/g
 
 export class MysqlQueryCompiler extends DefaultQueryCompiler {
   protected override getCurrentParameterPlaceholder(): string {
@@ -47,6 +48,12 @@ export class MysqlQueryCompiler extends DefaultQueryCompiler {
   protected override sanitizeStringLiteral(value: string): string {
     return value.replace(LITERAL_ESCAPE_REGEX, (char) =>
       char === '\\' ? '\\\\' : "''",
+    )
+  }
+
+  protected override sanitizeJSONPathMemberValue(value: string): string {
+    return value.replace(JSON_PATH_MEMBER_ESCAPE_REGEX, (char) =>
+      char === '\\' ? '\\\\' : char === "'" ? "''" : '\\"',
     )
   }
 

--- a/src/dialect/sqlite/sqlite-query-compiler.ts
+++ b/src/dialect/sqlite/sqlite-query-compiler.ts
@@ -3,6 +3,7 @@ import type { OrActionNode } from '../../operation-node/or-action-node.js'
 import { DefaultQueryCompiler } from '../../query-compiler/default-query-compiler.js'
 
 const ID_WRAP_REGEX = /"/g
+const JSON_PATH_MEMBER_ESCAPE_REGEX = /[\\'"]/g
 
 export class SqliteQueryCompiler extends DefaultQueryCompiler {
   protected override visitOrAction(node: OrActionNode): void {
@@ -36,6 +37,12 @@ export class SqliteQueryCompiler extends DefaultQueryCompiler {
 
   protected override sanitizeIdentifier(identifier: string): string {
     return identifier.replace(ID_WRAP_REGEX, '""')
+  }
+
+  protected override sanitizeJSONPathMemberValue(value: string): string {
+    return value.replace(JSON_PATH_MEMBER_ESCAPE_REGEX, (char) =>
+      char === '\\' ? '\\\\' : char === "'" ? "''" : '\\"',
+    )
   }
 
   protected override visitDefaultInsertValue(_: DefaultInsertValueNode): void {

--- a/src/query-builder/json-path-builder.ts
+++ b/src/query-builder/json-path-builder.ts
@@ -16,6 +16,8 @@ import { isOperationNodeSource } from '../operation-node/operation-node-source.j
 import type { OperationNode } from '../operation-node/operation-node.js'
 import { ValueNode } from '../operation-node/value-node.js'
 
+const HASH_NEGATIVE_INDEX_REGEX = /^#-\d+$/
+
 export class JSONPathBuilder<S, O = S> {
   readonly #node: JSONReferenceNode | JSONPathNode
 
@@ -96,6 +98,16 @@ export class JSONPathBuilder<S, O = S> {
   >(
     index: `${I}` extends `${any}.${any}` | `#--${any}` ? never : I,
   ): TraversedJSONPathBuilder<S, O2> {
+    if (
+      (typeof index !== 'number' && typeof index !== 'string') ||
+      (typeof index === 'number' && !Number.isInteger(index)) ||
+      (typeof index === 'string' &&
+        index !== 'last' &&
+        !HASH_NEGATIVE_INDEX_REGEX.test(index))
+    ) {
+      throw new Error(`Unexpected index value in .at(...): ${index}`)
+    }
+
     return this.#createBuilderWithPathLeg('ArrayLocation', index)
   }
 

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -1630,7 +1630,7 @@ export class DefaultQueryCompiler
 
     if (isArrayLocation) {
       this.append('[')
-      this.append(value)
+      this.append(this.sanitizeStringLiteral(value))
       this.append(']')
     } else {
       this.append('."')

--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -119,6 +119,7 @@ import type { QueryId } from '../util/query-id.js'
 import type { RenameConstraintNode } from '../operation-node/rename-constraint-node.js'
 
 const LIT_WRAP_REGEX = /'/g
+const JSON_PATH_MEMBER_WRAP_REGEX = /['"]/g
 
 export class DefaultQueryCompiler
   extends OperationNodeVisitor
@@ -1625,16 +1626,16 @@ export class DefaultQueryCompiler
   protected override visitJSONPathLeg(node: JSONPathLegNode): void {
     const isArrayLocation = node.type === 'ArrayLocation'
 
-    this.append(isArrayLocation ? '[' : '.')
-
-    this.append(
-      typeof node.value === 'string'
-        ? this.sanitizeStringLiteral(node.value)
-        : String(node.value),
-    )
+    const value = String(node.value)
 
     if (isArrayLocation) {
+      this.append('[')
+      this.append(value)
       this.append(']')
+    } else {
+      this.append('."')
+      this.append(this.sanitizeJSONPathMemberValue(value))
+      this.append('"')
     }
   }
 
@@ -1820,6 +1821,12 @@ export class DefaultQueryCompiler
 
   protected sanitizeStringLiteral(value: string): string {
     return value.replace(LIT_WRAP_REGEX, "''")
+  }
+
+  protected sanitizeJSONPathMemberValue(value: string): string {
+    return value.replace(JSON_PATH_MEMBER_WRAP_REGEX, (char) =>
+      char === "'" ? "''" : '\\"',
+    )
   }
 
   protected addParameter(parameter: unknown): void {

--- a/test/node/src/json-traversal.test.ts
+++ b/test/node/src/json-traversal.test.ts
@@ -54,12 +54,12 @@ for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
             postgres: NOT_SUPPORTED,
             mysql: {
               parameters: [],
-              sql: "select `website`->'$.url' as `website_url` from `person_metadata`",
+              sql: 'select `website`->\'$."url"\' as `website_url` from `person_metadata`',
             },
             mssql: NOT_SUPPORTED,
             sqlite: {
               parameters: [],
-              sql: `select "website"->>'$.url' as "website_url" from "person_metadata"`,
+              sql: `select "website"->>'$."url"' as "website_url" from "person_metadata"`,
             },
           })
 
@@ -116,12 +116,12 @@ for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
             postgres: NOT_SUPPORTED,
             mysql: {
               parameters: [],
-              sql: "select `profile`->'$.auth.roles' as `roles` from `person_metadata`",
+              sql: 'select `profile`->\'$."auth"."roles"\' as `roles` from `person_metadata`',
             },
             mssql: NOT_SUPPORTED,
             sqlite: {
               parameters: [],
-              sql: `select "profile"->>'$.auth.roles' as "roles" from "person_metadata"`,
+              sql: `select "profile"->>'$."auth"."roles"' as "roles" from "person_metadata"`,
             },
           })
 
@@ -145,12 +145,12 @@ for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
             postgres: NOT_SUPPORTED,
             mysql: {
               parameters: [],
-              sql: "select `profile`->'$.tags[0]' as `main_tag` from `person_metadata`",
+              sql: 'select `profile`->\'$."tags"[0]\' as `main_tag` from `person_metadata`',
             },
             mssql: NOT_SUPPORTED,
             sqlite: {
               parameters: [],
-              sql: `select "profile"->>'$.tags[0]' as "main_tag" from "person_metadata"`,
+              sql: `select "profile"->>'$."tags"[0]' as "main_tag" from "person_metadata"`,
             },
           })
 
@@ -178,12 +178,12 @@ for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
             postgres: NOT_SUPPORTED,
             mysql: {
               parameters: [],
-              sql: "select `experience`->'$[0].establishment' as `establishment` from `person_metadata`",
+              sql: 'select `experience`->\'$[0]."establishment"\' as `establishment` from `person_metadata`',
             },
             mssql: NOT_SUPPORTED,
             sqlite: {
               parameters: [],
-              sql: `select "experience"->>'$[0].establishment' as "establishment" from "person_metadata"`,
+              sql: `select "experience"->>'$[0]."establishment"' as "establishment" from "person_metadata"`,
             },
           })
 
@@ -331,12 +331,12 @@ for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
             postgres: NOT_SUPPORTED,
             mysql: {
               parameters: [12],
-              sql: "select * from `person_metadata` where `profile`->'$.auth.login_count' = ?",
+              sql: `select * from \`person_metadata\` where \`profile\`->'$."auth"."login_count"' = ?`,
             },
             mssql: NOT_SUPPORTED,
             sqlite: {
               parameters: [12],
-              sql: `select * from "person_metadata" where "profile"->>'$.auth.login_count' = ?`,
+              sql: `select * from "person_metadata" where "profile"->>'$."auth"."login_count"' = ?`,
             },
           })
 
@@ -360,12 +360,12 @@ for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
             postgres: NOT_SUPPORTED,
             mysql: {
               parameters: [],
-              sql: "select * from `person_metadata` order by `profile`->'$.auth.login_count' desc",
+              sql: 'select * from `person_metadata` order by `profile`->\'$."auth"."login_count"\' desc',
             },
             mssql: NOT_SUPPORTED,
             sqlite: {
               parameters: [],
-              sql: `select * from "person_metadata" order by "profile"->>'$.auth.login_count' desc`,
+              sql: `select * from "person_metadata" order by "profile"->>'$."auth"."login_count"' desc`,
             },
           })
 
@@ -397,12 +397,12 @@ for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
             postgres: NOT_SUPPORTED,
             mysql: {
               parameters: ['Papa Johns', 911],
-              sql: "update `person_metadata` set `experience` = json_set(`experience`, '$[last].establishment', ?) where `person_id` = ?",
+              sql: 'update `person_metadata` set `experience` = json_set(`experience`, \'$[last]."establishment"\', ?) where `person_id` = ?',
             },
             mssql: NOT_SUPPORTED,
             sqlite: {
               parameters: ['Papa Johns', 911],
-              sql: `update "person_metadata" set "experience" = json_set("experience", '$[#-1].establishment', ?) where "person_id" = ?`,
+              sql: `update "person_metadata" set "experience" = json_set("experience", '$[#-1]."establishment"', ?) where "person_id" = ?`,
             },
           })
 

--- a/test/node/src/json-traversal.test.ts
+++ b/test/node/src/json-traversal.test.ts
@@ -1,27 +1,18 @@
 import {
-  ColumnDefinitionBuilder,
-  JSONColumnType,
-  ParseJSONResultsPlugin,
-  SqlBool,
-  sql,
-} from '../../../dist/cjs/index.js'
-import {
-  BuiltInDialect,
   DIALECTS,
+  type JSONTestContext,
   NOT_SUPPORTED,
-  clearDatabase,
-  destroyTest,
+  clearJSONDatabase,
+  destroyJSONTest,
   expect,
-  initTest,
-  insertDefaultDataSet,
+  initJSONTest,
+  insertDefaultJSONDataSet,
   testSql,
 } from './test-setup.js'
 
-type TestContext = Awaited<ReturnType<typeof initJSONTest>>
-
 for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
   describe(`${dialect}: json traversal`, () => {
-    let ctx: TestContext
+    let ctx: JSONTestContext
 
     before(async function () {
       ctx = await initJSONTest(this, dialect)
@@ -721,125 +712,4 @@ for (const dialect of DIALECTS.filter((dialect) => dialect !== 'mssql')) {
       })
     }
   })
-}
-
-async function initJSONTest<D extends BuiltInDialect>(
-  ctx: Mocha.Context,
-  dialect: D,
-) {
-  const testContext = await initTest(ctx, dialect)
-
-  let db = testContext.db.withTables<{
-    person_metadata: {
-      person_id: number
-      website: JSONColumnType<{ url: string }>
-      nicknames: JSONColumnType<string[]>
-      profile: JSONColumnType<{
-        auth: {
-          roles: string[]
-          last_login?: { device: string }
-          is_verified: SqlBool
-          login_count: number
-        }
-        avatar: string | null
-        tags: string[]
-      }>
-      experience: JSONColumnType<
-        {
-          establishment: string
-        }[]
-      >
-      schedule: JSONColumnType<{ name: string; time: string }[][][]>
-    }
-  }>()
-
-  if (dialect === 'sqlite') {
-    db = db.withPlugin(new ParseJSONResultsPlugin())
-  }
-
-  const jsonColumnDataType = resolveJSONColumnDataType(dialect)
-  const notNull = (cb: ColumnDefinitionBuilder) => cb.notNull()
-
-  await db.schema
-    .createTable('person_metadata')
-    .addColumn('person_id', 'integer', (cb) =>
-      cb.primaryKey().references('person.id'),
-    )
-    .addColumn('website', jsonColumnDataType, notNull)
-    .addColumn('nicknames', jsonColumnDataType, notNull)
-    .addColumn('profile', jsonColumnDataType, notNull)
-    .addColumn('experience', jsonColumnDataType, notNull)
-    .addColumn('schedule', jsonColumnDataType, notNull)
-    .execute()
-
-  return { ...testContext, db }
-}
-
-function resolveJSONColumnDataType(dialect: BuiltInDialect) {
-  switch (dialect) {
-    case 'postgres':
-      return 'jsonb'
-    case 'mysql':
-      return 'json'
-    case 'mssql':
-      return sql`nvarchar(max)`
-    case 'sqlite':
-      return 'text'
-  }
-}
-
-async function insertDefaultJSONDataSet(ctx: TestContext) {
-  await insertDefaultDataSet(ctx as any)
-
-  const people = await ctx.db
-    .selectFrom('person')
-    .select(['id', 'first_name', 'last_name'])
-    .execute()
-
-  await ctx.db
-    .insertInto('person_metadata')
-    .values(
-      people
-        .filter((person) => person.first_name && person.last_name)
-        .map((person, index) => ({
-          person_id: person.id,
-          website: JSON.stringify({
-            url: `https://www.${person.first_name!.toLowerCase()}${person.last_name!.toLowerCase()}.com`,
-          }),
-          nicknames: JSON.stringify([
-            `${person.first_name![0]}.${person.last_name![0]}.`,
-            `${person.first_name} the Great`,
-            `${person.last_name} the Magnificent`,
-          ]),
-          profile: JSON.stringify({
-            tags: ['awesome'],
-            auth: {
-              roles: ['contributor', 'moderator'],
-              last_login: {
-                device: 'android',
-              },
-              login_count: 12 + index,
-              is_verified: true,
-            },
-            avatar: null,
-          }),
-          experience: JSON.stringify([
-            {
-              establishment: 'The University of Life',
-            },
-          ]),
-          schedule: JSON.stringify([[[{ name: 'Gym', time: '12:15' }]]]),
-        })),
-    )
-    .execute()
-}
-
-async function clearJSONDatabase(ctx: TestContext) {
-  await ctx.db.deleteFrom('person_metadata').execute()
-  await clearDatabase(ctx as any)
-}
-
-async function destroyJSONTest(ctx: TestContext) {
-  await ctx.db.schema.dropTable('person_metadata').execute()
-  await destroyTest(ctx as any)
 }

--- a/test/node/src/sql-injection.test.ts
+++ b/test/node/src/sql-injection.test.ts
@@ -81,7 +81,7 @@ for (const dialect of DIALECTS) {
           .select((eb) => eb.ref('data', '->$').key(injection).as('first'))
 
         expect(query.compile().sql).to.equal(
-          `with ${identifierWrapper}people${identifierWrapper} as (select json_object('first', first_name) as ${identifierWrapper}data${identifierWrapper} from ${identifierWrapper}person${identifierWrapper}) select ${identifierWrapper}data${identifierWrapper}->'$.first'' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}person${identifierWrapper} -- ' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}`,
+          `with ${identifierWrapper}people${identifierWrapper} as (select json_object('first', first_name) as ${identifierWrapper}data${identifierWrapper} from ${identifierWrapper}person${identifierWrapper}) select ${identifierWrapper}data${identifierWrapper}->'$."first'' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}person${identifierWrapper} -- "' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}`,
         )
         await ctx.db.executeQuery(query)
         await assertDidNotDropTable(ctx, 'person')
@@ -105,14 +105,14 @@ for (const dialect of DIALECTS) {
           .select((eb) => eb.ref('data', '->$').key(injection).as('first'))
 
         expect(query.compile().sql).to.equal(
-          `with ${identifierWrapper}people${identifierWrapper} as (select json_object('first', first_name) as ${identifierWrapper}data${identifierWrapper} from ${identifierWrapper}person${identifierWrapper}) select ${identifierWrapper}data${identifierWrapper}->'$.first\\\\'' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}person${identifierWrapper} -- ' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}`,
+          `with ${identifierWrapper}people${identifierWrapper} as (select json_object('first', first_name) as ${identifierWrapper}data${identifierWrapper} from ${identifierWrapper}person${identifierWrapper}) select ${identifierWrapper}data${identifierWrapper}->'$."first\\\\'' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}person${identifierWrapper} -- "' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}`,
         )
         await ctx.db.executeQuery(query)
         await assertDidNotDropTable(ctx, 'person')
       })
 
       it('should not allow SQL injection via backslash escape in string literals', async () => {
-        const injection = `\\'; drop table ${identifierWrapper}person${identifierWrapper}; -- `
+        const injection = `"\\'; drop table ${identifierWrapper}person${identifierWrapper}; -- `
 
         const query = ctx.db
           .selectFrom('person')
@@ -120,7 +120,7 @@ for (const dialect of DIALECTS) {
           .selectAll()
 
         expect(query.compile().sql).to.equal(
-          `select * from ${identifierWrapper}person${identifierWrapper} where ${identifierWrapper}first_name${identifierWrapper} = '\\\\''; drop table ${identifierWrapper}person${identifierWrapper}; -- '`,
+          `select * from ${identifierWrapper}person${identifierWrapper} where ${identifierWrapper}first_name${identifierWrapper} = '"\\\\''; drop table ${identifierWrapper}person${identifierWrapper}; -- '`,
         )
         await ctx.db.executeQuery(query)
         await assertDidNotDropTable(ctx, 'person')

--- a/test/node/src/sql-injection.test.ts
+++ b/test/node/src/sql-injection.test.ts
@@ -6,6 +6,8 @@ import {
   DIALECTS,
   initJSONTest,
   insertDefaultJSONDataSet,
+  NOT_SUPPORTED,
+  testSql,
   type JSONTestContext,
 } from './test-setup.js'
 
@@ -72,7 +74,7 @@ for (const dialect of DIALECTS) {
       await assertDidNotDropTable(ctx, 'person')
     })
 
-    if (dialect === 'mysql') {
+    if (dialect === 'mysql' || dialect === 'sqlite') {
       it('should not allow SQL injection in $.key JSON paths', async () => {
         const injection =
           `first' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}person${identifierWrapper} -- ` as never
@@ -90,9 +92,18 @@ for (const dialect of DIALECTS) {
           .selectFrom('people')
           .select((eb) => eb.ref('data', '->$').key(injection).as('first'))
 
-        expect(query.compile().sql).to.equal(
-          `with ${identifierWrapper}people${identifierWrapper} as (select json_object('first', first_name) as ${identifierWrapper}data${identifierWrapper} from ${identifierWrapper}person${identifierWrapper}) select ${identifierWrapper}data${identifierWrapper}->'$."first'' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}person${identifierWrapper} -- "' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}`,
-        )
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: `with \`people\` as (select json_object('first', first_name) as \`data\` from \`person\`) select \`data\`->'$."first'' as \`first\` from \`people\`; drop table \`person\` -- "' as \`first\` from \`people\``,
+            parameters: [],
+          },
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: `with "people" as (select json_object('first', first_name) as "data" from "person") select "data"->'$."first'' as \\"first\\" from \\"people\\"; drop table \\"person\\" -- "' as "first" from "people"`,
+            parameters: [],
+          },
+        })
         await ctx.db.executeQuery(query)
         await assertDidNotDropTable(ctx, 'person')
       })
@@ -114,9 +125,18 @@ for (const dialect of DIALECTS) {
           .selectFrom('people')
           .select((eb) => eb.ref('data', '->$').key(injection).as('first'))
 
-        expect(query.compile().sql).to.equal(
-          `with ${identifierWrapper}people${identifierWrapper} as (select json_object('first', first_name) as ${identifierWrapper}data${identifierWrapper} from ${identifierWrapper}person${identifierWrapper}) select ${identifierWrapper}data${identifierWrapper}->'$."first\\\\\\\\'' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}pet${identifierWrapper} -- "' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}`,
-        )
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: `with \`people\` as (select json_object('first', first_name) as \`data\` from \`person\`) select \`data\`->'$."first\\\\\\\\'' as \`first\` from \`people\`; drop table \`pet\` -- "' as \`first\` from \`people\``,
+            parameters: [],
+          },
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: `with "people" as (select json_object('first', first_name) as "data" from "person") select "data"->'$."first\\\\'' as \\"first\\" from \\"people\\"; drop table \\"pet\\" -- "' as "first" from "people"`,
+            parameters: [],
+          },
+        })
         await ctx.db.executeQuery(query)
         await assertDidNotDropTable(ctx, 'pet')
       })
@@ -129,9 +149,18 @@ for (const dialect of DIALECTS) {
           .where('first_name', '=', sql.lit(injection))
           .selectAll()
 
-        expect(query.compile().sql).to.equal(
-          `select * from ${identifierWrapper}person${identifierWrapper} where ${identifierWrapper}first_name${identifierWrapper} = '\\\\''; drop table ${identifierWrapper}person${identifierWrapper}; -- '`,
-        )
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: `select * from \`person\` where \`first_name\` = '\\\\''; drop table \`person\`; -- '`,
+            parameters: [],
+          },
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: `select * from "person" where "first_name" = '\\''; drop table "person"; -- '`,
+            parameters: [],
+          },
+        })
         await ctx.db.executeQuery(query)
         await assertDidNotDropTable(ctx, 'person')
       })
@@ -146,9 +175,18 @@ for (const dialect of DIALECTS) {
             .as('exfiltrated'),
         )
 
-        expect(query.compile().sql).to.equal(
-          `select ${identifierWrapper}profile${identifierWrapper}->'$."${exfiltration}"' as ${identifierWrapper}exfiltrated${identifierWrapper} from ${identifierWrapper}person_metadata${identifierWrapper}`,
-        )
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: `select \`profile\`->'$."${exfiltration}"' as \`exfiltrated\` from \`person_metadata\``,
+            parameters: [],
+          },
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: `select "profile"->'$."${exfiltration}"' as "exfiltrated" from "person_metadata"`,
+            parameters: [],
+          },
+        })
 
         const result = await query.executeTakeFirstOrThrow()
 
@@ -165,9 +203,18 @@ for (const dialect of DIALECTS) {
             .as('exfiltrated'),
         )
 
-        expect(query.compile().sql).to.equal(
-          `select ${identifierWrapper}profile${identifierWrapper}->'$."auth\\\\".\\\\"login_count"' as ${identifierWrapper}exfiltrated${identifierWrapper} from ${identifierWrapper}person_metadata${identifierWrapper}`,
-        )
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: `select \`profile\`->'$."auth\\\\".\\\\"login_count"' as \`exfiltrated\` from \`person_metadata\``,
+            parameters: [],
+          },
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: `select "profile"->'$."auth\\".\\"login_count"' as "exfiltrated" from "person_metadata"`,
+            parameters: [],
+          },
+        })
 
         const result = await query.executeTakeFirstOrThrow()
 
@@ -184,16 +231,25 @@ for (const dialect of DIALECTS) {
             .as('exfiltrated'),
         )
 
-        expect(query.compile().sql).to.equal(
-          `select ${identifierWrapper}profile${identifierWrapper}->'$."tags[0]"' as ${identifierWrapper}exfiltrated${identifierWrapper} from ${identifierWrapper}person_metadata${identifierWrapper}`,
-        )
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: `select \`profile\`->'$."tags[0]"' as \`exfiltrated\` from \`person_metadata\``,
+            parameters: [],
+          },
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: `select "profile"->'$."tags[0]"' as "exfiltrated" from "person_metadata"`,
+            parameters: [],
+          },
+        })
 
         const result = await query.executeTakeFirstOrThrow()
 
         expect(result.exfiltrated).to.be.null
       })
 
-      it('should not allow exfiltration via $.* in $.key JSON paths', async () => {
+      it('should not allow exfiltration via wildcard in $.key JSON paths', async () => {
         const exfiltration = '*'
 
         const query = ctx.db.selectFrom('person_metadata').select((eb) =>
@@ -203,16 +259,25 @@ for (const dialect of DIALECTS) {
             .as('exfiltrated'),
         )
 
-        expect(query.compile().sql).to.equal(
-          `select ${identifierWrapper}profile${identifierWrapper}->'$."*"' as ${identifierWrapper}exfiltrated${identifierWrapper} from ${identifierWrapper}person_metadata${identifierWrapper}`,
-        )
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: {
+            sql: `select \`profile\`->'$."*"' as \`exfiltrated\` from \`person_metadata\``,
+            parameters: [],
+          },
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: `select "profile"->'$."*"' as "exfiltrated" from "person_metadata"`,
+            parameters: [],
+          },
+        })
 
         const result = await query.executeTakeFirstOrThrow()
 
         expect(result.exfiltrated).to.be.null
       })
 
-      it('should not allow exfiltration via $[*] in $.key JSON paths', async () => {
+      it('should not allow exfiltration via wildcard in $.at JSON paths', async () => {
         const exfiltration = '*'
 
         expect(() =>

--- a/test/node/src/sql-injection.test.ts
+++ b/test/node/src/sql-injection.test.ts
@@ -8,7 +8,7 @@ import {
 } from './test-setup.js'
 
 for (const dialect of DIALECTS) {
-  describe(`${dialect}: select`, () => {
+  describe.only(`${dialect}: select`, () => {
     let ctx: TestContext
     const identifierWrapper = dialect === 'mysql' ? '`' : '"'
 
@@ -112,7 +112,7 @@ for (const dialect of DIALECTS) {
       })
 
       it('should not allow SQL injection via backslash escape in string literals', async () => {
-        const injection = `"\\'; drop table ${identifierWrapper}person${identifierWrapper}; -- `
+        const injection = `\\'; drop table ${identifierWrapper}person${identifierWrapper}; -- `
 
         const query = ctx.db
           .selectFrom('person')
@@ -120,7 +120,7 @@ for (const dialect of DIALECTS) {
           .selectAll()
 
         expect(query.compile().sql).to.equal(
-          `select * from ${identifierWrapper}person${identifierWrapper} where ${identifierWrapper}first_name${identifierWrapper} = '"\\\\''; drop table ${identifierWrapper}person${identifierWrapper}; -- '`,
+          `select * from ${identifierWrapper}person${identifierWrapper} where ${identifierWrapper}first_name${identifierWrapper} = '\\\\''; drop table ${identifierWrapper}person${identifierWrapper}; -- '`,
         )
         await ctx.db.executeQuery(query)
         await assertDidNotDropTable(ctx, 'person')

--- a/test/node/src/sql-injection.test.ts
+++ b/test/node/src/sql-injection.test.ts
@@ -135,6 +135,95 @@ for (const dialect of DIALECTS) {
         await ctx.db.executeQuery(query)
         await assertDidNotDropTable(ctx, 'person')
       })
+
+      it('should not allow exfiltration via dots in $.key JSON paths', async () => {
+        const exfiltration = 'auth.login_count'
+
+        const query = ctx.db.selectFrom('person_metadata').select((eb) =>
+          eb
+            .ref('profile', '->$')
+            .key(exfiltration as never)
+            .as('exfiltrated'),
+        )
+
+        expect(query.compile().sql).to.equal(
+          `select ${identifierWrapper}profile${identifierWrapper}->'$."${exfiltration}"' as ${identifierWrapper}exfiltrated${identifierWrapper} from ${identifierWrapper}person_metadata${identifierWrapper}`,
+        )
+
+        const result = await query.executeTakeFirstOrThrow()
+
+        expect(result.exfiltrated).to.be.null
+      })
+
+      it('should not allow exfiltration via dots and working around quotes in $.key JSON paths', async () => {
+        const exfiltration = 'auth"."login_count'
+
+        const query = ctx.db.selectFrom('person_metadata').select((eb) =>
+          eb
+            .ref('profile', '->$')
+            .key(exfiltration as never)
+            .as('exfiltrated'),
+        )
+
+        expect(query.compile().sql).to.equal(
+          `select ${identifierWrapper}profile${identifierWrapper}->'$."auth\\\\".\\\\"login_count"' as ${identifierWrapper}exfiltrated${identifierWrapper} from ${identifierWrapper}person_metadata${identifierWrapper}`,
+        )
+
+        const result = await query.executeTakeFirstOrThrow()
+
+        expect(result.exfiltrated).to.be.null
+      })
+
+      it('should not allow exfiltration via brackets in $.key JSON paths', async () => {
+        const exfiltration = 'tags[0]'
+
+        const query = ctx.db.selectFrom('person_metadata').select((eb) =>
+          eb
+            .ref('profile', '->$')
+            .key(exfiltration as never)
+            .as('exfiltrated'),
+        )
+
+        expect(query.compile().sql).to.equal(
+          `select ${identifierWrapper}profile${identifierWrapper}->'$."tags[0]"' as ${identifierWrapper}exfiltrated${identifierWrapper} from ${identifierWrapper}person_metadata${identifierWrapper}`,
+        )
+
+        const result = await query.executeTakeFirstOrThrow()
+
+        expect(result.exfiltrated).to.be.null
+      })
+
+      it('should not allow exfiltration via $.* in $.key JSON paths', async () => {
+        const exfiltration = '*'
+
+        const query = ctx.db.selectFrom('person_metadata').select((eb) =>
+          eb
+            .ref('profile', '->$')
+            .key(exfiltration as never)
+            .as('exfiltrated'),
+        )
+
+        expect(query.compile().sql).to.equal(
+          `select ${identifierWrapper}profile${identifierWrapper}->'$."*"' as ${identifierWrapper}exfiltrated${identifierWrapper} from ${identifierWrapper}person_metadata${identifierWrapper}`,
+        )
+
+        const result = await query.executeTakeFirstOrThrow()
+
+        expect(result.exfiltrated).to.be.null
+      })
+
+      it('should not allow exfiltration via $[*] in $.key JSON paths', async () => {
+        const exfiltration = '*'
+
+        expect(() =>
+          ctx.db.selectFrom('person_metadata').select((eb) =>
+            eb
+              .ref('profile', '->$')
+              .at(exfiltration as never)
+              .as('exfiltrated'),
+          ),
+        ).to.throw
+      })
     }
   })
 }

--- a/test/node/src/sql-injection.test.ts
+++ b/test/node/src/sql-injection.test.ts
@@ -1,23 +1,33 @@
 import { expect } from 'chai'
 import { sql } from '../../../dist/cjs/index.js'
 import {
-  destroyTest,
+  clearJSONDatabase,
+  destroyJSONTest,
   DIALECTS,
-  initTest,
-  type TestContext,
+  initJSONTest,
+  insertDefaultJSONDataSet,
+  type JSONTestContext,
 } from './test-setup.js'
 
 for (const dialect of DIALECTS) {
-  describe.only(`${dialect}: select`, () => {
-    let ctx: TestContext
+  describe(`${dialect}: select`, () => {
+    let ctx: JSONTestContext
     const identifierWrapper = dialect === 'mysql' ? '`' : '"'
 
     before(async function () {
-      ctx = await initTest(this, dialect)
+      ctx = await initJSONTest(this, dialect)
+    })
+
+    beforeEach(async () => {
+      await insertDefaultJSONDataSet(ctx)
+    })
+
+    afterEach(async () => {
+      await clearJSONDatabase(ctx)
     })
 
     after(async () => {
-      await destroyTest(ctx)
+      await destroyJSONTest(ctx)
     })
 
     it('should not allow SQL injection in table names', async () => {
@@ -89,7 +99,7 @@ for (const dialect of DIALECTS) {
 
       it('should not allow SQL injection via backslash escape in $.key JSON paths', async () => {
         const injection =
-          `first\\' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}person${identifierWrapper} -- ` as never
+          `first\\' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}pet${identifierWrapper} -- ` as never
 
         const query = ctx.db
           .with('people', () =>
@@ -105,10 +115,10 @@ for (const dialect of DIALECTS) {
           .select((eb) => eb.ref('data', '->$').key(injection).as('first'))
 
         expect(query.compile().sql).to.equal(
-          `with ${identifierWrapper}people${identifierWrapper} as (select json_object('first', first_name) as ${identifierWrapper}data${identifierWrapper} from ${identifierWrapper}person${identifierWrapper}) select ${identifierWrapper}data${identifierWrapper}->'$."first\\\\'' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}person${identifierWrapper} -- "' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}`,
+          `with ${identifierWrapper}people${identifierWrapper} as (select json_object('first', first_name) as ${identifierWrapper}data${identifierWrapper} from ${identifierWrapper}person${identifierWrapper}) select ${identifierWrapper}data${identifierWrapper}->'$."first\\\\\\\\'' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}; drop table ${identifierWrapper}pet${identifierWrapper} -- "' as ${identifierWrapper}first${identifierWrapper} from ${identifierWrapper}people${identifierWrapper}`,
         )
         await ctx.db.executeQuery(query)
-        await assertDidNotDropTable(ctx, 'person')
+        await assertDidNotDropTable(ctx, 'pet')
       })
 
       it('should not allow SQL injection via backslash escape in string literals', async () => {
@@ -129,7 +139,7 @@ for (const dialect of DIALECTS) {
   })
 }
 
-async function assertDidNotDropTable(ctx: TestContext, tableName: string) {
+async function assertDidNotDropTable(ctx: JSONTestContext, tableName: string) {
   const tables = await ctx.db.introspection.getTables()
 
   expect(tables.some((table) => table.name === tableName)).to.be.true

--- a/test/node/src/test-setup.ts
+++ b/test/node/src/test-setup.ts
@@ -35,8 +35,13 @@ import {
   type SelectQueryBuilder,
   type OrderByDirection,
   type OrderByExpression,
+  type ColumnDefinitionBuilder,
+  ParseJSONResultsPlugin,
+  type JSONColumnType,
+  type SqlBool,
 } from '../../../dist/cjs/index.js'
 import type { ConnectionConfiguration } from 'tedious'
+import type { DataTypeExpression } from '../../../dist/cjs/parser/data-type-parser.js'
 
 export type Gender = 'male' | 'female' | 'other'
 export type MaritalStatus = 'single' | 'married' | 'divorced' | 'widowed'
@@ -544,4 +549,131 @@ export function orderBy<QB extends SelectQueryBuilder<any, any, any>>(
 
     return qb.orderBy(orderBy, direction) as QB
   }
+}
+
+export type JSONTestContext = Awaited<ReturnType<typeof initJSONTest>>
+
+export async function initJSONTest<D extends BuiltInDialect>(
+  ctx: Mocha.Context,
+  dialect: D,
+) {
+  const testContext = await initTest(ctx, dialect)
+
+  let db = testContext.db.withTables<{
+    person_metadata: {
+      person_id: number
+      website: JSONColumnType<{ url: string }>
+      nicknames: JSONColumnType<string[]>
+      profile: JSONColumnType<{
+        auth: {
+          roles: string[]
+          last_login?: { device: string }
+          is_verified: SqlBool
+          login_count: number
+        }
+        avatar: string | null
+        tags: string[]
+      }>
+      experience: JSONColumnType<
+        {
+          establishment: string
+        }[]
+      >
+      schedule: JSONColumnType<{ name: string; time: string }[][][]>
+    }
+  }>()
+
+  if (dialect === 'sqlite') {
+    db = db.withPlugin(new ParseJSONResultsPlugin())
+  }
+
+  const jsonColumnDataType = resolveJSONColumnDataType(dialect)
+  const notNull = (cb: ColumnDefinitionBuilder) => cb.notNull()
+
+  await db.schema
+    .createTable('person_metadata')
+    .addColumn('person_id', 'integer', (cb) =>
+      cb.primaryKey().references('person.id'),
+    )
+    .addColumn('website', jsonColumnDataType, notNull)
+    .addColumn('nicknames', jsonColumnDataType, notNull)
+    .addColumn('profile', jsonColumnDataType, notNull)
+    .addColumn('experience', jsonColumnDataType, notNull)
+    .addColumn('schedule', jsonColumnDataType, notNull)
+    .execute()
+
+  return { ...testContext, db }
+}
+
+export function resolveJSONColumnDataType(
+  dialect: BuiltInDialect,
+): DataTypeExpression {
+  switch (dialect) {
+    case 'postgres':
+      return 'jsonb'
+    case 'mysql':
+      return 'json'
+    case 'mssql':
+      return sql`nvarchar(max)`
+    case 'sqlite':
+      return 'text'
+  }
+}
+
+export async function insertDefaultJSONDataSet(
+  ctx: JSONTestContext,
+): Promise<void> {
+  await insertDefaultDataSet(ctx as any)
+
+  const people = await ctx.db
+    .selectFrom('person')
+    .select(['id', 'first_name', 'last_name'])
+    .execute()
+
+  await ctx.db
+    .insertInto('person_metadata')
+    .values(
+      people
+        .filter((person) => person.first_name && person.last_name)
+        .map((person, index) => ({
+          person_id: person.id,
+          website: JSON.stringify({
+            url: `https://www.${person.first_name!.toLowerCase()}${person.last_name!.toLowerCase()}.com`,
+          }),
+          nicknames: JSON.stringify([
+            `${person.first_name![0]}.${person.last_name![0]}.`,
+            `${person.first_name} the Great`,
+            `${person.last_name} the Magnificent`,
+          ]),
+          profile: JSON.stringify({
+            tags: ['awesome'],
+            auth: {
+              roles: ['contributor', 'moderator'],
+              last_login: {
+                device: 'android',
+              },
+              login_count: 12 + index,
+              is_verified: true,
+            },
+            avatar: null,
+          }),
+          experience: JSON.stringify([
+            {
+              establishment: 'The University of Life',
+            },
+          ]),
+          schedule: JSON.stringify([[[{ name: 'Gym', time: '12:15' }]]]),
+        })),
+    )
+    .execute()
+}
+
+export async function clearJSONDatabase(ctx: JSONTestContext): Promise<void> {
+  await ctx.db.deleteFrom('person_metadata').execute()
+  await clearDatabase(ctx as any)
+}
+
+export async function destroyJSONTest(ctx: JSONTestContext): Promise<void> {
+  await ctx.db.schema.dropTable('person_metadata').execute()
+  await destroyTest(ctx as any)
 }


### PR DESCRIPTION
Hey 👋 

This PR denies a bunch of SQL injection and exfiltration opportunities with today's implementation that can happen when passing user input unsanitized/validated and telling the compiler to ignore the compilation errors OR when using wide JSON types like `Record<string, unknown>` and such.

By wrapping `.key(...)` values with `"`'s and escaping `"`'s between, we ensure that every path leg is treated as a whole literal key. Can't maliciously traverse with `.` or `[..]`, or use something `*`, `**` and `?`.

This requires double escaping in MySQL, which was almost uncaught due to conditions MySQL has for validating JSON paths.

`.at(...)` cannot get similar wrapping and required runtime validation of values that guarantees we only accept what the types accept.