### PR TITLE
fix: PostgreSQL and MSSQL migrations are not running exclusively when `disableTransactions: true`.

### DIFF
--- a/src/dialect/dialect-adapter.ts
+++ b/src/dialect/dialect-adapter.ts
@@ -103,10 +103,12 @@ export interface DialectAdapter {
    * }
    * ```
    *
-   * If `supportsTransactionalDdl` is `true` then the `db` passed to this method
-   * is a transaction inside which the migrations will be executed. Otherwise
-   * `db` is a single connection (session) that will be used to execute the
-   * migrations.
+   * If `supportsTransactionalDdl` is `true` and Kysely starts the migration
+   * transaction, the `db` passed to this method is the transaction inside which
+   * the migrations will be executed. The matching `releaseMigrationLock` call
+   * receives the same connection (session) after the transaction has settled.
+   * Otherwise `db` is a single connection (session) that will be used to
+   * execute the migrations.
    */
   acquireMigrationLock(
     db: Kysely<any>,
@@ -116,10 +118,11 @@ export interface DialectAdapter {
   /**
    * Releases the migration lock. See {@link acquireMigrationLock}.
    *
-   * If `supportsTransactionalDdl` is `true` then the `db` passed to this method
-   * is a transaction inside which the migrations were executed. Otherwise `db`
-   * is a single connection (session) that was used to execute the migrations
-   * and the `acquireMigrationLock` call.
+   * If `supportsTransactionalDdl` is `true` and Kysely starts the migration
+   * transaction, the `db` passed to this method is the same connection (session)
+   * after the transaction has settled. Otherwise `db` is the transaction or
+   * single connection that was used to execute the migrations and the
+   * `acquireMigrationLock` call.
    */
   releaseMigrationLock(
     db: Kysely<any>,

--- a/src/dialect/dialect-adapter.ts
+++ b/src/dialect/dialect-adapter.ts
@@ -103,12 +103,10 @@ export interface DialectAdapter {
    * }
    * ```
    *
