### PR TITLE
feat: add HandleEmptyInsertValuesPlugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ export * from './plugin/with-schema/with-schema-plugin.js'
 export * from './plugin/parse-json-results/parse-json-results-plugin.js'
 export * from './plugin/handle-empty-in-lists/handle-empty-in-lists-plugin.js'
 export * from './plugin/handle-empty-in-lists/handle-empty-in-lists.js'
+export * from './plugin/handle-empty-insert-values/handle-empty-insert-values-plugin.js'
 export * from './plugin/safe-null-comparison/safe-null-comparison-plugin.js'
 
 export * from './operation-node/add-column-node.js'

--- a/src/plugin/handle-empty-insert-values/handle-empty-insert-values-plugin.ts
+++ b/src/plugin/handle-empty-insert-values/handle-empty-insert-values-plugin.ts
@@ -1,0 +1,62 @@
+import type { QueryResult } from '../../driver/database-connection.js'
+import type {
+  KyselyPlugin,
+  PluginTransformQueryArgs,
+  PluginTransformResultArgs,
+} from '../kysely-plugin.js'
+import type { UnknownRow } from '../../util/type-utils.js'
+import { HandleEmptyInsertValuesTransformer } from './handle-empty-insert-values-transformer.js'
+import type { RootOperationNode } from '../../operation-node/root-operation-node.js'
+
+/**
+ * A plugin that handles empty `insert into t values ()` queries.
+ *
+ * An insert with no columns and no values is invalid SQL syntax in many databases
+ * and results in a runtime error. This can happen when dynamically building insert
+ * queries and passing an empty object or an array of objects that all have no
+ * defined columns.
+ *
+ * The empty insert is replaced with `insert into t select * from t where 1 = 0`,
+ * which inserts no rows.
+ *
+ * ### Examples
+ *
+ * ```ts
+ * import Sqlite from 'better-sqlite3'
+ * import { HandleEmptyInsertValuesPlugin, Kysely, SqliteDialect } from 'kysely'
+ * import type { Database } from 'type-editor' // imaginary module
+ *
+ * const db = new Kysely<Database>({
+ *   dialect: new SqliteDialect({
+ *     database: new Sqlite(':memory:'),
+ *   }),
+ *   plugins: [
+ *     new HandleEmptyInsertValuesPlugin()
+ *   ],
+ * })
+ *
+ * const result = await db
+ *   .insertInto('person')
+ *   .values({})
+ *   .execute()
+ * ```
+ *
+ * The generated SQL (SQLite):
+ *
+ * ```sql
+ * insert into "person" select * from "person" where 1 = 0
+ * ```
+ */
+export class HandleEmptyInsertValuesPlugin implements KyselyPlugin {
+  readonly #transformer = new HandleEmptyInsertValuesTransformer()
+
+  transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+    return this.#transformer.transformNode(args.node, args.queryId)
+  }
+
+  async transformResult(
+    args: PluginTransformResultArgs,
+  ): Promise<QueryResult<UnknownRow>> {
+    return args.result
+  }
+}

