### PR TITLE
fix(safe-null-comparison): emit literal NULL instead of parameterised null operand

### DIFF
--- a/src/plugin/safe-null-comparison/safe-null-comparison-transformer.ts
+++ b/src/plugin/safe-null-comparison/safe-null-comparison-transformer.ts
@@ -27,7 +27,18 @@ export class SafeNullComparisonTransformer extends OperationNodeTransformer {
     return BinaryOperationNode.create(
       leftOperand,
       OperatorNode.create(op === '=' ? 'is' : 'is not'),
-      rightOperand,
+      // Emit the null operand inline as the SQL keyword `null` rather
+      // than preserving the parameterised `ValueNode`. The compiled
+      // shape `... IS <placeholder>` is non-standard SQL — strict-ANSI
+      // parsers (PostgreSQL, Microsoft SQL Server) reject it at parse
+      // time. `createImmediate(null)` routes through `appendImmediateValue`
+      // in the default query compiler, which writes the literal `null`
+      // keyword. Resulting `... IS NULL` / `... IS NOT NULL` is the
+      // ANSI-standard null-predicate form and is valid across every
+      // dialect Kysely supports.
+      //
+      // Fixes #1830.
+      ValueNode.createImmediate(null),
     )
   }
 }

--- a/test/node/src/safe-null-comparison-plugin.test.ts
+++ b/test/node/src/safe-null-comparison-plugin.test.ts
@@ -38,20 +38,20 @@ for (const dialect of DIALECTS) {
 
       testSql(query, dialect, {
         postgres: {
-          sql: 'select from "person" where "first_name" is $1',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is null',
+          parameters: [],
         },
         mysql: {
-          sql: 'select from `person` where `first_name` is ?',
-          parameters: [null],
+          sql: 'select from `person` where `first_name` is null',
+          parameters: [],
         },
         mssql: {
-          sql: 'select from "person" where "first_name" is @1',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is null',
+          parameters: [],
         },
         sqlite: {
-          sql: 'select from "person" where "first_name" is ?',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is null',
+          parameters: [],
         },
       })
     })
@@ -90,20 +90,20 @@ for (const dialect of DIALECTS) {
 
       testSql(query, dialect, {
         postgres: {
-          sql: 'select from "person" where "first_name" is not $1',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is not null',
+          parameters: [],
         },
         mysql: {
-          sql: 'select from `person` where `first_name` is not ?',
-          parameters: [null],
+          sql: 'select from `person` where `first_name` is not null',
+          parameters: [],
         },
         mssql: {
-          sql: 'select from "person" where "first_name" is not @1',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is not null',
+          parameters: [],
         },
         sqlite: {
-          sql: 'select from "person" where "first_name" is not ?',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is not null',
+          parameters: [],
         },
       })
     })
@@ -142,20 +142,20 @@ for (const dialect of DIALECTS) {
 
       testSql(query, dialect, {
         postgres: {
-          sql: 'select from "person" where "first_name" is not $1',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is not null',
+          parameters: [],
         },
         mysql: {
-          sql: 'select from `person` where `first_name` is not ?',
-          parameters: [null],
+          sql: 'select from `person` where `first_name` is not null',
+          parameters: [],
         },
         mssql: {
-          sql: 'select from "person" where "first_name" is not @1',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is not null',
+          parameters: [],
         },
         sqlite: {
-          sql: 'select from "person" where "first_name" is not ?',
-          parameters: [null],
+          sql: 'select from "person" where "first_name" is not null',
+          parameters: [],
         },
       })
     })
@@ -195,20 +195,20 @@ for (const dialect of DIALECTS) {
 
       testSql(query, dialect, {
         postgres: {
-          sql: 'select from "person" where "first_name" is $1 and "last_name" is $2',
-          parameters: [null, null],
+          sql: 'select from "person" where "first_name" is null and "last_name" is null',
+          parameters: [],
         },
         mysql: {
-          sql: 'select from `person` where `first_name` is ? and `last_name` is ?',
-          parameters: [null, null],
+          sql: 'select from `person` where `first_name` is null and `last_name` is null',
+          parameters: [],
         },
         mssql: {
-          sql: 'select from "person" where "first_name" is @1 and "last_name" is @2',
-          parameters: [null, null],
+          sql: 'select from "person" where "first_name" is null and "last_name" is null',
+          parameters: [],
         },
         sqlite: {
-          sql: 'select from "person" where "first_name" is ? and "last_name" is ?',
-          parameters: [null, null],
+          sql: 'select from "person" where "first_name" is null and "last_name" is null',
+          parameters: [],
         },
       })
     })
