### PR TITLE
docs(#1892): add marshift/kysely-deno-sqlite3 to community dialects

### DIFF
--- a/site/docs/dialects.md
+++ b/site/docs/dialects.md
@@ -36,6 +36,7 @@ A dialect is the glue between Kysely and the underlying database engine. Check t
 | Fetch driver                  | https://github.com/andersgee/kysely-fetch-driver                            |
 | SQLite WASM                   | https://github.com/DallasHoff/sqlocal                                       |
 | Deno SQLite                   | https://gitlab.com/soapbox-pub/kysely-deno-sqlite                           |
+| Deno SQLite3                  | https://github.com/marshift/kysely-deno-sqlite3                             |
 | Node SQLite                   | https://github.com/wolfie/kysely-node-native-sqlite                         |
 | TiDB Cloud Serverless Driver  | https://github.com/tidbcloud/kysely                                         |
 | Capacitor SQLite Kysely       | https://github.com/DawidWetzler/capacitor-sqlite-kysely                     |


### PR DESCRIPTION
Closes #1892

## Summary

Adds [marshift/kysely-deno-sqlite3](https://github.com/marshift/kysely-deno-sqlite3) to the community dialects table in the docs.

The existing Deno SQLite entry (`soapbox-pub/kysely-deno-sqlite`) hasn't been maintained for 2 years and doesn't work with newer versions of Kysely. This new entry provides the currently-maintained alternative for Deno users.