### PR TITLE
fix(site): suppress llms-txt plugin warning by including generated index pages

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -46,7 +46,7 @@ export default {
             '.code-example',
           ],
           enableLlmsFullTxt: true,
-          includeGeneratedIndex: false,
+          includeGeneratedIndex: true,
           includePages: true,
           includeVersionedDocs: false,
           relativePaths: false,


### PR DESCRIPTION
The warning fires because `includeGeneratedIndex: false` causes 13 auto-generated category index pages to be excluded from the llms.txt output. The plugin counts any excluded route and emits:

```
[WARNING] [docusaurus-plugin-llms-txt] WARNING: Excluded 13 routes by current config
```

There's no plugin option to suppress this warning - it fires whenever `excludedCount > 0`. The previous attempt (#1788) added `excludeRoutes` patterns, but that approach can't work: routes already excluded by `includeGeneratedIndex: false` are still counted as excluded, and adding `excludeRoutes` for them has zero effect on the count.

The fix is to set `includeGeneratedIndex: true`, which includes the category index pages in the output. This makes `excludedCount = 0` and eliminates the warning.

The category index pages (e.g. `/docs/category/select`, `/docs/category/recipes`) contain lightweight listing content - including them in llms.txt actually gives LLMs useful navigation context about the docs structure.

Closes #1786