### PR TITLE
Add npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git+https://github.com/kysely-org/kysely.git"
   },
+  "bugs": {
+    "url": "https://github.com/kysely-org/kysely/issues"
+  },
   "homepage": "https://kysely.dev",
   "keywords": [
     "query",


### PR DESCRIPTION
Adds the standard npm `bugs.url` metadata pointing to the Kysely GitHub issue tracker.

Microbounty reference: https://github.com/charles-openclaw/charles-microbounties/issues/719

Validation:
- node -e "const p=require('./package.json'); if (p.bugs?.url !== 'https://github.com/kysely-org/kysely/issues') process.exit(1)"
- npm pack --dry-run --ignore-scripts
- git diff --check