--- a/src/plugin/handle-empty-insert-values/handle-empty-insert-values-plugin.ts
+++ b/src/plugin/handle-empty-insert-values/handle-empty-insert-values-plugin.ts
@@ -9,12 +9,11 @@ import { HandleEmptyInsertValuesTransformer } from './handle-empty-insert-values
 import type { RootOperationNode } from '../../operation-node/root-operation-node.js'
 
 /**
- * A plugin that handles empty `insert into t values ()` queries.
+ * A plugin that handles empty array inserts (`.values([])`).
  *
- * An insert with no columns and no values is invalid SQL syntax in many databases
+ * Passing an empty array to `.values()` produces invalid SQL in most databases
  * and results in a runtime error. This can happen when dynamically building insert
- * queries and passing an empty object or an array of objects that all have no
- * defined columns.
+ * queries from a filtered list that turns out to be empty.
  *
  * The empty insert is replaced with `insert into t select * from t where 1 = 0`,
  * which inserts no rows.
@@ -37,7 +36,7 @@ import type { RootOperationNode } from '../../operation-node/root-operation-node
  *
  * const result = await db
  *   .insertInto('person')
- *   .values({})
+ *   .values([])
  *   .execute()
  * ```
  *

--- a/src/plugin/handle-empty-insert-values/handle-empty-insert-values-transformer.ts
+++ b/src/plugin/handle-empty-insert-values/handle-empty-insert-values-transformer.ts
@@ -13,8 +13,7 @@ import type { QueryId } from '../../util/query-id.js'
 
 type EmptyInsertValuesNode = InsertQueryNode & {
   into: TableNode
-  columns: Readonly<[]>
-  values: ValuesNode
+  values: ValuesNode & { values: Readonly<[]> }
 }
 
 let _eq: OperatorNode
@@ -61,6 +60,6 @@ export class HandleEmptyInsertValuesTransformer extends OperationNodeTransformer
   #isEmptyInsertValuesNode(
     node: InsertQueryNode,
   ): node is EmptyInsertValuesNode {
-    return node.columns?.length === 0 && node.values !== undefined && ValuesNode.is(node.values)
+    return node.values !== undefined && ValuesNode.is(node.values) && node.values.values.length === 0
   }
 }

--- a/src/plugin/handle-empty-insert-values/handle-empty-insert-values-transformer.ts
+++ b/src/plugin/handle-empty-insert-values/handle-empty-insert-values-transformer.ts
@@ -1,0 +1,66 @@
+import { BinaryOperationNode } from '../../operation-node/binary-operation-node.js'
+import { InsertQueryNode } from '../../operation-node/insert-query-node.js'
+import { OperationNodeTransformer } from '../../operation-node/operation-node-transformer.js'
+import { OperatorNode } from '../../operation-node/operator-node.js'
+import { SelectionNode } from '../../operation-node/selection-node.js'
+import { SelectQueryNode } from '../../operation-node/select-query-node.js'
+import type { TableNode } from '../../operation-node/table-node.js'
+import { ValuesNode } from '../../operation-node/values-node.js'
+import { ValueNode } from '../../operation-node/value-node.js'
+import { WhereNode } from '../../operation-node/where-node.js'
+import { freeze } from '../../util/object-utils.js'
+import type { QueryId } from '../../util/query-id.js'
+
+type EmptyInsertValuesNode = InsertQueryNode & {
+  into: TableNode
+  columns: Readonly<[]>
+  values: ValuesNode
+}
+
+let _eq: OperatorNode
+let _contradiction: BinaryOperationNode
+let _where: WhereNode
+let _selectAll: ReadonlyArray<ReturnType<typeof SelectionNode.createSelectAll>>
+
+function replaceWithSelectFrom(node: EmptyInsertValuesNode): InsertQueryNode {
+  const eq = (_eq ||= OperatorNode.create('='))
+  const contradiction = (_contradiction ||= BinaryOperationNode.create(
+    ValueNode.createImmediate(1),
+    eq,
+    ValueNode.createImmediate(0),
+  ))
+  const where = (_where ||= WhereNode.create(contradiction))
+  const selectAll = (_selectAll ||= freeze([SelectionNode.createSelectAll()]))
+
+  const selectNode = freeze({
+    ...SelectQueryNode.cloneWithSelections(
+      SelectQueryNode.createFrom([node.into]),
+      selectAll,
+    ),
+    where,
+  })
+
+  return InsertQueryNode.cloneWith(node, {
+    columns: undefined,
+    values: selectNode,
+  })
+}
+
+export class HandleEmptyInsertValuesTransformer extends OperationNodeTransformer {
+  protected override transformInsertQuery(
+    node: InsertQueryNode,
+    queryId?: QueryId,
+  ): InsertQueryNode {
+    if (this.#isEmptyInsertValuesNode(node)) {
+      return replaceWithSelectFrom(node)
+    }
+
+    return super.transformInsertQuery(node, queryId)
+  }
+
+  #isEmptyInsertValuesNode(
+    node: InsertQueryNode,
+  ): node is EmptyInsertValuesNode {
+    return node.columns?.length === 0 && node.values !== undefined && ValuesNode.is(node.values)
+  }
+}

--- a/test/node/src/handle-empty-insert-values-plugin.test.ts
+++ b/test/node/src/handle-empty-insert-values-plugin.test.ts
@@ -1,0 +1,116 @@
+import { HandleEmptyInsertValuesPlugin } from '../../../dist/index.js'
+import {
+  destroyTest,
+  initTest,
+  type TestContext,
+  testSql,
+  expect,
+  DIALECTS,
+  insertDefaultDataSet,
+  clearDatabase,
+} from './test-setup.js'
+
+for (const dialect of DIALECTS) {
+  const { variant } = dialect
+
+  describe(`${variant}: handle empty insert values plugin`, () => {
+    let ctx: TestContext
+
+    before(async function () {
+      ctx = await initTest(this, dialect, {
+        plugins: [new HandleEmptyInsertValuesPlugin()],
+      })
+    })
+
+    beforeEach(async () => {
+      await insertDefaultDataSet(ctx)
+    })
+
+    afterEach(async () => {
+      await clearDatabase(ctx)
+    })
+
+    after(async () => {
+      await destroyTest(ctx)
+    })
+
+    it('should handle `insert into t values ()` via .values({})', async () => {
+      const query = ctx.db.insertInto('person').values({} as any)
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: 'insert into "person" select * from "person" where 1 = 0',
+          parameters: [],
+        },
+        mysql: {
+          sql: 'insert into `person` select * from `person` where 1 = 0',
+          parameters: [],
+        },
+        mssql: {
+          sql: 'insert into "person" select * from "person" where 1 = 0',
+          parameters: [],
+        },
+        sqlite: {
+          sql: 'insert into "person" select * from "person" where 1 = 0',
+          parameters: [],
+        },
+      })
+
+      const result = await query.executeTakeFirstOrThrow()
+
+      expect(result.numInsertedOrUpdatedRows).to.equal(0n)
+    })
+
+    it('should handle `insert into t values ()` via .values([{}, {}])', async () => {
+      const query = ctx.db.insertInto('person').values([{}, {}] as any)
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: 'insert into "person" select * from "person" where 1 = 0',
+          parameters: [],
+        },
+        mysql: {
+          sql: 'insert into `person` select * from `person` where 1 = 0',
+          parameters: [],
+        },
+        mssql: {
+          sql: 'insert into "person" select * from "person" where 1 = 0',
+          parameters: [],
+        },
+        sqlite: {
+          sql: 'insert into "person" select * from "person" where 1 = 0',
+          parameters: [],
+        },
+      })
+
+      const result = await query.executeTakeFirstOrThrow()
+
+      expect(result.numInsertedOrUpdatedRows).to.equal(0n)
+    })
+
+    it('should not affect non-empty inserts', async () => {
+      const query = ctx.db
+        .insertInto('person')
+        .values({ first_name: 'Test', last_name: 'User', gender: 'other' })
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: 'insert into "person" ("first_name", "last_name", "gender") values ($1, $2, $3)',
+          parameters: ['Test', 'User', 'other'],
+        },
+        mysql: {
+          sql: 'insert into `person` (`first_name`, `last_name`, `gender`) values (?, ?, ?)',
+          parameters: ['Test', 'User', 'other'],
+        },
+        mssql: {
+          sql: 'insert into "person" ("first_name", "last_name", "gender") values (@1, @2, @3)',
+          parameters: ['Test', 'User', 'other'],
+        },
+        sqlite: {
+          sql: 'insert into "person" ("first_name", "last_name", "gender") values (?, ?, ?)',
+          parameters: ['Test', 'User', 'other'],
+        },
+      })
+    })
+  })
+}

--- a/test/node/src/handle-empty-insert-values-plugin.test.ts
+++ b/test/node/src/handle-empty-insert-values-plugin.test.ts
@@ -34,35 +34,8 @@ for (const dialect of DIALECTS) {
       await destroyTest(ctx)
     })
 
-    it('should handle `insert into t values ()` via .values({})', async () => {
-      const query = ctx.db.insertInto('person').values({} as any)
-
-      testSql(query, dialect, {
-        postgres: {
-          sql: 'insert into "person" select * from "person" where 1 = 0',
-          parameters: [],
-        },
-        mysql: {
-          sql: 'insert into `person` select * from `person` where 1 = 0',
-          parameters: [],
-        },
-        mssql: {
-          sql: 'insert into "person" select * from "person" where 1 = 0',
-          parameters: [],
-        },
-        sqlite: {
-          sql: 'insert into "person" select * from "person" where 1 = 0',
-          parameters: [],
-        },
-      })
-
-      const result = await query.executeTakeFirstOrThrow()
-
-      expect(result.numInsertedOrUpdatedRows).to.equal(0n)
-    })
-
-    it('should handle `insert into t values ()` via .values([{}, {}])', async () => {
-      const query = ctx.db.insertInto('person').values([{}, {}] as any)
+    it('should handle `insert into t values ()` via .values([])', async () => {
+      const query = ctx.db.insertInto('person').values([] as any)
 
       testSql(query, dialect, {
         postgres: {


### PR DESCRIPTION
Adds a new opt-in plugin, `HandleEmptyInsertValuesPlugin`, for handling empty array inserts.

```ts
insertInto("t").values([]) // Invalid SQL causing a runtime error
```

This produces invalid SQL in most databases, causing a runtime error. This can happen if we forget to length check a list before insert.

When triggered, the plugin rewrites the query to `INSERT INTO t SELECT * FROM t WHERE 1 = 0`, which is valid SQL that inserts zero rows and returns `numInsertedOrUpdatedRows: 0n`.

```ts
plugins: [
    new HandleEmptyInsertValuesPlugin()
],

...

insertInto("t").values([]) // Valid SQL, no-op
```

Relevant to the discussion here https://github.com/kysely-org/kysely/pull/1473#issuecomment-2925158012 on PR #1473.

Also relevant to these closed issues #596, #1401, #1630.