### PR TITLE
Note that MSSQL uses .output() for returning data

### DIFF
--- a/site/docs/examples/insert/0030-returning-data.mdx
+++ b/site/docs/examples/insert/0030-returning-data.mdx
@@ -9,6 +9,9 @@ the inserted row's columns (or any other expression) as the return value. `retur
 works just like `select`. Refer to `select` method's examples and documentation for
 more info.
 
+MS SQL Server (MSSQL) does not support `returning`. Use the `output` method
+instead, e.g. `.output(['inserted.id', 'inserted.first_name as name'])`.
+
 import { Playground } from '../../../src/components/Playground'
 
 import {

--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -170,6 +170,9 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, out O>
    * works just like `select`. Refer to `select` method's examples and documentation for
    * more info.
    *
+   * MS SQL Server (MSSQL) does not support `returning`. Use the `output` method
+   * instead, e.g. `.output(['inserted.id', 'inserted.first_name as name'])`.
+   *
    * ```ts
    * const result = await db
    *   .insertInto('person')


### PR DESCRIPTION
The returning-data example could send MSSQL users toward `.returning()`, but MSSQL uses `.output()` for that case.
I added the note in the source JSDoc and regenerated the docs from it.
Checked it with the build, generated examples, and the JSDoc check.
Closes #1466