### PR TITLE
fix: release the connection mutex even when driver release rejects

### DIFF
--- a/src/driver/runtime-driver.ts
+++ b/src/driver/runtime-driver.ts
@@ -109,9 +109,11 @@ export class RuntimeDriver implements Driver {
     connection: DatabaseConnection,
     options?: AbortableOperationOptions,
   ): Promise<void> {
-    await this.#driver.releaseConnection(connection, options)
-
-    this.#connectionMutex?.releaseLock()
+    try {
+      await this.#driver.releaseConnection(connection, options)
+    } finally {
+      this.#connectionMutex?.releaseLock()
+    }
   }
 
   async beginTransaction(

--- a/test/node/src/connection-mutex-release.test.ts
+++ b/test/node/src/connection-mutex-release.test.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai'
+
+import {
+  DummyDriver,
+  Kysely,
+  SqliteAdapter,
+  SqliteIntrospector,
+  SqliteQueryCompiler,
+  type DatabaseConnection,
+  type QueryResult,
+} from '../../../dist/index.js'
+
+/**
+ * Regression test for the single-connection mutex being leaked when a driver's
+ * `releaseConnection` rejects.
+ *
+ * For single-connection dialects (`supportsMultipleConnections === false`, e.g.
+ * SQLite / PGlite) `RuntimeDriver` serializes access with a `ConnectionMutex`.
+ * The lock is obtained in `acquireConnection` and released in
+ * `releaseConnection` AFTER awaiting the underlying driver's release. If that
+ * await rejects, the lock must still be released — otherwise the next
+ * `acquireConnection` waits on the mutex forever and the instance deadlocks.
+ */
+describe('single-connection mutex release', () => {
+  class EmptyConnection implements DatabaseConnection {
+    async executeQuery<R>(): Promise<QueryResult<R>> {
+      return { rows: [] }
+    }
+    async *streamQuery<R>(): AsyncIterableIterator<QueryResult<R>> {
+      // no rows
+    }
+  }
+
+  class FailingReleaseDriver extends DummyDriver {
+    #releaseCount = 0
+
+    override async acquireConnection(): Promise<DatabaseConnection> {
+      return new EmptyConnection()
+    }
+
+    override async releaseConnection(): Promise<void> {
+      this.#releaseCount++
+      // Only the first release rejects; the instance must survive it.
+      if (this.#releaseCount === 1) {
+        throw new Error('driver releaseConnection failed')
+      }
+    }
+  }
+
+  function createDb(): Kysely<any> {
+    return new Kysely<any>({
+      dialect: {
+        createAdapter: () => new SqliteAdapter(),
+        createDriver: () => new FailingReleaseDriver(),
+        createIntrospector: (db) => new SqliteIntrospector(db),
+        createQueryCompiler: () => new SqliteQueryCompiler(),
+      },
+    })
+  }
+
+  it('releases the connection mutex even when the driver release rejects', async () => {
+    const db = createDb()
+
+    // First query acquires the single connection; the driver's release rejects,
+    // so the query rejects. The mutex lock must still be freed.
+    let firstError: Error | undefined
+    try {
+      await db.selectFrom('person').selectAll().execute()
+    } catch (error) {
+      firstError = error as Error
+    }
+    expect(firstError?.message).to.equal('driver releaseConnection failed')
+
+    // Second query must be able to acquire the connection again. If the mutex
+    // lock leaked, this never resolves and the race below rejects.
+    const secondQuery = db.selectFrom('person').selectAll().execute()
+    const result = await Promise.race([
+      secondQuery,
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('DEADLOCK: second query never acquired the connection')),
+          2000,
+        ),
+      ),
+    ])
+
+    expect(result).to.deep.equal([])
+
+    await db.destroy()
+  })
+})


### PR DESCRIPTION
## Problem

Single-connection dialects (`supportsMultipleConnections === false` — e.g. SQLite, PGlite, libSQL) serialize connection access with a `ConnectionMutex`. In `RuntimeDriver.releaseConnection`, the mutex's `releaseLock()` runs only *after* `await this.#driver.releaseConnection(...)`:

```ts
await this.#driver.releaseConnection(connection, options)
this.#connectionMutex?.releaseLock()
```

If that await rejects, `releaseLock()` is skipped, so every subsequent `acquireConnection()` waits on the mutex forever — the instance deadlocks.

## Fix

Wrap the driver release in `try { … } finally { this.#connectionMutex?.releaseLock() }`, so the lock is always freed — mirroring the intent of the existing acquire/abort-path guard. Behaviour on the happy path is unchanged.

## Test

`test/node/src/connection-mutex-release.test.ts` adds a single-connection driver whose `releaseConnection` rejects. The test **deadlocks (times out) on the current code** and **passes with the fix**.

## Honest scope

The two bundled single-connection drivers (sqlite, pglite) have a no-op `releaseConnection` that never throws, so this is reached by custom/remote single-connection drivers whose release performs I/O (libSQL/Turso, Cloudflare D1). It's a robustness + internal-consistency fix with a severe failure mode (permanent instance deadlock).

---
*AI Disclosure: This contribution was proposed by Prodia, an autonomous TypeScript evolution system (https://prodia.dev). Human review was applied before submission. All changes pass the project's test suite.*