@@ -223,20 +223,20 @@ for (const dialect of DIALECTS) {
 
       testSql(query, dialect, {
         postgres: {
-          sql: 'select from "person" where "first_name" is $1 and "last_name" is not $2 and "last_name" = $3',
-          parameters: [null, null, 'Foo'],
+          sql: 'select from "person" where "first_name" is null and "last_name" is not null and "last_name" = $1',
+          parameters: ['Foo'],
         },
         mysql: {
-          sql: 'select from `person` where `first_name` is ? and `last_name` is not ? and `last_name` = ?',
-          parameters: [null, null, 'Foo'],
+          sql: 'select from `person` where `first_name` is null and `last_name` is not null and `last_name` = ?',
+          parameters: ['Foo'],
         },
         mssql: {
-          sql: 'select from "person" where "first_name" is @1 and "last_name" is not @2 and "last_name" = @3',
-          parameters: [null, null, 'Foo'],
+          sql: 'select from "person" where "first_name" is null and "last_name" is not null and "last_name" = @1',
+          parameters: ['Foo'],
         },
         sqlite: {
-          sql: 'select from "person" where "first_name" is ? and "last_name" is not ? and "last_name" = ?',
-          parameters: [null, null, 'Foo'],
+          sql: 'select from "person" where "first_name" is null and "last_name" is not null and "last_name" = ?',
+          parameters: ['Foo'],
         },
       })
     })


### PR DESCRIPTION
## What

Fixes #1830 — `SafeNullComparisonPlugin` emits non-standard `IS <placeholder>` SQL that PostgreSQL and SQL Server reject at parse time.

The transformer rewrote `=` / `!=` / `<>` against literal `null` to `is` / `is not` correctly, but preserved the null right operand as a parameterised `ValueNode`. The compiled shape was:

| Dialect | Compiled SQL | Result |
|---|---|---|
| PostgreSQL | `WHERE "col" IS $1` (params `[null]`) | ❌ `syntax error at or near "$1"` |
| MSSQL | `WHERE [col] IS @p1` (params `[null]`) | ❌ `Incorrect syntax near '@p1'` |
| MySQL | `WHERE \`col\` IS ?` (params `[null]`) | ✅ accepted (permissive parser) |
| SQLite | `WHERE "col" IS ?` (params `[null]`) | ✅ accepted (permissive parser) |

PostgreSQL and SQL Server enforce the SQL-standard `IS` predicate grammar literally — `IS` must be followed by `NULL` / `TRUE` / `FALSE` / `UNKNOWN` / `DISTINCT FROM …`. SQLite and MySQL accept `IS <expr>` as a more general binary comparator and evaluate it correctly when the right operand resolves to NULL at runtime, but the emitted SQL is still non-standard on those dialects.

Full empirical matrix + driver versions + server containers used to verify each row: <https://github.com/forinda/kick-js/issues/220#issuecomment-4442237049>.

## How

One-line change in `safe-null-comparison-transformer.ts`:

```diff
 return BinaryOperationNode.create(
   leftOperand,
   OperatorNode.create(op === '=' ? 'is' : 'is not'),
-  rightOperand,
+  ValueNode.createImmediate(null),
 )
```

`ValueNode.createImmediate(value)` already exists in `src/operation-node/value-node.ts` and routes through `appendImmediateValue` in `DefaultQueryCompiler` (around line 1900 in `default-query-compiler.ts`), which writes the SQL keyword `null` literally when the value is null. No new node-type or compiler-path work.

After the fix, all four dialects emit:

```text
where "deletedAt" is null         params: []
where "deletedAt" is not null     params: []
```

Non-null comparisons are untouched (still parameterised as before).

## Tests

`test/node/src/safe-null-comparison-plugin.test.ts` previously locked the broken behaviour — every test expected `is $1` / `is ?` / `is @1` with `parameters: [null]`. Those expectations are updated to the new correct shape (`is null` / `is not null` with `parameters: []`). The mixed-clause + non-null-passthrough cases are updated to match.

I verified the compile-only output across all four dialects via a one-off Node script against `pnpm build` output (see commit message body for the per-dialect verification). I didn't run the full `test:node:run` suite locally because that requires `docker compose up` for all four servers — happy to bring those up if you'd like a recorded run before merging, but the changes are pure compile-time and the existing test harness's `testSql` uses `query.compile()` (no DB round trip needed for the assertions in this file).

## Adopter context

We hit this in [`@forinda/kickjs-db`](https://github.com/forinda/kick-js) on a PostgreSQL adopter app and shipped a kickjs-side workaround (a custom `OperationNodeTransformer` subclass with the same one-line swap). That workaround can be deleted from kickjs once this lands.

## Surprise-PR check

Per CONTRIBUTING.md: this PR is linked to #1830 (which I filed today). No prior PR was open on it. Happy to follow whatever assignment / pair-up process the maintainers prefer — please let me know if you'd like a different workflow.

Thanks for reviewing! 🙏
