### PR TITLE
ci: test node.js v26.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://endoflife.date/nodejs
-        node-version: [22.x, 24.x, 25.x]
+        node-version: [22.x, 24.x, 26.x]
         with-transformer: [false, true]
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@types/prototype-pollution-vulnerable-lodash.merge-dont-upgrade": "npm:@types/lodash.merge@4.6.1",
     "@types/semver": "7.7.1",
     "@types/sinon": "21.0.1",
-    "better-sqlite3": "12.9.0",
+    "better-sqlite3": "12.10.0",
     "chai": "6.2.2",
     "chai-as-promised": "8.0.2",
     "esbuild": "0.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: 21.0.1
         version: 21.0.1
       better-sqlite3:
-        specifier: 12.9.0
-        version: 12.9.0
+        specifier: 12.10.0
+        version: 12.10.0
       chai:
         specifier: 6.2.2
         version: 6.2.2
@@ -2834,9 +2834,9 @@ packages:
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -10633,7 +10633,7 @@ snapshots:
 
   bcp-47-match@2.0.3: {}
 
-  better-sqlite3@12.9.0:
+  better-sqlite3@12.10.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 # Allow (true) or disallow (false) script execution.
 # https://pnpm.io/settings#allowbuilds
 allowBuilds:
-  better-sqlite3@12.9.0: true
+  better-sqlite3@12.10.0: true
   core-js: false # site dependency, useless scripts
   core-js-pure: false # site dependency, useless scripts
   esbuild@0.27.3 || 0.28.0: true # tsx@4.21.0 dependency || direct.
@@ -30,7 +30,7 @@ engineStrict: true
 # https://pnpm.io/settings#ignoreworkspacerootcheck
 ignoreWorkspaceRootCheck: true
 
-# fail and don't fallback to "too new" version of packages when none of their other 
+# fail and don't fallback to "too new" version of packages when none of their other
 # versions match `minimumReleaseAge` range (default is 1 day).
 # https://pnpm.io/settings#minimumreleaseagestrict
 minimumReleaseAgeStrict: true


### PR DESCRIPTION
Hey 👋 

This PR bumps `better-sqlite3` to `12.10.0` which enables testing with Node.js 26.