### PR TITLE
fix(sqlite): emit RETURNING before ORDER BY/LIMIT in deleteFrom

### DIFF
--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -440,6 +440,11 @@ export class DefaultQueryCompiler
       this.visitNode(node.where)
     }
 
+    if (node.returning) {
+      this.append(' ')
+      this.visitNode(node.returning)
+    }
+
     if (node.orderBy) {
       this.append(' ')
       this.visitNode(node.orderBy)
@@ -448,11 +453,6 @@ export class DefaultQueryCompiler
     if (node.limit) {
       this.append(' ')
       this.visitNode(node.limit)
-    }
-
-    if (node.returning) {
-      this.append(' ')
-      this.visitNode(node.returning)
     }
 
     if (wrapInParens) {

--- a/test/node/src/delete.test.ts
+++ b/test/node/src/delete.test.ts
@@ -219,6 +219,32 @@ for (const dialect of DIALECTS) {
       })
     }
 
+    if (sqlSpec === 'sqlite') {
+      it('should emit RETURNING before ORDER BY and LIMIT in SQLite', async () => {
+        const query = ctx.db
+          .deleteFrom('person')
+          .where('gender', '=', 'male')
+          .returning('first_name')
+          .orderBy('first_name')
+          .limit(1)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: NOT_SUPPORTED,
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: 'delete from "person" where "gender" = ? returning "first_name" order by "first_name" limit ?',
+            parameters: ['male', 1],
+          },
+        })
+
+        const result = await query.execute()
+
+        expect(result).to.have.length(1)
+        expect(result[0]).to.have.property('first_name')
+      })
+    }
+
     if (sqlSpec === 'postgres') {
       it('should delete from t1 using t2', async () => {
         const query = ctx.db


### PR DESCRIPTION
## Problem

On SQLite, `deleteFrom().where().returning().orderBy().limit()` generates invalid SQL:

```sql
-- generated (wrong)
delete from "person" where "gender" = ? order by "first_name" limit ? returning "first_name"

-- required by SQLite
delete from "person" where "gender" = ? returning "first_name" order by "first_name" limit ?
```

SQLite mandates that `RETURNING` appears immediately after the `WHERE` clause, before `ORDER BY` and `LIMIT`. Placing it after those clauses is a syntax error.

## Root cause

`visitDeleteQuery` in `src/query-compiler/default-query-compiler.ts` emitted the `returning` block after `orderBy` and `limit`. Its sibling `visitUpdateQuery` already has the correct order (WHERE → RETURNING → ORDER BY → LIMIT), but the equivalent fix was never applied to `visitDeleteQuery`.

This is the same class of bug fixed for UPDATE in #1691.

## Fix

Moved the `node.returning` block in `visitDeleteQuery` to emit before `node.orderBy` and `node.limit`, matching the ordering in `visitUpdateQuery`.

## Test

Added a SQLite-only test in `test/node/src/delete.test.ts` that verifies `deleteFrom().where().returning().orderBy().limit()` emits clauses in the correct order and executes successfully.

Closes #1931