### PR TITLE
fix(site): include generated pages in llms output

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -46,7 +46,7 @@ export default {
             '.code-example',
           ],
           enableLlmsFullTxt: true,
-          includeGeneratedIndex: false,
+          includeGeneratedIndex: true,
           includePages: true,
           includeVersionedDocs: false,
           relativePaths: false,


### PR DESCRIPTION
Closes #1786.\n\nIncludes generated category index pages in the llms output so the docs build no longer reports excluded generated routes.\n\nChecks:\n- pnpm --dir site build\n- pnpm exec prettier --check site/docusaurus.config.ts