### PR TITLE
fix(dialect): parse and normalize stringified JSON default column bounds during introspection

### DIFF
--- a/src/dialect/database-introspector.ts
+++ b/src/dialect/database-introspector.ts
@@ -54,5 +54,6 @@ export interface ColumnMetadata {
   readonly isAutoIncrementing: boolean
   readonly isNullable: boolean
   readonly hasDefaultValue: boolean
+  readonly defaultValue?: string
   readonly comment?: string
 }

--- a/src/dialect/mysql/mysql-introspector.ts
+++ b/src/dialect/mysql/mysql-introspector.ts
@@ -83,6 +83,12 @@ export class MysqlIntrospector implements DatabaseIntrospector {
         tables.push(table)
       }
 
+      let defaultValue: string | undefined = it.COLUMN_DEFAULT ?? undefined
+      if (defaultValue && /^'(\[.*\]|\{.*\})'$/.test(defaultValue)) {
+        const match = defaultValue.match(/^'(\[.*\]|\{.*\})'$/)
+        if (match) defaultValue = match[1]
+      }
+
       table.columns.push(
         freeze({
           name: it.COLUMN_NAME,
@@ -90,6 +96,7 @@ export class MysqlIntrospector implements DatabaseIntrospector {
           isNullable: it.IS_NULLABLE === 'YES',
           isAutoIncrementing: it.EXTRA.toLowerCase().includes('auto_increment'),
           hasDefaultValue: it.COLUMN_DEFAULT !== null,
+          defaultValue,
           comment: it.COLUMN_COMMENT === '' ? undefined : it.COLUMN_COMMENT,
         }),
       )

--- a/src/dialect/postgres/postgres-introspector.ts
+++ b/src/dialect/postgres/postgres-introspector.ts
@@ -47,6 +47,9 @@ export class PostgresIntrospector implements DatabaseIntrospector {
         'typ.typnamespace',
         'dtns.oid',
       )
+      .leftJoin('pg_catalog.pg_attrdef as d', (join) =>
+        join.onRef('d.adrelid', '=', 'c.oid').onRef('d.adnum', '=', 'a.attnum'),
+      )
       .select([
         'a.attname as column',
         'a.attnotnull as not_null',
@@ -58,6 +61,9 @@ export class PostgresIntrospector implements DatabaseIntrospector {
         'dtns.nspname as type_schema',
         sql<string | null>`col_description(a.attrelid, a.attnum)`.as(
           'column_description',
+        ),
+        sql<string | null>`pg_get_expr(d.adbin, d.adrelid)`.as(
+          'column_default',
         ),
         sql<
           string | null
@@ -122,12 +128,19 @@ export class PostgresIntrospector implements DatabaseIntrospector {
         tables.push(table)
       }
 
+      let defaultValue: string | undefined = column.column_default ?? undefined
+      if (defaultValue && /^'(\[.*\]|\{.*\})'::jsonb?$/.test(defaultValue)) {
+        const match = defaultValue.match(/^'(\[.*\]|\{.*\})'::jsonb?$/)
+        if (match) defaultValue = match[1]
+      }
+
       table.columns.push(
         freeze({
           comment: column.column_description ?? undefined,
           dataType: column.type,
           dataTypeSchema: column.type_schema,
           hasDefaultValue: column.has_default,
+          defaultValue,
           isAutoIncrementing: column.auto_incrementing !== null,
           isNullable: !column.not_null,
           name: column.column,
@@ -154,4 +167,5 @@ interface RawColumnMetadata {
   type_schema: string
   auto_incrementing: string | null
   column_description: string | null
+  column_default: string | null
 }


### PR DESCRIPTION
### Description
This PR enhances the database schema introspection engine for both PostgreSQL and MySQL dialects to correctly capture and normalize raw default column expression constraints. By introducing structured regex string filters during metadata mapping, we prevent stringified JSON objects and arrays (such as `[]` or `{}`) from being double-escaped or corrupted by engine-specific type-casting suffixes.

### Technical Context
Previously, Kysely's introspection drivers evaluated default layout constraints purely down to a binary `hasDefaultValue` flag. When extending the engine to extract literal default strings, database-specific stringifications introduced immediate syntax parsing hazards:
* **PostgreSQL:** Appends explicit data-type casting suffixes alongside string encapsulation literals (e.g., `'[]'::jsonb`).
* **MySQL:** Wraps structural brackets in redundant outer string literals (e.g., `'[]'`).

Passing these raw metadata values un-sanitized down to downstream migration or schema generation utilities results in malformed SQL outputs due to nested character escaping blocks.

### Resolution Strategy
* **Schema Query Expansion:** Updated the PostgreSQL introspection queries to cleanly select raw default structures via `pg_get_expr()` by joining against `pg_attrdef`.
* **Structural Regex Trapping:** Embedded targeted validation trimmers inside the respective dialect mapping loops (`postgres-introspector.ts` and `mysql-introspector.ts`) to cleanly isolate the inner structural contents (`[]` or `{}`) from outer quotes and type casts.
* **Core Types Extension:** Extended the global `ColumnMetadata` interface in `database-introspector.ts` to cleanly support the new `readonly defaultValue?: string` schema attribute without any type regressions.