### PR TITLE
fix: plugin chaining

### DIFF
--- a/src/query-executor/query-executor-base.ts
+++ b/src/query-executor/query-executor-base.ts
@@ -302,13 +302,13 @@ export abstract class QueryExecutorBase implements QueryExecutor {
     queryId: QueryId,
     options?: AbortableOperationOptions | undefined,
   ): Promise<QueryResult<T>> {
-    const args = freeze({
-      queryId,
-      result,
-      signal: options?.signal,
-    } satisfies PluginTransformResultArgs)
-
     for (const plugin of this.#plugins) {
+      const args = freeze({
+        queryId,
+        result,
+        signal: options?.signal,
+      } satisfies PluginTransformResultArgs)
+
       result = await plugin.transformResult(args)
     }
 

--- a/test/node/src/query-id.test.ts
+++ b/test/node/src/query-id.test.ts
@@ -8,6 +8,7 @@ import {
   PostgresQueryCompiler,
   type RootOperationNode,
   type QueryId,
+  type QueryResult,
 } from '../../../dist/index.js'
 import type { Database } from './test-setup.js'
 
@@ -72,4 +73,56 @@ describe('queryId', () => {
   function checkIn(queryId: QueryId, place: string): void {
     visits.set(queryId, [...(visits.get(queryId) || []), place])
   }
+})
+
+describe('result plugins', () => {
+  it('should pass each transformed result to the next plugin', async () => {
+    const db = new Kysely<Database>({
+      dialect: {
+        createAdapter: () => new PostgresAdapter(),
+        createDriver: () =>
+          new (class extends DummyDriver {
+            async acquireConnection(): Promise<DatabaseConnection> {
+              // @ts-ignore
+              return {
+                executeQuery: async <R>(): Promise<QueryResult<R>> => ({
+                  rows: [{ original: true }] as R[],
+                }),
+              }
+            }
+          })(),
+        createIntrospector: (db) => new PostgresIntrospector(db),
+        createQueryCompiler: () => new PostgresQueryCompiler(),
+      },
+      plugins: [
+        {
+          transformQuery: (args) => args.node,
+          transformResult: async (args) => ({
+            ...args.result,
+            rows: args.result.rows.map((row) => ({ ...row, first: true })),
+          }),
+        },
+        {
+          transformQuery: (args) => args.node,
+          transformResult: async (args) => ({
+            ...args.result,
+            rows: args.result.rows.map((row) => ({
+              ...row,
+              secondSawFirst: row.first,
+            })),
+          }),
+        },
+      ],
+    })
+
+    const result = await db.selectFrom('person').selectAll().execute()
+
+    expect(result).to.deep.equal([
+      {
+        first: true,
+        original: true,
+        secondSawFirst: true,
+      },
+    ])
+  })
 })


### PR DESCRIPTION
This PR fixes a regression in result plugin chaning from https://github.com/kysely-org/kysely/pull/1798/changes#diff-c64dda439503d27dc1cbeaa4813abf0eb82cfd770654ec94fd9a5b679c1727f9R306

Each plugin now receives fresh args containing the result returned by the previous plugin, as it was done before.