### PR TITLE
docs: kysely-typegen

### DIFF
--- a/site/docs/generating-types.md
+++ b/site/docs/generating-types.md
@@ -9,9 +9,11 @@ database schema, by automatically generating the database schema type definition
 
 There are several ways to do this using third-party libraries:
 
-- [kysely-codegen](https://github.com/RobinBlomberg/kysely-codegen) - This library 
-generates Kysely database schema type definitions by connecting to and introspecting 
+- [kysely-codegen](https://github.com/RobinBlomberg/kysely-codegen) - This CLI tool
+generates Kysely database schema type definitions by connecting to and introspecting
 your database. This library works with all built-in dialects.
+
+- [kysely-typegen](https://github.com/theoludwig/kysely-typegen) - This library generates Kysely database schema type definitions by connecting to and introspecting your database. Lightweight (no runtime dependencies) and easily extendable (to support more dialects or features). You're in control of how to save the generated types, how to connect to the database, etc.
 
 - [prisma-kysely](https://github.com/valtyr/prisma-kysely) - This library generates 
 Kysely database schema type definitions from your existing Prisma schemas.

--- a/site/docs/recipes/0002-data-types.md
+++ b/site/docs/recipes/0002-data-types.md
@@ -75,6 +75,6 @@ export const db = new Kysely<Database>({
 
 ## Type generators
 
-There are third-party type generators such as [kysely-codegen](https://github.com/RobinBlomberg/kysely-codegen) and [kanel-kysely](https://kristiandupont.github.io/kanel/kanel-kysely.html) that automatically generate TypeScript types based on the database schema. Find out more at ["Generating types"](https://kysely.dev/docs/generating-types).
+There are third-party type generators such as [kysely-codegen](https://github.com/RobinBlomberg/kysely-codegen), [kysely-typegen](https://github.com/theoludwig/kysely-typegen) and [kanel-kysely](https://kristiandupont.github.io/kanel/kanel-kysely.html) that automatically generate TypeScript types based on the database schema. Find out more at ["Generating types"](https://kysely.dev/docs/generating-types).
 
 If these tools generate a type that doesn't match the runtime type you observe, please refer to their documentation or open an issue in their github. Kysely has no control over these libraries.

--- a/site/src/components/SectionFeatures/index.tsx
+++ b/site/src/components/SectionFeatures/index.tsx
@@ -15,7 +15,7 @@ const FeatureList: FeatureItem[] = [
         Kysely's state-of-the-art, type-safe API provides precise result types
         and catches errors within queries at compile-time, giving
         high-performing teams the confidence to ship at greater velocity. Use
-        `kysely-codegen` to make the database the source of types.
+        `kysely-codegen` or `kysely-typegen` to make the database the source of types.
       </>
     ),
   },


### PR DESCRIPTION
Mention [kysely-typegen](https://npmx.dev/package/kysely-typegen) in the documentation, it is a lightweight alternative to `kysely-codegen`.

From the README:

## Why?

Why `kysely-typegen` if there is already `kysely-codegen`? Comparison:

|                               | `kysely-codegen@0.20.0`                  | `kysely-typegen`                                                                    |
| ----------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------- |
| **Install Size**              | 6.8 MB                                   | 22.1 kB                                                                             |
| **Dependencies**              | 35 total                                 | 0 (no runtime dependencies)                                                         |
| **Type**                      | CLI                                      | Library/Programmatic Usage                                                          |
| **Code Size/Maintainability** | Heavy                                    | Lightweight/Simple and straightforward (string manipulation instead of complex AST) |
| **Database Support**          | PostgreSQL, MySQL, SQLite, MSSQL, LibSQL | PostgreSQL (both `pg` and `postgres` package), MySQL, SQLite (**can be easily extended to more**)                      |

`kysely-typegen` is a **library** (not a CLI), which means you are in control of where and how to run it, and is designed to be **extensible**, easy to add support for more database dialects.

For more details, why this project was created, and the design decisions, see: <https://github.com/RobinBlomberg/kysely-codegen/issues/175>.

Thank you to the kysely ecosystem, and kysely-codegen contributors for inspiration and ideas.