### PR TITLE
fix(sqlite): returning clauses wrongfuly output after order by and limit in delete queries.

### DIFF
--- a/src/query-compiler/default-query-compiler.ts
+++ b/src/query-compiler/default-query-compiler.ts
@@ -440,6 +440,11 @@ export class DefaultQueryCompiler
       this.visitNode(node.where)
     }
 
+    if (node.returning) {
+      this.append(' ')
+      this.visitNode(node.returning)
+    }
+
     if (node.orderBy) {
       this.append(' ')
       this.visitNode(node.orderBy)
@@ -448,11 +453,6 @@ export class DefaultQueryCompiler
     if (node.limit) {
       this.append(' ')
       this.visitNode(node.limit)
-    }
-
-    if (node.returning) {
-      this.append(' ')
-      this.visitNode(node.returning)
     }
 
     if (wrapInParens) {

--- a/test/node/src/delete.test.ts
+++ b/test/node/src/delete.test.ts
@@ -1020,5 +1020,28 @@ for (const dialect of DIALECTS) {
         expect(result.last_name).to.equal('Aniston')
       })
     }
+
+    if (sqlSpec === 'sqlite') {
+      it('should order and limit the amount of deleted rows and return', async () => {
+        const query = ctx.db
+          .deleteFrom('person')
+          .where('gender', '=', 'male')
+          .returning('id')
+          .orderBy('first_name')
+          .limit(1)
+
+        testSql(query, dialect, {
+          postgres: NOT_SUPPORTED,
+          mysql: NOT_SUPPORTED,
+          mssql: NOT_SUPPORTED,
+          sqlite: {
+            sql: 'delete from "person" where "gender" = ? returning "id" order by "first_name" limit ?',
+            parameters: ['male', 1],
+          },
+        })
+
+        await query.execute()
+      })
+    }
   })
 }

--- a/test/node/src/update.test.ts
+++ b/test/node/src/update.test.ts
@@ -456,6 +456,8 @@ for (const dialect of DIALECTS) {
             parameters: ['Barson', 'female', 1],
           },
         })
+
+        await query.execute()
       })
 
       it('should update all rows, returning some fields of updated rows, and conditionally returning additional fields', async () => {


### PR DESCRIPTION
Hey 👋 

This PR is based on a non-human contribution which will remain discredited for being driven by a lazy asshole who doesn't have the decency to participate.

It fixes a bug affecting SQLite users where delete queries are output with `returning` clauses before `order by` and `limit` clauses causing a runtime error.