### PR TITLE
feat(postgres): support postgres 18 old and new returning syntax

### DIFF
--- a/src/parser/select-parser.ts
+++ b/src/parser/select-parser.ts
@@ -26,7 +26,19 @@ import {
   type ExpressionBuilder,
 } from '../expression/expression-builder.js'
 
+type Postgres18Column<DB, TB extends keyof DB> = Extract<keyof DB[TB], string>
+
+type AnyPostgres18Column<DB, TB extends keyof DB> =
+  | `old.${Postgres18Column<DB, TB>}`
+  | `new.${Postgres18Column<DB, TB>}`
+
+type AnyAliasedPostgres18Column<DB, TB extends keyof DB> =
+  | `old.${Postgres18Column<DB, TB>} as ${string}`
+  | `new.${Postgres18Column<DB, TB>} as ${string}`
+
 export type SelectExpression<DB, TB extends keyof DB> =
+  | AnyPostgres18Column<DB, TB>
+  | AnyAliasedPostgres18Column<DB, TB>
   | AnyAliasedColumnWithTable<DB, TB>
   | AnyAliasedColumn<DB, TB>
   | AnyColumnWithTable<DB, TB>
@@ -89,17 +101,25 @@ type ExtractAliasFromSelectExpression<SE> = SE extends string
         : never
 
 type ExtractAliasFromStringSelectExpression<SE extends string> =
-  SE extends `${string}.${string}.${string} as ${infer A}`
+  SE extends `old.${string} as ${infer A}`
     ? A
-    : SE extends `${string}.${string} as ${infer A}`
+    : SE extends `new.${string} as ${infer A}`
       ? A
-      : SE extends `${string} as ${infer A}`
-        ? A
-        : SE extends `${string}.${string}.${infer C}`
-          ? C
-          : SE extends `${string}.${infer C}`
-            ? C
-            : SE
+      : SE extends `old.${infer C}`
+        ? `old.${C}`
+        : SE extends `new.${infer C}`
+          ? `new.${C}`
+          : SE extends `${string}.${string}.${string} as ${infer A}`
+            ? A
+            : SE extends `${string}.${string} as ${infer A}`
+              ? A
+              : SE extends `${string} as ${infer A}`
+                ? A
+                : SE extends `${string}.${string}.${infer C}`
+                  ? C
+                  : SE extends `${string}.${infer C}`
+                    ? C
+                    : SE
 
 type ExtractTypeFromSelectExpression<
   DB,
@@ -123,37 +143,53 @@ type ExtractTypeFromStringSelectExpression<
   DB,
   TB extends keyof DB,
   SE extends string,
-> = SE extends `${infer SC}.${infer T}.${infer C} as ${string}`
-  ? `${SC}.${T}` extends TB
-    ? C extends keyof DB[`${SC}.${T}`]
-      ? DB[`${SC}.${T}`][C]
-      : never
+> = SE extends `old.${infer C} as ${string}`
+  ? C extends AnyColumn<DB, TB>
+    ? ExtractColumnType<DB, TB, C>
     : never
-  : SE extends `${infer T}.${infer C} as ${string}`
-    ? T extends TB
-      ? C extends keyof DB[T]
-        ? DB[T][C]
-        : never
+  : SE extends `new.${infer C} as ${string}`
+    ? C extends AnyColumn<DB, TB>
+      ? ExtractColumnType<DB, TB, C>
       : never
-    : SE extends `${infer C} as ${string}`
+    : SE extends `old.${infer C}`
       ? C extends AnyColumn<DB, TB>
         ? ExtractColumnType<DB, TB, C>
         : never
-      : SE extends `${infer SC}.${infer T}.${infer C}`
-        ? `${SC}.${T}` extends TB
-          ? C extends keyof DB[`${SC}.${T}`]
-            ? DB[`${SC}.${T}`][C]
-            : never
+      : SE extends `new.${infer C}`
+        ? C extends AnyColumn<DB, TB>
+          ? ExtractColumnType<DB, TB, C>
           : never
-        : SE extends `${infer T}.${infer C}`
-          ? T extends TB
-            ? C extends keyof DB[T]
-              ? DB[T][C]
+        : SE extends `${infer SC}.${infer T}.${infer C} as ${string}`
+          ? `${SC}.${T}` extends TB
+            ? C extends keyof DB[`${SC}.${T}`]
+              ? DB[`${SC}.${T}`][C]
               : never
             : never
