### PR TITLE
fix: allow never-update columns in onConflict where clause

### DIFF
--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -47,6 +47,7 @@ import {
   type OnConflictDoNothingBuilder,
   type OnConflictTables,
   type OnConflictUpdateBuilder,
+  type OnConflictWhereDatabase,
 } from './on-conflict-builder.js'
 import { OnConflictNode } from '../operation-node/on-conflict-node.js'
 import type { Selectable } from '../util/column-type.js'
@@ -886,7 +887,8 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, out O>
     ) =>
       | OnConflictUpdateBuilder<
           OnConflictDatabase<DB, TB>,
-          OnConflictTables<TB>
+          OnConflictTables<TB>,
+          OnConflictWhereDatabase<DB, TB>
         >
       | OnConflictDoNothingBuilder<DB, TB>,
   ): InsertQueryBuilder<DB, TB, O> {

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -15,7 +15,7 @@ import {
   type UpdateObjectExpression,
   parseUpdateObjectExpression,
 } from '../parser/update-set-parser.js'
-import type { Updateable } from '../util/column-type.js'
+import type { Selectable, Updateable } from '../util/column-type.js'
 import { freeze } from '../util/object-utils.js'
 import type { AnyColumn, SqlBool } from '../util/type-utils.js'
 import type { WhereInterface } from './where-interface.js'
@@ -254,7 +254,11 @@ export class OnConflictBuilder<
       OnConflictTables<TB>,
       OnConflictTables<TB>
     >,
-  ): OnConflictUpdateBuilder<OnConflictDatabase<DB, TB>, OnConflictTables<TB>> {
+  ): OnConflictUpdateBuilder<
+    OnConflictDatabase<DB, TB>,
+    OnConflictTables<TB>,
+    OnConflictWhereDatabase<DB, TB>
+  > {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWith(this.#props.onConflictNode, {
@@ -280,6 +284,21 @@ export type OnConflictDatabase<DB, TB extends keyof DB> = {
   [K in keyof DB | 'excluded']: Updateable<K extends keyof DB ? DB[K] : DB[TB]>
 }
 
+/**
+ * The database type used to resolve references in the `where` clause of an
+ * `on conflict do update` action.
+ *
+ * Unlike {@link OnConflictDatabase}, which uses {@link Updateable} to only
+ * expose columns that can be part of the update set, this type uses
+ * {@link Selectable} so that all readable columns are referenceable. A `where`
+ * clause is a read-only context, so columns whose update type is `never` (e.g.
+ * `ColumnType<Date, never, never>` or {@link GeneratedAlways}) must still be
+ * usable there.
+ */
+export type OnConflictWhereDatabase<DB, TB extends keyof DB> = {
+  [K in keyof DB | 'excluded']: Selectable<K extends keyof DB ? DB[K] : DB[TB]>
+}
+
 export type OnConflictTables<TB> = TB | 'excluded'
 
 export class OnConflictDoNothingBuilder<
@@ -297,8 +316,12 @@ export class OnConflictDoNothingBuilder<
   }
 }
 
-export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
-  implements WhereInterface<DB, TB>, OperationNodeSource
+export class OnConflictUpdateBuilder<
+  DB,
+  TB extends keyof DB,
+  WDB extends Record<TB, any> = DB,
+>
+  implements WhereInterface<WDB, TB>, OperationNodeSource
 {
   readonly #props: OnConflictBuilderProps
 
@@ -309,22 +332,26 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
   /**
    * Specify a where condition for the update operation.
    *
+   * The `where` clause is a read-only context, so all selectable columns are
+   * referenceable here, including those whose update type is `never` (e.g.
+   * `ColumnType<Date, never, never>`), which are excluded from the update set.
+   *
    * See {@link WhereInterface.where} for more info.
    */
   where<
-    RE extends ReferenceExpression<DB, TB>,
-    VE extends OperandValueExpressionOrList<DB, TB, RE>,
+    RE extends ReferenceExpression<WDB, TB>,
+    VE extends OperandValueExpressionOrList<WDB, TB, RE>,
   >(
     lhs: RE,
     op: ComparisonOperatorExpression,
     rhs: VE,
-  ): OnConflictUpdateBuilder<DB, TB>
+  ): OnConflictUpdateBuilder<DB, TB, WDB>
 
-  where<E extends ExpressionOrFactory<DB, TB, SqlBool>>(
+  where<E extends ExpressionOrFactory<WDB, TB, SqlBool>>(
     expression: E,
-  ): OnConflictUpdateBuilder<DB, TB>
+  ): OnConflictUpdateBuilder<DB, TB, WDB>
 
