### PR TITLE
fix(types): allow non-updateable columns in ON CONFLICT DO UPDATE WHERE

### DIFF
--- a/src/query-builder/insert-query-builder.ts
+++ b/src/query-builder/insert-query-builder.ts
@@ -47,6 +47,7 @@ import {
   type OnConflictDoNothingBuilder,
   type OnConflictTables,
   type OnConflictUpdateBuilder,
+  type OnConflictUpdateWhereDatabase,
 } from './on-conflict-builder.js'
 import { OnConflictNode } from '../operation-node/on-conflict-node.js'
 import type { Selectable } from '../util/column-type.js'
@@ -886,7 +887,8 @@ export class InsertQueryBuilder<DB, TB extends keyof DB, out O>
     ) =>
       | OnConflictUpdateBuilder<
           OnConflictDatabase<DB, TB>,
-          OnConflictTables<TB>
+          OnConflictTables<TB>,
+          OnConflictUpdateWhereDatabase<DB, TB>
         >
       | OnConflictDoNothingBuilder<DB, TB>,
   ): InsertQueryBuilder<DB, TB, O> {

--- a/src/query-builder/on-conflict-builder.ts
+++ b/src/query-builder/on-conflict-builder.ts
@@ -15,7 +15,7 @@ import {
   type UpdateObjectExpression,
   parseUpdateObjectExpression,
 } from '../parser/update-set-parser.js'
-import type { Updateable } from '../util/column-type.js'
+import type { Selectable, Updateable } from '../util/column-type.js'
 import { freeze } from '../util/object-utils.js'
 import type { AnyColumn, SqlBool } from '../util/type-utils.js'
 import type { WhereInterface } from './where-interface.js'
@@ -254,7 +254,11 @@ export class OnConflictBuilder<
       OnConflictTables<TB>,
       OnConflictTables<TB>
     >,
-  ): OnConflictUpdateBuilder<OnConflictDatabase<DB, TB>, OnConflictTables<TB>> {
+  ): OnConflictUpdateBuilder<
+    OnConflictDatabase<DB, TB>,
+    OnConflictTables<TB>,
+    OnConflictUpdateWhereDatabase<DB, TB>
+  > {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWith(this.#props.onConflictNode, {
@@ -280,6 +284,10 @@ export type OnConflictDatabase<DB, TB extends keyof DB> = {
   [K in keyof DB | 'excluded']: Updateable<K extends keyof DB ? DB[K] : DB[TB]>
 }
 
+export type OnConflictUpdateWhereDatabase<DB, TB extends keyof DB> = {
+  [K in keyof DB | 'excluded']: Selectable<K extends keyof DB ? DB[K] : DB[TB]>
+}
+
 export type OnConflictTables<TB> = TB | 'excluded'
 
 export class OnConflictDoNothingBuilder<
@@ -297,9 +305,11 @@ export class OnConflictDoNothingBuilder<
   }
 }
 
