### PR TITLE
Fix typo in `CreateTypeBuilder.asEnum` docstring

### DIFF
--- a/src/schema/create-type-builder.ts
+++ b/src/schema/create-type-builder.ts
@@ -22,7 +22,7 @@ export class CreateTypeBuilder implements OperationNodeSource, Compilable {
   }
 
   /**
-   * Creates an anum type.
+   * Creates an enum type.
    *
    * ### Examples
    *


### PR DESCRIPTION
This PR fixes a minor typo in the `CreateTypeBuilder.asEnum` docstring, changing `anum` to `enum`.