-  where(...args: any[]): OnConflictUpdateBuilder<DB, TB> {
+  where(...args: any[]): OnConflictUpdateBuilder<DB, TB, WDB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithUpdateWhere(
@@ -340,13 +367,13 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
    * See {@link WhereInterface.whereRef} for more info.
    */
   whereRef<
-    LRE extends ReferenceExpression<DB, TB>,
-    RRE extends ReferenceExpression<DB, TB>,
+    LRE extends ReferenceExpression<WDB, TB>,
+    RRE extends ReferenceExpression<WDB, TB>,
   >(
     lhs: LRE,
     op: ComparisonOperatorExpression,
     rhs: RRE,
-  ): OnConflictUpdateBuilder<DB, TB> {
+  ): OnConflictUpdateBuilder<DB, TB, WDB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithUpdateWhere(
@@ -356,7 +383,7 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
     })
   }
 
-  clearWhere(): OnConflictUpdateBuilder<DB, TB> {
+  clearWhere(): OnConflictUpdateBuilder<DB, TB, WDB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithoutUpdateWhere(

--- a/test/typings/test-d/insert.test-d.ts
+++ b/test/typings/test-d/insert.test-d.ts
@@ -66,6 +66,74 @@ async function testInsert(db: Kysely<Database>) {
 
   expectType<InsertResult>(r5)
 
+  // A column whose update type is `never` (e.g. `modified_at` is
+  // `ColumnType<Date, never, never>`) should still be referenceable in the
+  // `onConflict` `where` clause, since `where` is a read-only context.
+  const r5b = await db
+    .insertInto('person')
+    .values(person)
+    .onConflict((oc) =>
+      oc
+        .column('id')
+        .doUpdateSet({ first_name: 'foo' })
+        .where('modified_at', '>', new Date()),
+    )
+    .executeTakeFirst()
+
+  expectType<InsertResult>(r5b)
+
+  // A `GeneratedAlways` column (also `ColumnType<T, never, never>`) should be
+  // referenceable in the `onConflict` `where` clause.
+  const r5c = await db
+    .insertInto('book')
+    .values({ name: 'foo' })
+    .onConflict((oc) =>
+      oc.column('id').doUpdateSet({ name: 'bar' }).where('id', '=', 1),
+    )
+    .executeTakeFirst()
+
+  expectType<InsertResult>(r5c)
+
+  // The `excluded` virtual table should also expose `never`-update columns in
+  // the `onConflict` `where` clause.
+  const r5d = await db
+    .insertInto('person')
+    .values(person)
+    .onConflict((oc) =>
+      oc
+        .column('id')
+        .doUpdateSet({ first_name: 'foo' })
+        .whereRef('modified_at', '<', 'excluded.modified_at'),
+    )
+    .executeTakeFirst()
+
+  expectType<InsertResult>(r5d)
+
+  // A `never`-update column must still be rejected in the `onConflict`
+  // `doUpdateSet` call, since it cannot be updated.
+  expectError(
+    db
+      .insertInto('person')
+      .values(person)
+      .onConflict((oc) =>
+        oc.column('id').doUpdateSet({ modified_at: new Date() }),
+      ),
+  )
+
+  // A non-existent column must still be rejected in the `onConflict` `where`
+  // clause.
+  expectError(
+    db
+      .insertInto('person')
+      .values(person)
+      .onConflict((oc) =>
+        oc
+          .column('id')
+          .doUpdateSet({ first_name: 'foo' })
+          .where('doesnt_exist', '=', 1),
+      ),
+  )
+
   const r6 = await db
     .insertInto('person')
     .values((eb) => ({


### PR DESCRIPTION
## Problem
A column whose update type is `never` (e.g. `ColumnType<Date, never, never>` or `GeneratedAlways<T>`) cannot be referenced in the `.where()` clause of an `onConflict(...).doUpdateSet(...)` action, even though `where` is a read-only context.

## Root cause
`OnConflictDatabase` wraps every table through `Updateable`, which filters out columns whose update type is `never`. `OnConflictUpdateBuilder` resolved its `where`/`whereRef` references against that filtered database, so read-only columns were invisible there.

## Fix
Add `OnConflictWhereDatabase` (built with `Selectable` instead of `Updateable`) and a third `WDB` generic on `OnConflictUpdateBuilder` (defaults to `DB` for backwards compatibility). `where`/`whereRef`/`clearWhere` resolve against `WDB`; `doUpdateSet` keeps using the `Updateable`-filtered DB, so non-updateable columns are still rejected in the update set.

## Tests
Added type tests in `test/typings/test-d/insert.test-d.ts` covering `ColumnType<Date, never, never>` and `GeneratedAlways` columns referenceable in onConflict `where`, plus regression guards that `doUpdateSet` still rejects `never`-update columns and `where` still rejects non-existent columns.

Closes #1409