### PR TITLE
docs: add kysely-durable-objects to community dialects

### DIFF
--- a/site/docs/dialects.md
+++ b/site/docs/dialects.md
@@ -26,6 +26,7 @@ A dialect is the glue between Kysely and the underlying database engine. Check t
 | PlanetScale Serverless Driver | https://github.com/depot/kysely-planetscale                                 |
 | Cloudflare D1                 | https://github.com/aidenwallis/kysely-d1                                    |
 | Cloudflare Durable Objects    | https://github.com/benallfree/kysely-do                                     |
+| Cloudflare Durable Objects    | https://github.com/jeffwilde/kysely-durable-objects                         |
 | AWS RDS Data API              | https://github.com/serverless-stack/kysely-data-api                         |
 | SurrealDB                     | https://github.com/igalklebanov/kysely-surrealdb                            |
 | Neon                          | https://github.com/seveibar/kysely-neon                                     |


### PR DESCRIPTION
Adds [`kysely-durable-objects`](https://github.com/jeffwilde/kysely-durable-objects) to the community dialects table — a Kysely dialect for Cloudflare Durable Object SQLite storage (`ctx.storage.sql`).

I left the existing `benallfree/kysely-do` row in place rather than replacing it, so both packages targeting this platform are listed. Happy to adjust label / wording if you'd prefer a different convention for two entries pointing at the same platform.

`kysely-durable-objects` is published to npm with provenance, MIT-licensed, and tested inside real `workerd` (via `@cloudflare/vitest-pool-workers`) across a `compatibility_date` matrix from DO-SQLite GA to today.