### PR TITLE
fix: `$narrowType` mishandling branded types.

### DIFF
--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -159,10 +159,10 @@ export type NarrowPartial<O, T> = T extends object
       [K in keyof O & string]: K extends keyof T
         ? T[K] extends NotNull
           ? Exclude<O[K], null>
-          : T[K] extends object
-            ? SimplifyDeep<O[K] & NarrowPartial<O[K], T[K]>>
-            : T[K] extends O[K]
-              ? T[K]
+          : T[K] extends O[K]
+            ? T[K]
+            : T[K] extends object
+              ? SimplifyDeep<O[K] & NarrowPartial<O[K], T[K]>>
               : KyselyTypeError<`$narrowType() call failed: passed type does not exist in '${K}'s type union`>
         : O[K]
     }>

--- a/test/typings/test-d/select.test-d.ts
+++ b/test/typings/test-d/select.test-d.ts
@@ -11,6 +11,8 @@ import {
 } from '../index.js'
 import type { Database, Person } from '../shared.js'
 
+declare const $brand: unique symbol
+
 async function testSelectSingle(db: Kysely<Database>) {
   const qb = db.selectFrom('person')
 
@@ -152,6 +154,50 @@ async function testSelectSingle(db: Kysely<Database>) {
       tags: string[]
     }
   }>(r18)
+
+  const [r19] = await db
+    .$extendTables<{
+      organization: {
+        companyId: string & {
+          [$brand]: { CompanyNanoId: true }
+        }
+        headCount: number
+        metadata: {
+          createdAt: Date & {
+            [$brand]: { PastDate: true }
+          }
+          updatedAt: Date
+        }
+      }
+    }>()
+    .selectFrom('organization')
+    .selectAll()
+    .$narrowType<{
+      headCount: number & { [$brand]: { HeadCount: true } }
+      metadata: {
+        updatedAt: Date & {
+          [$brand]: {
+            PastDate: true
+          }
+        }
+      }
+    }>()
+    .execute()
+
+  expectType<{
+    companyId: string & {
+      [$brand]: { CompanyNanoId: true }
+    }
+    headCount: number & { [$brand]: { HeadCount: true } }
+    metadata: {
+      createdAt: Date & {
+        [$brand]: { PastDate: true }
+      }
+      updatedAt: Date & {
+        [$brand]: { PastDate: true }
+      }
+    }
+  }>(r19)
 
   const expr1 = db.selectFrom('person').select('first_name').$asScalar()
   expectType<ExpressionWrapper<Database, 'person', string>>(expr1)


### PR DESCRIPTION
Hey :wave:

closes #1849.

This PR fixes a regression in handling of branded typed columns and nested properties, where they would be treated as plain object and you'd get enumerations of primitive types' methods in the output type.