-   * If `supportsTransactionalDdl` is `true` and Kysely starts the migration
-   * transaction, the `db` passed to this method is the transaction inside which
-   * the migrations will be executed. The matching `releaseMigrationLock` call
-   * receives the same connection (session) after the transaction has settled.
-   * Otherwise `db` is a single connection (session) that will be used to
-   * execute the migrations.
+   * If `supportsTransactionalDdl` is `true` then the `db` passed to this method
+   * is a transaction inside which the migrations will be executed. Otherwise
+   * `db` is a single connection (session) that will be used to execute the
+   * migrations.
    */
   acquireMigrationLock(
     db: Kysely<any>,
@@ -118,11 +116,10 @@ export interface DialectAdapter {
   /**
    * Releases the migration lock. See {@link acquireMigrationLock}.
    *
-   * If `supportsTransactionalDdl` is `true` and Kysely starts the migration
-   * transaction, the `db` passed to this method is the same connection (session)
-   * after the transaction has settled. Otherwise `db` is the transaction or
-   * single connection that was used to execute the migrations and the
-   * `acquireMigrationLock` call.
+   * If `supportsTransactionalDdl` is `true` then the `db` passed to this method
+   * is a transaction inside which the migrations were executed. Otherwise `db`
+   * is a single connection (session) that was used to execute the migrations
+   * and the `acquireMigrationLock` call.
    */
   releaseMigrationLock(
     db: Kysely<any>,

--- a/src/dialect/mssql/mssql-adapter.ts
+++ b/src/dialect/mssql/mssql-adapter.ts
@@ -2,6 +2,9 @@ import type { Kysely } from '../../kysely.js'
 import { DEFAULT_MIGRATION_TABLE } from '../../migration/migrator.js'
 import { sql } from '../../raw-builder/sql.js'
 import { DialectAdapterBase } from '../dialect-adapter-base.js'
+import type { MigrationLockOptions } from '../dialect-adapter.js'
+
+const LOCK_PRINCIPAL = 'dbo'
 
 export class MssqlAdapter extends DialectAdapterBase {
   override get supportsCreateIfNotExists(): boolean {
@@ -16,19 +19,36 @@ export class MssqlAdapter extends DialectAdapterBase {
     return true
   }
 
-  override async acquireMigrationLock(db: Kysely<any>): Promise<void> {
-    // Acquire a transaction-level exclusive lock on the migrations table.
+  override async acquireMigrationLock(
+    db: Kysely<any>,
+    _opt: MigrationLockOptions,
+  ): Promise<void> {
+    // Acquire a session-level exclusive lock on the migrations table. A
+    // session-level lock (as opposed to the default transaction-level lock)
+    // stays held after the migration transaction commits and until we release
+    // it explicitly in `releaseMigrationLock` OR the session ends. This way we
+    // know the lock is either released by us after successful or failed
+    // migrations OR it's released by SQL Server if the connection dies.
     // https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-ver16
     await sql`exec sp_getapplock @DbPrincipal = ${sql.lit(
-      'dbo',
-    )}, @Resource = ${sql.lit(DEFAULT_MIGRATION_TABLE)}, @LockMode = ${sql.lit(
-      'Exclusive',
+      LOCK_PRINCIPAL,
+    )}, @Resource = ${sql.lit(
+      DEFAULT_MIGRATION_TABLE,
+    )}, @LockMode = ${sql.lit('Exclusive')}, @LockOwner = ${sql.lit(
+      'Session',
     )}`.execute(db)
   }
 
-  override async releaseMigrationLock(): Promise<void> {
-    // Nothing to do here. `sp_getapplock` is automatically released at the
-    // end of the transaction and since `supportsTransactionalDdl` true, we know
-    // the `db` instance passed to acquireMigrationLock is actually a transaction.
+  override async releaseMigrationLock(
+    db: Kysely<any>,
+    _opt: MigrationLockOptions,
+  ): Promise<void> {
+    // Release the session-level lock acquired in `acquireMigrationLock`.
+    // https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-releaseapplock-transact-sql?view=sql-server-ver16
+    await sql`exec sp_releaseapplock @DbPrincipal = ${sql.lit(
+      LOCK_PRINCIPAL,
+    )}, @Resource = ${sql.lit(DEFAULT_MIGRATION_TABLE)}, @LockOwner = ${sql.lit(
+      'Session',
+    )}`.execute(db)
   }
 }

--- a/src/dialect/postgres/postgres-adapter.ts
+++ b/src/dialect/postgres/postgres-adapter.ts
@@ -3,8 +3,8 @@ import { sql } from '../../raw-builder/sql.js'
 import { DialectAdapterBase } from '../dialect-adapter-base.js'
 import type { MigrationLockOptions } from '../dialect-adapter.js'
 
-// Random id for our migration lock.
 const LOCK_ID = BigInt('3853314791062309107')
+const LOCK_TIMEOUT_MILLISECONDS = 60 * 60 * 1_000
 
 export class PostgresAdapter extends DialectAdapterBase {
   override get supportsTransactionalDdl(): boolean {
@@ -19,9 +19,16 @@ export class PostgresAdapter extends DialectAdapterBase {
     db: Kysely<any>,
     _opt: MigrationLockOptions,
   ): Promise<void> {
-    // Non-transactional migrations are autocommitted statement by statement,
-    // so use a session-level lock held until releaseMigrationLock.
-    await sql`select pg_advisory_lock(${sql.lit(LOCK_ID)})`.execute(db)
+    // in 1 RTT, acquire a session-level advisory lock with a timeout.
+    //
+    // if ever this runs inside a transaction, niche edge case we support - the
+    // user is responsible to set a different timeout value or disable (`0` value).
+    await sql`
+    with set_timeout as (
+      select set_config('lock_timeout', '${sql.lit(LOCK_TIMEOUT_MILLISECONDS)}', true) as config_val
+    )
+    select pg_advisory_lock(${sql.lit(LOCK_ID)})
+    from set_timeout`.execute(db)
   }
 
   override async releaseMigrationLock(

--- a/src/dialect/postgres/postgres-adapter.ts
+++ b/src/dialect/postgres/postgres-adapter.ts
@@ -3,8 +3,12 @@ import { sql } from '../../raw-builder/sql.js'
 import { DialectAdapterBase } from '../dialect-adapter-base.js'
 import type { MigrationLockOptions } from '../dialect-adapter.js'
 
-// Random id for our transaction lock.
+// Random id for our migration lock.
 const LOCK_ID = BigInt('3853314791062309107')
+// Mirrors the MySQL adapter's `get_lock` timeout so a migrator doesn't wait
+// forever for a competing migrator to release the lock.
+const LOCK_TIMEOUT_SECONDS = 60 * 60
+const LOCK_POLL_INTERVAL_MS = 100
 
 export class PostgresAdapter extends DialectAdapterBase {
   override get supportsTransactionalDdl(): boolean {
@@ -19,16 +23,38 @@ export class PostgresAdapter extends DialectAdapterBase {
     db: Kysely<any>,
     _opt: MigrationLockOptions,
   ): Promise<void> {
-    // Acquire a transaction level advisory lock.
-    await sql`select pg_advisory_xact_lock(${sql.lit(LOCK_ID)})`.execute(db)
+    // Kysely uses a single connection to run the migrations. Because of that,
+    // we can take a session level advisory lock and release it using
+    // `releaseMigrationLock`. We poll `pg_try_advisory_lock` instead of
+    // blocking on `pg_advisory_lock` so that a migrator doesn't wait forever for
+    // a competing migrator - it fails once the timeout is exceeded.
+    const startTime = Date.now()
+
+    while (true) {
+      const result = await sql<{
+        acquired: boolean
+      }>`select pg_try_advisory_lock(${sql.lit(LOCK_ID)}) as acquired`.execute(
+        db,
+      )
+
+      if (result.rows[0]?.acquired) {
+        return
+      }
+
+      if (Date.now() - startTime >= LOCK_TIMEOUT_SECONDS * 1000) {
+        throw new Error(
+          `Timed out after ${LOCK_TIMEOUT_SECONDS} seconds while waiting for the migration lock.`,
+        )
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_INTERVAL_MS))
+    }
   }
 
   override async releaseMigrationLock(
-    _db: Kysely<any>,
+    db: Kysely<any>,
     _opt: MigrationLockOptions,
   ): Promise<void> {
-    // Nothing to do here. `pg_advisory_xact_lock` is automatically released at the
-    // end of the transaction and since `supportsTransactionalDdl` true, we know
-    // the `db` instance passed to acquireMigrationLock is actually a transaction.
+    await sql`select pg_advisory_unlock(${sql.lit(LOCK_ID)})`.execute(db)
   }
 }

--- a/src/dialect/postgres/postgres-adapter.ts
+++ b/src/dialect/postgres/postgres-adapter.ts
@@ -5,10 +5,6 @@ import type { MigrationLockOptions } from '../dialect-adapter.js'
 
 // Random id for our migration lock.
 const LOCK_ID = BigInt('3853314791062309107')
-// Mirrors the MySQL adapter's `get_lock` timeout so a migrator doesn't wait
-// forever for a competing migrator to release the lock.
-const LOCK_TIMEOUT_SECONDS = 60 * 60
-const LOCK_POLL_INTERVAL_MS = 100
 
 export class PostgresAdapter extends DialectAdapterBase {
   override get supportsTransactionalDdl(): boolean {
@@ -23,32 +19,9 @@ export class PostgresAdapter extends DialectAdapterBase {
     db: Kysely<any>,
     _opt: MigrationLockOptions,
   ): Promise<void> {
-    // Kysely uses a single connection to run the migrations. Because of that,
-    // we can take a session level advisory lock and release it using
-    // `releaseMigrationLock`. We poll `pg_try_advisory_lock` instead of
-    // blocking on `pg_advisory_lock` so that a migrator doesn't wait forever for
-    // a competing migrator - it fails once the timeout is exceeded.
-    const startTime = Date.now()
-
-    while (true) {
-      const result = await sql<{
-        acquired: boolean
-      }>`select pg_try_advisory_lock(${sql.lit(LOCK_ID)}) as acquired`.execute(
-        db,
-      )
-
-      if (result.rows[0]?.acquired) {
-        return
-      }
-
-      if (Date.now() - startTime >= LOCK_TIMEOUT_SECONDS * 1000) {
-        throw new Error(
-          `Timed out after ${LOCK_TIMEOUT_SECONDS} seconds while waiting for the migration lock.`,
-        )
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_INTERVAL_MS))
-    }
+    // Non-transactional migrations are autocommitted statement by statement,
+    // so use a session-level lock held until releaseMigrationLock.
+    await sql`select pg_advisory_lock(${sql.lit(LOCK_ID)})`.execute(db)
   }
 
   override async releaseMigrationLock(

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -516,27 +516,33 @@ export class Migrator {
     })
 
     const run = async (db: Kysely<any>): Promise<MigrationResultSet> => {
+      const state = await this.#getState(db)
+
+      if (state.migrations.length === 0) {
+        return { results: [] }
+      }
+
+      const { direction, step } = getMigrationDirectionAndStep(state)
+
+      if (step <= 0) {
+        return { results: [] }
+      }
+
+      if (direction === 'Down') {
+        return await this.#migrateDown(db, state, step)
+      } else if (direction === 'Up') {
+        return await this.#migrateUp(db, state, step)
+      }
+
+      return { results: [] }
+    }
+
+    const runWithLock = async (
+      db: Kysely<any>,
+    ): Promise<MigrationResultSet> => {
       try {
         await adapter.acquireMigrationLock(db, lockOptions)
-        const state = await this.#getState(db)
-
-        if (state.migrations.length === 0) {
-          return { results: [] }
-        }
-
-        const { direction, step } = getMigrationDirectionAndStep(state)
-
-        if (step <= 0) {
-          return { results: [] }
-        }
-
-        if (direction === 'Down') {
-          return await this.#migrateDown(db, state, step)
-        } else if (direction === 'Up') {
-          return await this.#migrateUp(db, state, step)
-        }
-
-        return { results: [] }
+        return await run(db)
       } finally {
         await adapter.releaseMigrationLock(db, lockOptions)
       }
@@ -558,14 +564,23 @@ export class Migrator {
         )
       }
 
-      return run(this.#props.db)
+      return runWithLock(this.#props.db)
     }
 
     if (adapter.supportsTransactionalDdl && !disableTransactions) {
-      return this.#props.db.transaction().execute(run)
+      return this.#props.db.connection().execute(async (db) => {
+        try {
+          return await db.transaction().execute(async (trx) => {
+            await adapter.acquireMigrationLock(trx, lockOptions)
+            return await run(trx)
+          })
+        } finally {
+          await adapter.releaseMigrationLock(db, lockOptions)
+        }
+      })
     }
 
-    return this.#props.db.connection().execute(run)
+    return this.#props.db.connection().execute(runWithLock)
   }
 
   async #getState(db: Kysely<any>): Promise<MigrationState> {

--- a/src/migration/migrator.ts
+++ b/src/migration/migrator.ts
@@ -539,10 +539,11 @@ export class Migrator {
 
     const runWithLock = async (
       db: Kysely<any>,
+      cb: (db: Kysely<any>) => Promise<MigrationResultSet>,
     ): Promise<MigrationResultSet> => {
       try {
         await adapter.acquireMigrationLock(db, lockOptions)
-        return await run(db)
+        return await cb(db)
       } finally {
         await adapter.releaseMigrationLock(db, lockOptions)
       }
@@ -564,23 +565,18 @@ export class Migrator {
         )
       }
 
-      return runWithLock(this.#props.db)
+      return runWithLock(this.#props.db, run)
     }
 
     if (adapter.supportsTransactionalDdl && !disableTransactions) {
-      return this.#props.db.connection().execute(async (db) => {
-        try {
-          return await db.transaction().execute(async (trx) => {
-            await adapter.acquireMigrationLock(trx, lockOptions)
-            return await run(trx)
-          })
-        } finally {
-          await adapter.releaseMigrationLock(db, lockOptions)
-        }
-      })
+      return this.#props.db
+        .connection()
+        .execute((db) =>
+          runWithLock(db, (db) => db.transaction().execute((trx) => run(trx))),
+        )
     }
 
-    return this.#props.db.connection().execute(runWithLock)
+    return this.#props.db.connection().execute((db) => runWithLock(db, run))
   }
 
   async #getState(db: Kysely<any>): Promise<MigrationState> {

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -54,7 +54,7 @@ for (const dialect of DIALECTS) {
 
     describe('getMigrations', () => {
       it('should get migrations', async () => {
-        const [migrator] = createMigrations([
+        const { migrator } = createMigrations([
           'migration1',
           'migration2',
           'migration3',
@@ -84,19 +84,18 @@ for (const dialect of DIALECTS) {
 
     describe('migrateToLatest', () => {
       it('should run all unexecuted migrations', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations([
-          'migration1',
-          'migration2',
-        ])
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations(['migration1', 'migration2'])
 
         const { results: results1 } = await migrator1.migrateToLatest()
 
-        const [migrator2, executedUpMethods2] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration3',
-          'migration4',
-        ])
+        const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+          createMigrations([
+            'migration1',
+            'migration2',
+            'migration3',
+            'migration4',
+          ])
 
         const { results: results2 } = await migrator2.migrateToLatest()
 
@@ -115,18 +114,13 @@ for (const dialect of DIALECTS) {
       })
 
       it('should return an error if a new migration is added before the last executed one', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations([
-          'migration1',
-          'migration3',
-        ])
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations(['migration1', 'migration3'])
 
         await migrator1.migrateToLatest()
 
-        const [migrator2, executedUpMethods2] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration3',
-        ])
+        const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+          createMigrations(['migration1', 'migration2', 'migration3'])
 
         const { error } = await migrator2.migrateToLatest()
 
@@ -140,17 +134,18 @@ for (const dialect of DIALECTS) {
       })
 
       it('should run a new migration added before the last executed one with allowUnorderedMigrations enabled', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations(
-          ['migration1', 'migration3'],
-          { allowUnorderedMigrations: true },
-        )
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations(['migration1', 'migration3'], {
+            allowUnorderedMigrations: true,
+          })
 
         const { results: results1 } = await migrator1.migrateToLatest()
 
-        const [migrator2, executedUpMethods2] = createMigrations(
-          ['migration1', 'migration2', 'migration3', 'migration4'],
-          { allowUnorderedMigrations: true },
-        )
+        const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+          createMigrations(
+            ['migration1', 'migration2', 'migration3', 'migration4'],
+            { allowUnorderedMigrations: true },
+          )
 
         const { results: results2 } = await migrator2.migrateToLatest()
 
@@ -169,19 +164,13 @@ for (const dialect of DIALECTS) {
       })
 
       it('should return an error if a previously executed migration is missing', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration3',
-        ])
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations(['migration1', 'migration2', 'migration3'])
 
         await migrator1.migrateToLatest()
 
-        const [migrator2, executedUpMethods2] = createMigrations([
-          'migration2',
-          'migration3',
-          'migration4',
-        ])
+        const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+          createMigrations(['migration2', 'migration3', 'migration4'])
 
         const { error } = await migrator2.migrateToLatest()
 
@@ -199,17 +188,11 @@ for (const dialect of DIALECTS) {
       })
 
       it('should return an error if a the last executed migration is not found', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration3',
-        ])
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations(['migration1', 'migration2', 'migration3'])
 
-        const [migrator2, executedUpMethods2] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration4',
-        ])
+        const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+          createMigrations(['migration1', 'migration2', 'migration4'])
 
         await migrator1.migrateToLatest()
         const { error } = await migrator2.migrateToLatest()
@@ -229,17 +212,17 @@ for (const dialect of DIALECTS) {
 
       describe('with allowUnorderedMigrations', () => {
         it('should return an error if a previously executed migration is missing', async () => {
-          const [migrator1, executedUpMethods1] = createMigrations(
-            ['migration1', 'migration2', 'migration3'],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+            createMigrations(['migration1', 'migration2', 'migration3'], {
+              allowUnorderedMigrations: true,
+            })
 
           await migrator1.migrateToLatest()
 
-          const [migrator2, executedUpMethods2] = createMigrations(
-            ['migration2', 'migration3', 'migration4'],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+            createMigrations(['migration2', 'migration3', 'migration4'], {
+              allowUnorderedMigrations: true,
+            })
 
           const { error } = await migrator2.migrateToLatest()
 
@@ -257,15 +240,15 @@ for (const dialect of DIALECTS) {
         })
 
         it('should return an error if a the last executed migration is not found', async () => {
-          const [migrator1, executedUpMethods1] = createMigrations(
-            ['migration1', 'migration2', 'migration3'],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+            createMigrations(['migration1', 'migration2', 'migration3'], {
+              allowUnorderedMigrations: true,
+            })
 
-          const [migrator2, executedUpMethods2] = createMigrations(
-            ['migration1', 'migration2', 'migration4'],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+            createMigrations(['migration1', 'migration2', 'migration4'], {
+              allowUnorderedMigrations: true,
+            })
 
           await migrator1.migrateToLatest()
           const { error } = await migrator2.migrateToLatest()
@@ -285,7 +268,7 @@ for (const dialect of DIALECTS) {
       })
 
       it('should return an error if one of the migrations fails', async () => {
-        const [migrator, executedUpMethods] = createMigrations([
+        const { migrator, executedUpMethods } = createMigrations([
           'migration1',
           { name: 'migration2', error: 'whoopsydaisy' },
           'migration3',
@@ -309,7 +292,7 @@ for (const dialect of DIALECTS) {
       })
 
       it('should work correctly when run in parallel', async () => {
-        const [migrator, executedUpMethods] = createMigrations([
+        const { migrator, executedUpMethods } = createMigrations([
           'migration1',
           'migration2',
         ])
@@ -360,21 +343,23 @@ for (const dialect of DIALECTS) {
 
     describe('migrateTo', () => {
       it('should migrate up to a specific migration', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration3',
-          'migration4',
-        ])
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations([
+            'migration1',
+            'migration2',
+            'migration3',
+            'migration4',
+          ])
 
         const { results: results1 } = await migrator1.migrateTo('migration2')
 
-        const [migrator2, executedUpMethods2] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration3',
-          'migration4',
-        ])
+        const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+          createMigrations([
+            'migration1',
+            'migration2',
+            'migration3',
+            'migration4',
+          ])
 
         const { results: results2 } = await migrator2.migrateTo('migration3')
 
@@ -392,7 +377,7 @@ for (const dialect of DIALECTS) {
       })
 
       it('should migrate all the way down', async () => {
-        const [migrator, executedUpMethods, executedDownMethods] =
+        const { migrator, executedUpMethods, executedDownMethods } =
           createMigrations(['migration1', 'migration2', 'migration3'])
 
         const { results: results1 } = await migrator.migrateToLatest()
@@ -423,7 +408,7 @@ for (const dialect of DIALECTS) {
       })
 
       it('should migrate all the way down with a foreign NO_MIGRATIONS object', async () => {
-        const [migrator, executedUpMethods, executedDownMethods] =
+        const { migrator, executedUpMethods, executedDownMethods } =
           createMigrations(['migration1', 'migration2', 'migration3'])
 
         const { results: results1 } = await migrator.migrateToLatest()
@@ -456,22 +441,26 @@ for (const dialect of DIALECTS) {
       })
 
       it('should migrate down to a specific migration', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration3',
-          'migration4',
-        ])
-
-        const { results: results1 } = await migrator1.migrateTo('migration4')
-
-        const [migrator2, executedUpMethods2, executedDownMethods2] =
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
           createMigrations([
             'migration1',
             'migration2',
             'migration3',
             'migration4',
           ])
+
+        const { results: results1 } = await migrator1.migrateTo('migration4')
+
+        const {
+          migrator: migrator2,
+          executedUpMethods: executedUpMethods2,
+          executedDownMethods: executedDownMethods2,
+        } = createMigrations([
+          'migration1',
+          'migration2',
+          'migration3',
+          'migration4',
+        ])
 
         const { results: results2 } = await migrator2.migrateTo('migration2')
 
@@ -500,23 +489,25 @@ for (const dialect of DIALECTS) {
 
       describe('with allowUnorderedMigrations enabled', () => {
         it('should migrate up to a specific migration', async () => {
-          const [migrator1, executedUpMethods1] = createMigrations(
-            ['migration1', 'migration3', 'migration4', 'migration5'],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+            createMigrations(
+              ['migration1', 'migration3', 'migration4', 'migration5'],
+              { allowUnorderedMigrations: true },
+            )
 
           const { results: results1 } = await migrator1.migrateTo('migration3')
 
-          const [migrator2, executedUpMethods2] = createMigrations(
-            [
-              'migration1',
-              'migration2',
-              'migration3',
-              'migration4',
-              'migration5',
-            ],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+            createMigrations(
+              [
+                'migration1',
+                'migration2',
+                'migration3',
+                'migration4',
+                'migration5',
+              ],
+              { allowUnorderedMigrations: true },
+            )
 
           const { results: results2 } = await migrator2.migrateTo('migration4')
 
@@ -535,18 +526,21 @@ for (const dialect of DIALECTS) {
         })
 
         it('should migrate all the way down', async () => {
-          const [migrator1, executedUpMethods1] = createMigrations(
-            ['migration1', 'migration2', 'migration4'],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+            createMigrations(['migration1', 'migration2', 'migration4'], {
+              allowUnorderedMigrations: true,
+            })
 
           const { results: results1 } = await migrator1.migrateToLatest()
 
-          const [migrator2, executedUpMethods2, executedDownMethods2] =
-            createMigrations(
-              ['migration1', 'migration2', 'migration3', 'migration4'],
-              { allowUnorderedMigrations: true },
-            )
+          const {
+            migrator: migrator2,
+            executedUpMethods: executedUpMethods2,
+            executedDownMethods: executedDownMethods2,
+          } = createMigrations(
+            ['migration1', 'migration2', 'migration3', 'migration4'],
+            { allowUnorderedMigrations: true },
+          )
 
           const { results: results2 } = await migrator2.migrateTo(NO_MIGRATIONS)
 
@@ -588,24 +582,28 @@ for (const dialect of DIALECTS) {
         })
 
         it('should migrate down to a specific migration', async () => {
-          const [migrator1, executedUpMethods1] = createMigrations(
-            ['migration1', 'migration2', 'migration3', 'migration5'],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+            createMigrations(
+              ['migration1', 'migration2', 'migration3', 'migration5'],
+              { allowUnorderedMigrations: true },
+            )
 
           const { results: results1 } = await migrator1.migrateTo('migration5')
 
-          const [migrator2, executedUpMethods2, executedDownMethods2] =
-            createMigrations(
-              [
-                'migration1',
-                'migration2',
-                'migration3',
-                'migration4',
-                'migration5',
-              ],
-              { allowUnorderedMigrations: true },
-            )
+          const {
+            migrator: migrator2,
+            executedUpMethods: executedUpMethods2,
+            executedDownMethods: executedDownMethods2,
+          } = createMigrations(
+            [
+              'migration1',
+              'migration2',
+              'migration3',
+              'migration4',
+              'migration5',
+            ],
+            { allowUnorderedMigrations: true },
+          )
 
           const { results: results2 } = await migrator2.migrateTo('migration2')
 
@@ -641,19 +639,17 @@ for (const dialect of DIALECTS) {
         })
 
         it('should migrate down if allowUnorderedMigrations is enabled and migration names are not in order', async () => {
-          const [migrator1, executedUpMethods1] = createMigrations(
-            ['migration1', 'migration3'],
-            { allowUnorderedMigrations: true },
-          )
+          const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+            createMigrations(['migration1', 'migration3'], {
+              allowUnorderedMigrations: true,
+            })
 
           const { results: results1 } = await migrator1.migrateToLatest()
 
-          const [migrator2, executedUpMethods2] = createMigrations(
-            ['migration1', 'migration2', 'migration3'],
-            {
+          const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+            createMigrations(['migration1', 'migration2', 'migration3'], {
               allowUnorderedMigrations: true,
-            },
-          )
+            })
 
           const { results: results2 } = await migrator2.migrateToLatest()
 
@@ -673,10 +669,13 @@ for (const dialect of DIALECTS) {
           expect(executedUpMethods1).to.eql(['migration1', 'migration3'])
           expect(executedUpMethods2).to.eql(['migration2'])
 
-          const [migrator3, executedUpMethods3, executedDownMethods3] =
-            createMigrations(['migration1', 'migration2', 'migration3'], {
-              allowUnorderedMigrations: true,
-            })
+          const {
+            migrator: migrator3,
+            executedUpMethods: executedUpMethods3,
+            executedDownMethods: executedDownMethods3,
+          } = createMigrations(['migration1', 'migration2', 'migration3'], {
+            allowUnorderedMigrations: true,
+          })
 
           const { results: results3 } = await migrator3.migrateDown()
           expect(results3).to.eql([
@@ -709,7 +708,7 @@ for (const dialect of DIALECTS) {
       })
 
       it('should migrate up one step', async () => {
-        const [migrator, executedUpMethods] = createMigrations([
+        const { migrator, executedUpMethods } = createMigrations([
           'migration1',
           'migration2',
         ])
@@ -737,19 +736,18 @@ for (const dialect of DIALECTS) {
       })
 
       it('should return an error when migrating up if a new migration is added before the last executed one', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations([
-          'migration1',
-          'migration3',
-        ])
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations(['migration1', 'migration3'])
 
         await migrator1.migrateToLatest()
 
-        const [migrator2, executedUpMethods2] = createMigrations([
-          'migration1',
-          'migration2',
-          'migration3',
-          'migration4',
-        ])
+        const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+          createMigrations([
+            'migration1',
+            'migration2',
+            'migration3',
+            'migration4',
+          ])
 
         const { error } = await migrator2.migrateUp()
 
@@ -763,17 +761,18 @@ for (const dialect of DIALECTS) {
       })
 
       it('should migrate up one step with allowUnorderedMigrations enabled', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations(
-          ['migration1', 'migration3'],
-          { allowUnorderedMigrations: true },
-        )
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations(['migration1', 'migration3'], {
+            allowUnorderedMigrations: true,
+          })
 
         const { results: results1 } = await migrator1.migrateToLatest()
 
-        const [migrator2, executedUpMethods2] = createMigrations(
-          ['migration1', 'migration2', 'migration3', 'migration4'],
-          { allowUnorderedMigrations: true },
-        )
+        const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+          createMigrations(
+            ['migration1', 'migration2', 'migration3', 'migration4'],
+            { allowUnorderedMigrations: true },
+          )
 
         const { results: results2 } = await migrator2.migrateUp()
         const { results: results3 } = await migrator2.migrateUp()
@@ -796,9 +795,12 @@ for (const dialect of DIALECTS) {
       })
 
       it('should not execute in transaction if disableTransactions is true on the `Migrator` instance', async () => {
-        const [migrator, executedUpMethods] = createMigrations(['migration1'], {
-          disableTransactions: true,
-        })
+        const { migrator, executedUpMethods } = createMigrations(
+          ['migration1'],
+          {
+            disableTransactions: true,
+          },
+        )
 
         const { results } = await migrator.migrateUp()
 
@@ -812,9 +814,12 @@ for (const dialect of DIALECTS) {
       })
 
       it('should not execute in transaction if disableTransactions is true when calling `migrateUp`', async () => {
-        const [migrator, executedUpMethods] = createMigrations(['migration1'], {
-          disableTransactions: false,
-        })
+        const { migrator, executedUpMethods } = createMigrations(
+          ['migration1'],
+          {
+            disableTransactions: false,
+          },
+        )
 
         const { results } = await migrator.migrateUp({
           disableTransactions: true,
@@ -833,12 +838,13 @@ for (const dialect of DIALECTS) {
         const shouldExecuteInTransaction =
           ctx.db.getExecutor().adapter.supportsTransactionalDdl
 
-        const [migrator, executedUpMethods] = createMigrations(
-          [{ name: 'migration1', transaction: shouldExecuteInTransaction }],
-          {
-            disableTransactions: false,
-          },
-        )
+        const { migrator, executedUpMethods, executedInTransactions } =
+          createMigrations(
+            [{ name: 'migration1', transaction: shouldExecuteInTransaction }],
+            {
+              disableTransactions: false,
+            },
+          )
 
         const { results } = await migrator.migrateUp()
 
@@ -847,18 +853,20 @@ for (const dialect of DIALECTS) {
         ])
 
         expect(executedUpMethods).to.eql(['migration1'])
+        expect(executedInTransactions).to.eql([shouldExecuteInTransaction])
       })
 
-      it('should execute in transaction if disableTransactions is false when calling `migrateUp` and transactionDdl supported', async () => {
+      it('should execute in transaction when `migrateUp` is called with disableTransactions false even though the Migrator instance has disableTransactions true', async () => {
         const shouldExecuteInTransaction =
           ctx.db.getExecutor().adapter.supportsTransactionalDdl
 
-        const [migrator, executedUpMethods] = createMigrations(
-          [{ name: 'migration1', transaction: shouldExecuteInTransaction }],
-          {
-            disableTransactions: true,
-          },
-        )
+        const { migrator, executedUpMethods, executedInTransactions } =
+          createMigrations(
+            [{ name: 'migration1', transaction: shouldExecuteInTransaction }],
+            {
+              disableTransactions: true,
+            },
+          )
 
         const { results } = await migrator.migrateUp({
           disableTransactions: false,
@@ -869,6 +877,7 @@ for (const dialect of DIALECTS) {
         ])
 
         expect(executedUpMethods).to.eql(['migration1'])
+        expect(executedInTransactions).to.eql([shouldExecuteInTransaction])
       })
 
       if (sqlSpec === 'postgres' || sqlSpec === 'mssql') {
@@ -907,20 +916,31 @@ for (const dialect of DIALECTS) {
 
       if (variant === 'postgres') {
         it('should not run concurrent migrators in parallel when disableTransactions is true (issue #1894)', async () => {
-          // Two migrators running `migrateToLatest` in parallel with
-          // `disableTransactions: true` must not execute migrations
-          // concurrently. Without a surrounding transaction, Postgres releases
-          // `pg_advisory_xact_lock` at the end of the statement that acquires
-          // it, so both migrators can run the same migration's `up` and the
-          // loser fails when it tries to insert a duplicate row into the
-          // migration table.
-          const [migratorA, executedUpA] = createMigrations(
+          let timestamp = 0
+          const executedRuns: {
+            name: string
+            source: 'A' | 'B'
+            timestamp: number
+          }[] = []
+          const recordRun =
+            (source: 'A' | 'B') =>
+            (name: string): void => {
+              executedRuns.push({
+                name,
+                source,
+                timestamp: ++timestamp,
+              })
+            }
+
+          const { migrator: migratorA } = createMigrations(
             ['migration1', 'migration2'],
             { disableTransactions: true },
+            { onUp: recordRun('A') },
           )
-          const [migratorB, executedUpB] = createMigrations(
-            ['migration1', 'migration2'],
+          const { migrator: migratorB } = createMigrations(
+            ['migration1', 'migration2', 'migration3'],
             { disableTransactions: true },
+            { onUp: recordRun('B') },
           )
 
           const [resultA, resultB] = await Promise.all([
@@ -928,23 +948,17 @@ for (const dialect of DIALECTS) {
             migratorB.migrateToLatest(),
           ])
 
-          // Neither migrator may error (no duplicate-key violation).
           expect(resultA.error).to.be.undefined
           expect(resultB.error).to.be.undefined
 
-          // Each migration's `up` must run exactly once across both migrators.
-          const allExecutedUp = [...executedUpA, ...executedUpB]
-          expect(allExecutedUp.sort()).to.eql(['migration1', 'migration2'])
-
-          // The migration table must contain exactly one row per migration.
-          const executed = await (ctx.db as Kysely<any>)
-            .selectFrom(DEFAULT_MIGRATION_TABLE)
-            .select('name')
-            .orderBy('name')
-            .execute()
-          expect(executed.map((it: { name: string }) => it.name)).to.eql([
-            'migration1',
-            'migration2',
+          expect(
+            executedRuns
+              .sort((a, b) => a.timestamp - b.timestamp)
+              .map(({ name, source }) => ({ name, source })),
+          ).to.eql([
+            { name: 'migration1', source: 'A' },
+            { name: 'migration2', source: 'A' },
+            { name: 'migration3', source: 'B' },
           ])
         })
       }
@@ -984,7 +998,7 @@ for (const dialect of DIALECTS) {
 
     describe('migrateDown', () => {
       it('should migrate down one step', async () => {
-        const [migrator, executedUpMethods, executedDownMethods] =
+        const { migrator, executedUpMethods, executedDownMethods } =
           createMigrations([
             'migration1',
             'migration2',
@@ -1014,15 +1028,16 @@ for (const dialect of DIALECTS) {
       })
 
       it('should return an error if a new migration is added before the last executed one', async () => {
-        const [migrator1, executedUpMethods1] = createMigrations([
-          'migration1',
-          'migration3',
-        ])
+        const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+          createMigrations(['migration1', 'migration3'])
 
         await migrator1.migrateToLatest()
 
-        const [migrator2, _executedUpMethods2, executedDownMethods2] =
-          createMigrations(['migration1', 'migration2', 'migration3'])
+        const {
+          migrator: migrator2,
+          executedUpMethods: _executedUpMethods2,
+          executedDownMethods: executedDownMethods2,
+        } = createMigrations(['migration1', 'migration2', 'migration3'])
 
         const { error } = await migrator2.migrateDown()
 
@@ -1036,24 +1051,30 @@ for (const dialect of DIALECTS) {
       })
 
       it('should migrate down one step with allowUnorderedMigrations enabled', async () => {
-        const [migrator1, executedUpMethods1, _executedDownMethods1] =
-          createMigrations(['migration1', 'migration2', 'migration4'], {
-            allowUnorderedMigrations: true,
-          })
+        const {
+          migrator: migrator1,
+          executedUpMethods: executedUpMethods1,
+          executedDownMethods: _executedDownMethods1,
+        } = createMigrations(['migration1', 'migration2', 'migration4'], {
+          allowUnorderedMigrations: true,
+        })
 
         await migrator1.migrateToLatest()
 
-        const [migrator2, _executedUpMethods2, executedDownMethods2] =
-          createMigrations(
-            [
-              'migration1',
-              'migration2',
-              'migration3',
-              'migration4',
-              'migration5',
-            ],
-            { allowUnorderedMigrations: true },
-          )
+        const {
+          migrator: migrator2,
+          executedUpMethods: _executedUpMethods2,
+          executedDownMethods: executedDownMethods2,
+        } = createMigrations(
+          [
+            'migration1',
+            'migration2',
+            'migration3',
+            'migration4',
+            'migration5',
+          ],
+          { allowUnorderedMigrations: true },
+        )
 
         const { results: results1 } = await migrator2.migrateDown()
         const { results: results2 } = await migrator2.migrateDown()
@@ -1100,17 +1121,19 @@ for (const dialect of DIALECTS) {
         })
 
         it('should use the same ordering strategy for migrations for both not executed migrations and executed migrations', async () => {
-          const [migrator1, executedUpMethods1] = createMigrations([
-            '2024-01-01-create-table',
-            '2024-01-01.2-update-table',
-          ])
+          const { migrator: migrator1, executedUpMethods: executedUpMethods1 } =
+            createMigrations([
+              '2024-01-01-create-table',
+              '2024-01-01.2-update-table',
+            ])
 
           await migrator1.migrateToLatest()
 
-          const [migrator2, executedUpMethods2] = createMigrations([
-            '2024-01-01-create-table',
-            '2024-01-01.2-update-table',
-          ])
+          const { migrator: migrator2, executedUpMethods: executedUpMethods2 } =
+            createMigrations([
+              '2024-01-01-create-table',
+              '2024-01-01.2-update-table',
+            ])
 
           const { results: results2, error } = await migrator2.migrateToLatest()
           expect(error).to.be.undefined
@@ -1128,7 +1151,7 @@ for (const dialect of DIALECTS) {
     if (sqlSpec === 'postgres' || sqlSpec === 'mssql') {
       describe('custom migration tables in a custom schema', () => {
         it('should create custom migration tables in custom schema', async () => {
-          const [migrator, executedUpMethods] = createMigrations(
+          const { migrator, executedUpMethods } = createMigrations(
             ['migration1', 'migration2', 'migration3', 'migration4'],
             {
               migrationTableName: CUSTOM_MIGRATION_TABLE,
@@ -1209,9 +1232,16 @@ for (const dialect of DIALECTS) {
         | { name: string; error?: string; transaction?: boolean }
       )[],
       migratorConfig?: Partial<MigratorProps>,
-    ): [Migrator, string[], string[]] {
+      options?: { onUp?: (migrationName: string) => void },
+    ): {
+      migrator: Migrator
+      executedUpMethods: string[]
+      executedDownMethods: string[]
+      executedInTransactions: boolean[]
+    } {
       const executedUpMethods: string[] = []
       const executedDownMethods: string[] = []
+      const executedInTransactions: boolean[] = []
 
       const migrations = migrationConfigs.reduce<Record<string, Migration>>(
         (migrations, rawConfig) => {
@@ -1229,10 +1259,11 @@ for (const dialect of DIALECTS) {
                 }
 
                 if (config.transaction !== undefined) {
-                  expect(db.isTransaction).to.equal(config.transaction)
+                  executedInTransactions.push(db.isTransaction)
                 }
 
                 executedUpMethods.push(config.name)
+                options?.onUp?.(config.name)
               },
 
               async down(_db): Promise<void> {
@@ -1250,8 +1281,8 @@ for (const dialect of DIALECTS) {
         {},
       )
 
-      return [
-        new Migrator({
+      return {
+        migrator: new Migrator({
           db: ctx.db,
           provider: {
             getMigrations: () => Promise.resolve(migrations),
@@ -1260,7 +1291,8 @@ for (const dialect of DIALECTS) {
         }),
         executedUpMethods,
         executedDownMethods,
-      ]
+        executedInTransactions,
+      }
     }
 
     async function doesTableExists(

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -840,7 +840,7 @@ for (const dialect of DIALECTS) {
 
         const { migrator, executedUpMethods, executedInTransactions } =
           createMigrations(
-            [{ name: 'migration1', transaction: shouldExecuteInTransaction }],
+            ['migration1'],
             {
               disableTransactions: false,
             },
@@ -853,7 +853,12 @@ for (const dialect of DIALECTS) {
         ])
 
         expect(executedUpMethods).to.eql(['migration1'])
-        expect(executedInTransactions).to.eql([shouldExecuteInTransaction])
+        expect(executedInTransactions).to.eql([
+          {
+            name: 'migration1',
+            isTransaction: shouldExecuteInTransaction,
+          },
+        ])
       })
 
       it('should execute in transaction when `migrateUp` is called with disableTransactions false even though the Migrator instance has disableTransactions true', async () => {
@@ -862,7 +867,7 @@ for (const dialect of DIALECTS) {
 
         const { migrator, executedUpMethods, executedInTransactions } =
           createMigrations(
-            [{ name: 'migration1', transaction: shouldExecuteInTransaction }],
+            ['migration1'],
             {
               disableTransactions: true,
             },
@@ -877,7 +882,12 @@ for (const dialect of DIALECTS) {
         ])
 
         expect(executedUpMethods).to.eql(['migration1'])
-        expect(executedInTransactions).to.eql([shouldExecuteInTransaction])
+        expect(executedInTransactions).to.eql([
+          {
+            name: 'migration1',
+            isTransaction: shouldExecuteInTransaction,
+          },
+        ])
       })
 
       if (sqlSpec === 'postgres' || sqlSpec === 'mssql') {
@@ -1227,21 +1237,21 @@ for (const dialect of DIALECTS) {
     }
 
     function createMigrations(
-      migrationConfigs: (
-        | string
-        | { name: string; error?: string; transaction?: boolean }
-      )[],
+      migrationConfigs: (string | { name: string; error?: string })[],
       migratorConfig?: Partial<MigratorProps>,
       options?: { onUp?: (migrationName: string) => void },
     ): {
       migrator: Migrator
       executedUpMethods: string[]
       executedDownMethods: string[]
-      executedInTransactions: boolean[]
+      executedInTransactions: { name: string; isTransaction: boolean }[]
     } {
       const executedUpMethods: string[] = []
       const executedDownMethods: string[] = []
-      const executedInTransactions: boolean[] = []
+      const executedInTransactions: {
+        name: string
+        isTransaction: boolean
+      }[] = []
 
       const migrations = migrationConfigs.reduce<Record<string, Migration>>(
         (migrations, rawConfig) => {
@@ -1258,9 +1268,10 @@ for (const dialect of DIALECTS) {
                   throw new Error(config.error)
                 }
 
-                if (config.transaction !== undefined) {
-                  executedInTransactions.push(db.isTransaction)
-                }
+                executedInTransactions.push({
+                  name: config.name,
+                  isTransaction: db.isTransaction,
+                })
 
                 executedUpMethods.push(config.name)
                 options?.onUp?.(config.name)

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -839,12 +839,9 @@ for (const dialect of DIALECTS) {
           ctx.db.getExecutor().adapter.supportsTransactionalDdl
 
         const { migrator, executedUpMethods, executedInTransactions } =
-          createMigrations(
-            ['migration1'],
-            {
-              disableTransactions: false,
-            },
-          )
+          createMigrations(['migration1'], {
+            disableTransactions: false,
+          })
 
         const { results } = await migrator.migrateUp()
 
@@ -866,12 +863,9 @@ for (const dialect of DIALECTS) {
           ctx.db.getExecutor().adapter.supportsTransactionalDdl
 
         const { migrator, executedUpMethods, executedInTransactions } =
-          createMigrations(
-            ['migration1'],
-            {
-              disableTransactions: true,
-            },
-          )
+          createMigrations(['migration1'], {
+            disableTransactions: true,
+          })
 
         const { results } = await migrator.migrateUp({
           disableTransactions: false,
@@ -924,52 +918,32 @@ for (const dialect of DIALECTS) {
         })
       }
 
-      if (variant === 'postgres') {
+      if (variant === 'postgres' || variant === 'mssql') {
         it('should not run concurrent migrators in parallel when disableTransactions is true (issue #1894)', async () => {
-          let timestamp = 0
-          const executedRuns: {
-            name: string
-            source: 'A' | 'B'
-            timestamp: number
-          }[] = []
-          const recordRun =
-            (source: 'A' | 'B') =>
-            (name: string): void => {
-              executedRuns.push({
-                name,
-                source,
-                timestamp: ++timestamp,
-              })
-            }
+          let startedRunning: () => void
+          const migratorARunning = new Promise<void>(
+            (resolve) => (startedRunning = resolve),
+          )
 
           const { migrator: migratorA } = createMigrations(
-            ['migration1', 'migration2'],
+            [{ durationMs: 1_000, name: 'migrationA', preUp: () => startedRunning() }],
             { disableTransactions: true },
-            { onUp: recordRun('A') },
           )
-          const { migrator: migratorB } = createMigrations(
-            ['migration1', 'migration2', 'migration3'],
-            { disableTransactions: true },
-            { onUp: recordRun('B') },
-          )
+          const { migrator: migratorB } = createMigrations(['migrationB'], {
+            disableTransactions: false,
+          })
 
           const [resultA, resultB] = await Promise.all([
             migratorA.migrateToLatest(),
-            migratorB.migrateToLatest(),
+            migratorARunning.then(() => migratorB.migrateToLatest()),
           ])
 
           expect(resultA.error).to.be.undefined
-          expect(resultB.error).to.be.undefined
-
-          expect(
-            executedRuns
-              .sort((a, b) => a.timestamp - b.timestamp)
-              .map(({ name, source }) => ({ name, source })),
-          ).to.eql([
-            { name: 'migration1', source: 'A' },
-            { name: 'migration2', source: 'A' },
-            { name: 'migration3', source: 'B' },
-          ])
+          expect(resultB.error)
+            .to.be.instanceOf(Error)
+            .and.satisfy((val: Error) =>
+              val.message.includes('migrationA is missing'),
+            )
         })
       }
 
@@ -1237,9 +1211,16 @@ for (const dialect of DIALECTS) {
     }
 
     function createMigrations(
-      migrationConfigs: (string | { name: string; error?: string })[],
+      migrationConfigs: (
+        | string
+        | {
+            durationMs?: number
+            name: string
+            error?: string
+            preUp?: () => void
+          }
+      )[],
       migratorConfig?: Partial<MigratorProps>,
-      options?: { onUp?: (migrationName: string) => void },
     ): {
       migrator: Migrator
       executedUpMethods: string[]
@@ -1256,13 +1237,16 @@ for (const dialect of DIALECTS) {
       const migrations = migrationConfigs.reduce<Record<string, Migration>>(
         (migrations, rawConfig) => {
           const config =
-            typeof rawConfig === 'string' ? { name: rawConfig } : rawConfig
+            typeof rawConfig === 'string'
+              ? { durationMs: 20, name: rawConfig }
+              : { durationMs: 20, ...rawConfig }
 
           return {
             ...migrations,
             [config.name]: {
               async up(db): Promise<void> {
-                await setTimeout(20)
+                config.preUp?.()
+                await setTimeout(config.durationMs)
 
                 if (config.error) {
                   throw new Error(config.error)
@@ -1274,11 +1258,10 @@ for (const dialect of DIALECTS) {
                 })
 
                 executedUpMethods.push(config.name)
-                options?.onUp?.(config.name)
               },
 
               async down(_db): Promise<void> {
-                await setTimeout(20)
+                await setTimeout(config.durationMs)
 
                 if (config.error) {
                   throw new Error(config.error)

--- a/test/node/src/migration.test.ts
+++ b/test/node/src/migration.test.ts
@@ -830,9 +830,15 @@ for (const dialect of DIALECTS) {
       })
 
       it('should execute in transaction if disableTransactions is false on the `Migrator` instance and transactionDdl supported', async () => {
-        const [migrator, executedUpMethods] = createMigrations(['migration1'], {
-          disableTransactions: false,
-        })
+        const shouldExecuteInTransaction =
+          ctx.db.getExecutor().adapter.supportsTransactionalDdl
+
+        const [migrator, executedUpMethods] = createMigrations(
+          [{ name: 'migration1', transaction: shouldExecuteInTransaction }],
+          {
+            disableTransactions: false,
+          },
+        )
 
         const { results } = await migrator.migrateUp()
 
@@ -841,18 +847,18 @@ for (const dialect of DIALECTS) {
         ])
 
         expect(executedUpMethods).to.eql(['migration1'])
-
-        if (ctx.db.getExecutor().adapter.supportsTransactionalDdl) {
-          expect(transactionSpy.called).to.be.true
-        } else {
-          expect(transactionSpy.called).to.be.false
-        }
       })
 
       it('should execute in transaction if disableTransactions is false when calling `migrateUp` and transactionDdl supported', async () => {
-        const [migrator, executedUpMethods] = createMigrations(['migration1'], {
-          disableTransactions: true,
-        })
+        const shouldExecuteInTransaction =
+          ctx.db.getExecutor().adapter.supportsTransactionalDdl
+
+        const [migrator, executedUpMethods] = createMigrations(
+          [{ name: 'migration1', transaction: shouldExecuteInTransaction }],
+          {
+            disableTransactions: true,
+          },
+        )
 
         const { results } = await migrator.migrateUp({
           disableTransactions: false,
@@ -863,12 +869,6 @@ for (const dialect of DIALECTS) {
         ])
 
         expect(executedUpMethods).to.eql(['migration1'])
-
-        if (ctx.db.getExecutor().adapter.supportsTransactionalDdl) {
-          expect(transactionSpy.called).to.be.true
-        } else {
-          expect(transactionSpy.called).to.be.false
-        }
       })
 
       if (sqlSpec === 'postgres' || sqlSpec === 'mssql') {
@@ -902,6 +902,50 @@ for (const dialect of DIALECTS) {
           } finally {
             await trx.rollback().execute()
           }
+        })
+      }
+
+      if (variant === 'postgres') {
+        it('should not run concurrent migrators in parallel when disableTransactions is true (issue #1894)', async () => {
+          // Two migrators running `migrateToLatest` in parallel with
+          // `disableTransactions: true` must not execute migrations
+          // concurrently. Without a surrounding transaction, Postgres releases
+          // `pg_advisory_xact_lock` at the end of the statement that acquires
+          // it, so both migrators can run the same migration's `up` and the
+          // loser fails when it tries to insert a duplicate row into the
+          // migration table.
+          const [migratorA, executedUpA] = createMigrations(
+            ['migration1', 'migration2'],
+            { disableTransactions: true },
+          )
+          const [migratorB, executedUpB] = createMigrations(
+            ['migration1', 'migration2'],
+            { disableTransactions: true },
+          )
+
+          const [resultA, resultB] = await Promise.all([
+            migratorA.migrateToLatest(),
+            migratorB.migrateToLatest(),
+          ])
+
+          // Neither migrator may error (no duplicate-key violation).
+          expect(resultA.error).to.be.undefined
+          expect(resultB.error).to.be.undefined
+
+          // Each migration's `up` must run exactly once across both migrators.
+          const allExecutedUp = [...executedUpA, ...executedUpB]
+          expect(allExecutedUp.sort()).to.eql(['migration1', 'migration2'])
+
+          // The migration table must contain exactly one row per migration.
+          const executed = await (ctx.db as Kysely<any>)
+            .selectFrom(DEFAULT_MIGRATION_TABLE)
+            .select('name')
+            .orderBy('name')
+            .execute()
+          expect(executed.map((it: { name: string }) => it.name)).to.eql([
+            'migration1',
+            'migration2',
+          ])
         })
       }
 
@@ -1160,7 +1204,10 @@ for (const dialect of DIALECTS) {
     }
 
     function createMigrations(
-      migrationConfigs: (string | { name: string; error?: string })[],
+      migrationConfigs: (
+        | string
+        | { name: string; error?: string; transaction?: boolean }
+      )[],
       migratorConfig?: Partial<MigratorProps>,
     ): [Migrator, string[], string[]] {
       const executedUpMethods: string[] = []
@@ -1174,11 +1221,15 @@ for (const dialect of DIALECTS) {
           return {
             ...migrations,
             [config.name]: {
-              async up(_db): Promise<void> {
+              async up(db): Promise<void> {
                 await setTimeout(20)
 
                 if (config.error) {
                   throw new Error(config.error)
+                }
+
+                if (config.transaction !== undefined) {
+                  expect(db.isTransaction).to.equal(config.transaction)
                 }
 
                 executedUpMethods.push(config.name)


### PR DESCRIPTION
Postgres migration locking was using a transaction-level advisory lock, which can be released too early when migrations are not protected by a surrounding transaction.

This switches the Postgres adapter to session-level advisory locking with `pg_try_advisory_lock`, the same one-hour timeout shape used by MySQL, and `pg_advisory_unlock` on release. For Kysely-owned transactional migrations, the migrator now keeps the migration body in a transaction but releases the lock from the same outer connection after the transaction settles, so the lock covers the whole migration run.

I added a real Postgres concurrent-migrator regression for #1894. It fails without the fix and passes with each migration applied once; I also ran build, node test build, the focused Postgres migration suite, ESM import tests, and export tests.

Fixes #1894