-          : SE extends AnyColumn<DB, TB>
-            ? ExtractColumnType<DB, TB, SE>
-            : never
+          : SE extends `${infer T}.${infer C} as ${string}`
+            ? T extends TB
+              ? C extends keyof DB[T]
+                ? DB[T][C]
+                : never
+              : never
+            : SE extends `${infer C} as ${string}`
+              ? C extends AnyColumn<DB, TB>
+                ? ExtractColumnType<DB, TB, C>
+                : never
+              : SE extends `${infer SC}.${infer T}.${infer C}`
+                ? `${SC}.${T}` extends TB
+                  ? C extends keyof DB[`${SC}.${T}`]
+                    ? DB[`${SC}.${T}`][C]
+                    : never
+                  : never
+                : SE extends `${infer T}.${infer C}`
+                  ? T extends TB
+                    ? C extends keyof DB[T]
+                      ? DB[T][C]
+                      : never
+                    : never
+                  : SE extends AnyColumn<DB, TB>
+                    ? ExtractColumnType<DB, TB, SE>
+                    : never
 
 export type AllSelection<DB, TB extends keyof DB> = DrainOuterGeneric<{
   [C in AnyColumn<DB, TB>]: {

--- a/test/node/src/update.test.ts
+++ b/test/node/src/update.test.ts
@@ -226,7 +226,7 @@ for (const dialect of DIALECTS) {
     }
 
     if (sqlSpec === 'postgres') {
-      it.only('should support postgres 18 old and new returning syntax', async () => {
+      it('should support postgres 18 old and new returning syntax', async () => {
         const query = ctx.db
           .updateTable('person')
           .set({ first_name: 'Mark' })

--- a/test/node/src/update.test.ts
+++ b/test/node/src/update.test.ts
@@ -1,4 +1,4 @@
-import { UpdateResult, sql } from '../../../dist/index.js'
+import { UpdateQueryBuilder, UpdateResult, sql } from '../../../dist/index.js'
 
 import {
   clearDatabase,
@@ -225,6 +225,44 @@ for (const dialect of DIALECTS) {
       })
     }
 
+    if (sqlSpec === 'postgres') {
+      it.only('should support postgres 18 old and new returning syntax', async () => {
+        const query = ctx.db
+          .updateTable('person')
+          .set({ first_name: 'Mark' })
+          .where('first_name', '=', 'Jennifer')
+          .returning([
+            'old.first_name as old_name',
+            'new.first_name as new_name',
+          ])
+
+        testSql(query, dialect, {
+          postgres: {
+            sql: 'update "person" set "first_name" = $1 where "first_name" = $2 returning "old"."first_name" as "old_name", "new"."first_name" as "new_name"',
+            parameters: ['Mark', 'Jennifer'],
+          },
+          mysql: NOT_SUPPORTED,
+          mssql: NOT_SUPPORTED,
+          sqlite: NOT_SUPPORTED,
+        })
+
+        type Postgres18ResultRow =
+          typeof query extends UpdateQueryBuilder<any, any, any, infer O>
+            ? O
+            : never
+
+        const simulatedResult: Postgres18ResultRow = {
+          old_name: 'Jennifer',
+          new_name: 'Mark',
+        }
+
+        expect(simulatedResult).to.containSubset({
+          old_name: 'Jennifer',
+          new_name: 'Mark',
+        })
+      })
+    }
+
     it('should update one row using a subquery', async () => {
       const query = ctx.db
         .updateTable('person')
@@ -255,7 +293,7 @@ for (const dialect of DIALECTS) {
         },
       })
 
-      const result = await query.executeTakeFirst()
+      const result = await query.executeTakeFirstOrThrow()
 
       expect(result).to.be.instanceOf(UpdateResult)
       expect(result.numUpdatedRows).to.equal(1n)


### PR DESCRIPTION
Closes #1803

### Description
This PR implements TypeScript and SQL compilation support for PostgreSQL 18 `RETURNING` clauses using the new `old.` and `new.` pseudotables.

### Implementation Details
- Added `AnyPostgres18Column` and `AnyAliasedPostgres18Column` template literal types to `SelectExpression` in `src/parser/select-parser.ts`.
- Placed these new types at the **very top** of the union hierarchy. In PostgreSQL 18, using a bare `RETURNING old.column` will always shadow any literal table named `old` in favor of the built-in transition relation. Our TypeScript implementation mirrors this native database prioritization by evaluating the PG18 types first.
- Updated `ExtractAliasFromStringSelectExpression` and `ExtractTypeFromStringSelectExpression` to bypass dialect table validation (`TB extends keyof DB`) for these specific keywords, correctly mapping property keys and inferring original data types.
- Added a targeted test suite in `test/node/src/update.test.ts`.

### Backward Compatibility & Dialect Execution Note
- I strictly used `testSql` and a static `simulatedResult` assert to test the compilation and type safety. We cannot perform a runtime `query.executeTakeFirst()` yet, because the local `pglite` test engine and older PostgreSQL instances used in the current CI setup will throw a syntax error (`missing FROM-clause entry for table "old"`), as they don't natively support PG18 features yet. 
- If a user runs a PostgreSQL version older than 18 and happens to own a literal table named `old` or `new`, this implementation will prioritize the Postgres 18 pseudotable types. At runtime on older database instances, this will result in a syntax error, unless the user explicitly joins that table. This matches Kysely's version-agnostic nature, but it's worth noting for legacy schemas.