### PR TITLE
feat(insert): add .as() method to alias the inserted table

### DIFF
--- a/src/operation-node/insert-query-node.ts
+++ b/src/operation-node/insert-query-node.ts
@@ -1,4 +1,5 @@
 import { freeze } from '../util/object-utils.js'
+import type { AliasNode } from './alias-node.js'
 import type { ColumnNode } from './column-node.js'
 import type { ExplainNode } from './explain-node.js'
 import type { OnConflictNode } from './on-conflict-node.js'
@@ -15,7 +16,7 @@ export type InsertQueryNodeProps = Omit<InsertQueryNode, 'kind' | 'into'>
 
 export interface InsertQueryNode extends OperationNode {
   readonly kind: 'InsertQueryNode'
-  readonly into?: TableNode
+  readonly into?: TableNode | AliasNode
   readonly columns?: ReadonlyArray<ColumnNode>
   readonly values?: OperationNode
   readonly returning?: ReturningNode
@@ -34,7 +35,7 @@ export interface InsertQueryNode extends OperationNode {
 type InsertQueryNodeFactory = Readonly<{
   is(node: OperationNode): node is InsertQueryNode
   create(
-    into: TableNode,
+    into: TableNode | AliasNode,
     withNode?: WithNode,
     replace?: boolean,
   ): Readonly<InsertQueryNode>
@@ -42,6 +43,10 @@ type InsertQueryNodeFactory = Readonly<{
   cloneWith(
     insertQuery: InsertQueryNode,
     props: InsertQueryNodeProps,
+  ): Readonly<InsertQueryNode>
+  cloneWithInto(
+    insertQuery: InsertQueryNode,
+    into: TableNode | AliasNode,
   ): Readonly<InsertQueryNode>
 }>
 
@@ -73,6 +78,13 @@ export const InsertQueryNode: InsertQueryNodeFactory =
       return freeze({
         ...insertQuery,
         ...props,
+      })
+    },
+
+    cloneWithInto(insertQuery, into) {
+      return freeze({
+        ...insertQuery,
+        into,
       })
     },
   })

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -63,6 +63,8 @@ import type {
   SelectExpressionFromOutputExpression,
 } from './output-interface.js'
 import { OrActionNode } from '../operation-node/or-action-node.js'
+import { AliasNode } from '../operation-node/alias-node.js'
+import { IdentifierNode } from '../operation-node/identifier-node.js'
 import type {
   Executable,
   ExecuteTakeFirstOrThrowOptions,
@@ -83,6 +85,46 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, out O>
 
   constructor(props: InsertQueryBuilderProps) {
     this.#props = freeze(props)
+  }
+
+  /**
+   * Adds an alias for the inserted table.
+   *
+   * Useful when using `ON CONFLICT DO UPDATE` to reference the row
+   * being inserted via its alias.
+   *
+   * Only supported on PostgreSQL and SQLite.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * const result = await db.insertInto('person')
+   *   .as('p')
+   *   .values({ first_name: 'Jennifer', last_name: 'Aniston', age: 40 })
+   *   .onConflict((oc) => oc
+   *     .column('first_name')
+   *     .doUpdateSet((eb) => ({ age: eb.ref('p.age') }))
+   *   )
+   *   .executeTakeFirst()
+   * ```
+   *
+   * The generated SQL (PostgreSQL):
+   *
+   * ```sql
+   * insert into "person" as "p" ("first_name", "last_name", "age")
+   * values ($1, $2, $3)
+   * on conflict ("first_name") do update set "age" = "p"."age"
+   * ```
+   */
+  as(alias: string): InsertQueryBuilder<DB, TB, O> {
+    const { queryNode } = this.#props
+    return new InsertQueryBuilder({
+      ...this.#props,
+      queryNode: InsertQueryNode.cloneWithInto(
+        queryNode,
+        AliasNode.create(queryNode.into!, IdentifierNode.create(alias)),
+      ),
+    })
   }
 
   /**

--- a/test/node/src/insert.test.ts
+++ b/test/node/src/insert.test.ts
@@ -677,6 +677,31 @@ for (const dialect of DIALECTS) {
       })
     }
 
+    it('should alias the inserted table using `as`', async () => {
+      const query = ctx.db
+        .insertInto('pet')
+        .as('p')
+        .values({
+          name: 'Hammy',
+          owner_id: 1,
+          species: 'hamster',
+        })
+        .onConflict((oc) => oc.column('name').doNothing())
+
+      testSql(query, dialect, {
+        postgres: {
+          sql: 'insert into "pet" as "p" ("name", "owner_id", "species") values ($1, $2, $3) on conflict ("name") do nothing',
+          parameters: ['Hammy', 1, 'hamster'],
+        },
+        mysql: NOT_SUPPORTED,
+        mssql: NOT_SUPPORTED,
+        sqlite: {
+          sql: 'insert into "pet" as "p" ("name", "owner_id", "species") values (?, ?, ?) on conflict ("name") do nothing',
+          parameters: ['Hammy', 1, 'hamster'],
+        },
+      })
+    })
+
     it('should insert multiple rows', async () => {
       const query = ctx.db.insertInto('person').values([
         {


### PR DESCRIPTION
Closes #731

## What

Adds an `.as(alias)` method to `InsertQueryBuilder` that lets you alias the inserted table, enabling `INSERT INTO table_name AS alias` syntax.

## Why

PostgreSQL (and SQLite) support aliasing the insert target table, which is mainly useful when you need to reference the inserted row by alias in an `ON CONFLICT DO UPDATE` expression:

```sql
insert into "person" as "p" ("first_name", "last_name", "age")
values ($1, $2, $3)
on conflict ("first_name") do update set "age" = "p"."age"
```

Without this, referencing `p.age` in the `doUpdateSet` expression is impossible.

## How

- `InsertQueryNode.into` now accepts `TableNode | AliasNode`
- Added `InsertQueryNode.cloneWithInto()` factory method to update the `into` field (which is excluded from `cloneWith` by design)
- Added `InsertQueryBuilder.as(alias: string)` method that wraps the current `into` node in an `AliasNode`
- No compiler changes needed — `visitAlias` already handles `{node} as {alias}` output correctly, and `with-schema-transformer` already handles `AliasNode` in table expression position

## Support matrix

- PostgreSQL: supported
- SQLite: supported
- MySQL / MSSQL: `NOT_SUPPORTED` (these dialects don't support INSERT ... AS alias syntax)