-export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
-  implements WhereInterface<DB, TB>, OperationNodeSource
-{
+export class OnConflictUpdateBuilder<
+  DB,
+  TB extends keyof DB,
+  WHEREB = DB,
+> implements OperationNodeSource {
   readonly #props: OnConflictBuilderProps
 
   constructor(props: OnConflictBuilderProps) {
@@ -312,19 +322,19 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
    * See {@link WhereInterface.where} for more info.
    */
   where<
-    RE extends ReferenceExpression<DB, TB>,
-    VE extends OperandValueExpressionOrList<DB, TB, RE>,
+    RE extends ReferenceExpression<WHEREB, TB & keyof WHEREB>,
+    VE extends OperandValueExpressionOrList<WHEREB, TB & keyof WHEREB, RE>,
   >(
     lhs: RE,
     op: ComparisonOperatorExpression,
     rhs: VE,
-  ): OnConflictUpdateBuilder<DB, TB>
+  ): OnConflictUpdateBuilder<DB, TB, WHEREB>
 
-  where<E extends ExpressionOrFactory<DB, TB, SqlBool>>(
+  where<E extends ExpressionOrFactory<WHEREB, TB & keyof WHEREB, SqlBool>>(
     expression: E,
-  ): OnConflictUpdateBuilder<DB, TB>
+  ): OnConflictUpdateBuilder<DB, TB, WHEREB>
 
-  where(...args: any[]): OnConflictUpdateBuilder<DB, TB> {
+  where(...args: any[]): OnConflictUpdateBuilder<DB, TB, WHEREB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithUpdateWhere(
@@ -340,13 +350,13 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
    * See {@link WhereInterface.whereRef} for more info.
    */
   whereRef<
-    LRE extends ReferenceExpression<DB, TB>,
-    RRE extends ReferenceExpression<DB, TB>,
+    LRE extends ReferenceExpression<WHEREB, TB & keyof WHEREB>,
+    RRE extends ReferenceExpression<WHEREB, TB & keyof WHEREB>,
   >(
     lhs: LRE,
     op: ComparisonOperatorExpression,
     rhs: RRE,
-  ): OnConflictUpdateBuilder<DB, TB> {
+  ): OnConflictUpdateBuilder<DB, TB, WHEREB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithUpdateWhere(
@@ -356,7 +366,7 @@ export class OnConflictUpdateBuilder<DB, TB extends keyof DB>
     })
   }
 
-  clearWhere(): OnConflictUpdateBuilder<DB, TB> {
+  clearWhere(): OnConflictUpdateBuilder<DB, TB, WHEREB> {
     return new OnConflictUpdateBuilder({
       ...this.#props,
       onConflictNode: OnConflictNode.cloneWithoutUpdateWhere(

--- a/test/typings/test-d/insert.test-d.ts
+++ b/test/typings/test-d/insert.test-d.ts
@@ -98,6 +98,38 @@ async function testInsert(db: Kysely<Database>) {
   // Explicitly excluded column
   expectError(db.insertInto('person').values({ modified_at: new Date() }))
 
+  // ON CONFLICT DO UPDATE WHERE should allow referencing columns whose UpdateType
+  // is `never` (read-only columns) because the WHERE clause filters rows to
+  // update, it does not update those columns. See #1189.
+  const r7 = await db
+    .insertInto('person')
+    .values(person)
+    .onConflict((oc) =>
+      oc.column('id').doUpdateSet({ first_name: 'Jennifer' }).where(
+        // `modified_at` has ColumnType<Date, never, never> — UpdateType is never,
+        // but referencing it in WHERE should be allowed (SelectType is Date).
+        'person.modified_at',
+        '<',
+        new Date(),
+      ),
+    )
+    .executeTakeFirst()
+
+  expectType<InsertResult>(r7)
+
+  // ON CONFLICT DO UPDATE WHERE should still reject non-existent columns.
+  expectError(
+    db
+      .insertInto('person')
+      .values(person)
+      .onConflict((oc) =>
+        oc
+          .column('id')
+          .doUpdateSet({ first_name: 'Jennifer' })
+          .where('person.doesnt_exist', '=', 1),
+      ),
+  )
+
   // Non-existent column in a `doUpdateSet` call.
   expectError(
     db


### PR DESCRIPTION
Closes #1189

## Root cause

`OnConflictUpdateBuilder<DB, TB>` received `DB` as
`OnConflictDatabase<…>` which maps every table through `Updateable<>`.
`Updateable` strips columns whose `UpdateType` is `never` (e.g.
`ColumnType<Date, never, never>` — read-only columns).

Because the `where()` / `whereRef()` overloads use
`ReferenceExpression<DB, TB>`, those stripped columns were not
recognised as valid references, producing the error reported in the
issue:

```
Argument of type '"person.employerId"' is not assignable to parameter of type
  'ReferenceExpression<OnConflictDatabase<…>, OnConflictTables<…>>'
```

This is incorrect: the `WHERE` clause after `DO UPDATE SET` is a filter
predicate that *reads* column values to decide which conflicting rows to
update. It must be allowed to reference any *selectable* column, regardless
of whether that column can be updated. The `doUpdateSet()` SET expression
is unaffected — it still operates on `Updateable` columns only, which is
correct.

## Fix

1. Added `OnConflictUpdateWhereDatabase<DB, TB>` — mirrors
   `OnConflictDatabase` but maps each table through `Selectable<>` instead
   of `Updateable<>`, preserving all selectable columns.

2. Added an optional third type parameter `WHEREB = DB` to
   `OnConflictUpdateBuilder` (default keeps backward compatibility).
   The `where()`, `whereRef()`, and `clearWhere()` methods now use
   `WHEREB` for reference expressions instead of `DB`.

3. `doUpdateSet()` now threads `OnConflictUpdateWhereDatabase<DB, TB>` as
   `WHEREB` so the WHERE chain sees the full set of selectable columns.

## Type-test verification

A new test in `test/typings/test-d/insert.test-d.ts` covers:

- **Positive**: referencing `person.modified_at` (`ColumnType<Date, never, never>` —
  `UpdateType = never`) in a WHERE clause is now accepted.
- **Negative**: referencing a non-existent column is still rejected (no
  regression on valid error detection).

Confirmed with `tsd`:
- Without the fix → 1 type error (the exact error from the issue)
- With the fix    → 0 errors, full type-test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)