### PR TITLE
fix infinite type check recursion

### DIFF
--- a/src/query-builder/delete-query-builder.ts
+++ b/src/query-builder/delete-query-builder.ts
@@ -794,7 +794,9 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
    * delete from `pet` order by `created_at` limit ?
    * ```
    */
-  limit(limit: ValueExpression<DB, TB, number>): DeleteQueryBuilder<DB, TB, O> {
+  limit<VE extends ValueExpression<DB, TB, number>>(
+    limit: VE,
+  ): DeleteQueryBuilder<DB, TB, O> {
     return new DeleteQueryBuilder({
       ...this.#props,
       queryNode: DeleteQueryNode.cloneWithLimit(
@@ -901,11 +903,14 @@ export class DeleteQueryBuilder<DB, TB extends keyof DB, O>
   $if<O2>(
     condition: boolean,
     func: (qb: this) => DeleteQueryBuilder<any, any, O2>,
-  ): O2 extends DeleteResult
-    ? DeleteQueryBuilder<DB, TB, DeleteResult>
-    : O2 extends O & infer E
-      ? DeleteQueryBuilder<DB, TB, O & Partial<E>>
-      : DeleteQueryBuilder<DB, TB, Partial<O2>> {
+  ): unknown extends O2
+    ? // See the identical guard on `UpdateQueryBuilder.$if`.
+      DeleteQueryBuilder<any, any, O2>
+    : O2 extends DeleteResult
+      ? DeleteQueryBuilder<DB, TB, DeleteResult>
+      : O2 extends O & infer E
+        ? DeleteQueryBuilder<DB, TB, O & Partial<E>>
+        : DeleteQueryBuilder<DB, TB, Partial<O2>> {
     if (condition) {
       return func(this) as any
     }

--- a/src/query-builder/join-builder.ts
+++ b/src/query-builder/join-builder.ts
@@ -34,7 +34,9 @@ export class JoinBuilder<
     rhs: OperandValueExpressionOrList<DB, TB, RE>,
   ): JoinBuilder<DB, TB>
 
-  on(expression: ExpressionOrFactory<DB, TB, SqlBool>): JoinBuilder<DB, TB>
+  on<E extends ExpressionOrFactory<DB, TB, SqlBool>>(
+    expression: E,
+  ): JoinBuilder<DB, TB>
 
   on(...args: any[]): JoinBuilder<DB, TB> {
     return new JoinBuilder({
@@ -52,11 +54,10 @@ export class JoinBuilder<
    *
    * See {@link WhereInterface.whereRef} for documentation and examples.
    */
-  onRef(
-    lhs: ReferenceExpression<DB, TB>,
-    op: ComparisonOperatorExpression,
-    rhs: ReferenceExpression<DB, TB>,
-  ): JoinBuilder<DB, TB> {
+  onRef<
+    LRE extends ReferenceExpression<DB, TB>,
+    RRE extends ReferenceExpression<DB, TB>,
+  >(lhs: LRE, op: ComparisonOperatorExpression, rhs: RRE): JoinBuilder<DB, TB> {
     return new JoinBuilder({
       ...this.#props,
       joinNode: JoinNode.cloneWithOn(

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1165,8 +1165,8 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * select "first_name" from "person" limit $1 offset $2
    * ```
    */
-  limit(
-    limit: ValueExpression<DB, TB, number | bigint | null>,
+  limit<VE extends ValueExpression<DB, TB, number | bigint | null>>(
+    limit: VE,
   ): SelectQueryBuilder<DB, TB, O>
 
   /**
@@ -1191,8 +1191,8 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    * select "first_name" from "person" limit $1 offset $2
    * ```
    */
-  offset(
-    offset: ValueExpression<DB, TB, number | bigint>,
+  offset<VE extends ValueExpression<DB, TB, number | bigint>>(
+    offset: VE,
   ): SelectQueryBuilder<DB, TB, O>
 
   /**
@@ -2784,22 +2784,48 @@ class AliasedSelectQueryBuilderImpl<
   }
 }
 
+/**
+ * Guards a join's result type against being computed for an unknown table
+ * expression.
+ *
+ * `TableExpression<DB, TB> extends TE` only holds when `TE` is as wide as its
+ * own constraint, which never happens at a call site - there `TE` is a specific
+ * table name, alias or subquery. It does happen when the compiler asks what a
+ * join returns for an arbitrary table expression, which is what it has to do
+ * whenever it compares two `SelectQueryBuilder` types structurally.
+ *
+ * Without this guard that comparison never terminates on its own: computing the
+ * join result yields a `SelectQueryBuilder` over a wider `DB`, whose own join
+ * methods yield a wider one still, so the compiler only stops when it hits its
+ * internal recursion limit. That limit differs between TypeScript versions - 7.0
+ * searches a level deeper than 5.9 and 6.0 - which made comparing two select
+ * query builders over 6x more expensive there.
+ *
+ * Collapsing to a fixed type makes the recursion converge instead: joining an
+ * unknown table expression again produces the same type, so the compiler
+ * recognises the pair it is already comparing and stops immediately.
+ */
+type JoinResultForUnknownTable<O> = SelectQueryBuilder<any, any, O>
+
 export type SelectQueryBuilderWithInnerJoin<
   DB,
   TB extends keyof DB,
   O,
   TE extends TableExpression<DB, TB>,
-> = TE extends `${infer T} as ${infer A}`
-  ? T extends keyof DB
-    ? InnerJoinedBuilder<DB, TB, O, A, DB[T]>
-    : never
-  : TE extends keyof DB
-    ? SelectQueryBuilder<DB, TB | TE, O>
-    : TE extends AliasedExpression<infer QO, infer QA>
-      ? InnerJoinedBuilder<DB, TB, O, QA, QO>
-      : TE extends (qb: any) => AliasedExpression<infer QO, infer QA>
-        ? InnerJoinedBuilder<DB, TB, O, QA, QO>
+> =
+  TableExpression<DB, TB> extends TE
+    ? JoinResultForUnknownTable<O>
+    : TE extends `${infer T} as ${infer A}`
+      ? T extends keyof DB
+        ? InnerJoinedBuilder<DB, TB, O, A, DB[T]>
         : never
+      : TE extends keyof DB
+        ? SelectQueryBuilder<DB, TB | TE, O>
+        : TE extends AliasedExpression<infer QO, infer QA>
+          ? InnerJoinedBuilder<DB, TB, O, QA, QO>
+          : TE extends (qb: any) => AliasedExpression<infer QO, infer QA>
+            ? InnerJoinedBuilder<DB, TB, O, QA, QO>
+            : never
 
 type InnerJoinedBuilder<
   DB,
@@ -2821,17 +2847,20 @@ export type SelectQueryBuilderWithLeftJoin<
   TB extends keyof DB,
   O,
   TE extends TableExpression<DB, TB>,
-> = TE extends `${infer T} as ${infer A}`
-  ? T extends keyof DB
-    ? LeftJoinedBuilder<DB, TB, O, A, DB[T]>
-    : never
-  : TE extends keyof DB
-    ? LeftJoinedBuilder<DB, TB, O, TE, DB[TE]>
-    : TE extends AliasedExpression<infer QO, infer QA>
-      ? LeftJoinedBuilder<DB, TB, O, QA, QO>
-      : TE extends (qb: any) => AliasedExpression<infer QO, infer QA>
-        ? LeftJoinedBuilder<DB, TB, O, QA, QO>
+> =
+  TableExpression<DB, TB> extends TE
+    ? JoinResultForUnknownTable<O>
+    : TE extends `${infer T} as ${infer A}`
+      ? T extends keyof DB
+        ? LeftJoinedBuilder<DB, TB, O, A, DB[T]>
         : never
+      : TE extends keyof DB
+        ? LeftJoinedBuilder<DB, TB, O, TE, DB[TE]>
+        : TE extends AliasedExpression<infer QO, infer QA>
+          ? LeftJoinedBuilder<DB, TB, O, QA, QO>
+          : TE extends (qb: any) => AliasedExpression<infer QO, infer QA>
+            ? LeftJoinedBuilder<DB, TB, O, QA, QO>
+            : never
 
 type LeftJoinedBuilder<
   DB,
@@ -2857,17 +2886,20 @@ export type SelectQueryBuilderWithRightJoin<
   TB extends keyof DB,
   O,
   TE extends TableExpression<DB, TB>,
-> = TE extends `${infer T} as ${infer A}`
-  ? T extends keyof DB
-    ? RightJoinedBuilder<DB, TB, O, A, DB[T]>
-    : never
-  : TE extends keyof DB
-    ? RightJoinedBuilder<DB, TB, O, TE, DB[TE]>
-    : TE extends AliasedExpression<infer QO, infer QA>
-      ? RightJoinedBuilder<DB, TB, O, QA, QO>
-      : TE extends (qb: any) => AliasedExpression<infer QO, infer QA>
-        ? RightJoinedBuilder<DB, TB, O, QA, QO>
+> =
+  TableExpression<DB, TB> extends TE
+    ? JoinResultForUnknownTable<O>
+    : TE extends `${infer T} as ${infer A}`
+      ? T extends keyof DB
+        ? RightJoinedBuilder<DB, TB, O, A, DB[T]>
         : never
+      : TE extends keyof DB
+        ? RightJoinedBuilder<DB, TB, O, TE, DB[TE]>
+        : TE extends AliasedExpression<infer QO, infer QA>
+          ? RightJoinedBuilder<DB, TB, O, QA, QO>
+          : TE extends (qb: any) => AliasedExpression<infer QO, infer QA>
+            ? RightJoinedBuilder<DB, TB, O, QA, QO>
+            : never
 
 type RightJoinedBuilder<
   DB,
@@ -2897,17 +2929,20 @@ export type SelectQueryBuilderWithFullJoin<
   TB extends keyof DB,
   O,
   TE extends TableExpression<DB, TB>,
-> = TE extends `${infer T} as ${infer A}`
-  ? T extends keyof DB
-    ? OuterJoinedBuilder<DB, TB, O, A, DB[T]>
-    : never
-  : TE extends keyof DB
-    ? OuterJoinedBuilder<DB, TB, O, TE, DB[TE]>
-    : TE extends AliasedExpression<infer QO, infer QA>
-      ? OuterJoinedBuilder<DB, TB, O, QA, QO>
-      : TE extends (qb: any) => AliasedExpression<infer QO, infer QA>
-        ? OuterJoinedBuilder<DB, TB, O, QA, QO>
+> =
+  TableExpression<DB, TB> extends TE
+    ? JoinResultForUnknownTable<O>
+    : TE extends `${infer T} as ${infer A}`
+      ? T extends keyof DB
+        ? OuterJoinedBuilder<DB, TB, O, A, DB[T]>
         : never
+      : TE extends keyof DB
+        ? OuterJoinedBuilder<DB, TB, O, TE, DB[TE]>
+        : TE extends AliasedExpression<infer QO, infer QA>
+          ? OuterJoinedBuilder<DB, TB, O, QA, QO>
+          : TE extends (qb: any) => AliasedExpression<infer QO, infer QA>
+            ? OuterJoinedBuilder<DB, TB, O, QA, QO>
+            : never
 
 type OuterJoinedBuilder<
   DB,

--- a/src/query-builder/update-query-builder.ts
+++ b/src/query-builder/update-query-builder.ts
@@ -972,11 +972,19 @@ export class UpdateQueryBuilder<DB, UT extends keyof DB, TB extends keyof DB, O>
   $if<O2>(
     condition: boolean,
     func: (qb: this) => UpdateQueryBuilder<any, any, any, O2>,
-  ): O2 extends UpdateResult
-    ? UpdateQueryBuilder<DB, UT, TB, UpdateResult>
-    : O2 extends O & infer E
-      ? UpdateQueryBuilder<DB, UT, TB, O & Partial<E>>
-      : UpdateQueryBuilder<DB, UT, TB, Partial<O2>> {
+  ): unknown extends O2
+    ? // `O2` is only this wide when the compiler is asking what `$if` returns
+      // for an unknown callback, which it has to do whenever it compares two
+      // `UpdateQueryBuilder` types. Resolving the branches below would turn
+      // that into a union of builders and make the comparison recurse - see
+      // `JoinResultForUnknownTable` in `select-query-builder.ts` for the same
+      // problem in the join result types. A single type converges instead.
+      UpdateQueryBuilder<any, any, any, O2>
+    : O2 extends UpdateResult
+      ? UpdateQueryBuilder<DB, UT, TB, UpdateResult>
+      : O2 extends O & infer E
+        ? UpdateQueryBuilder<DB, UT, TB, O & Partial<E>>
+        : UpdateQueryBuilder<DB, UT, TB, Partial<O2>> {
     if (condition) {
       return func(this) as any
     }

--- a/test/ts-benchmarks/delete-returning.bench.ts
+++ b/test/ts-benchmarks/delete-returning.bench.ts
@@ -17,48 +17,48 @@ bench.baseline(() => {
 
 bench('kysely.deleteFrom(table).returning(column)', () =>
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052'),
-).types([300, 'instantiations'])
+).types([304, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(~column)', () =>
   // @ts-expect-error
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052_'),
-).types([7279, 'instantiations'])
+).types([7349, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(table.column)', () =>
   deleteQuery.returning('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([300, 'instantiations'])
+).types([304, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(~table.column)', () =>
   // @ts-expect-error
   deleteQuery.returning('my_table_.col_164b7896ec8e770207febe0812c5f052'),
-).types([7279, 'instantiations'])
+).types([7349, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(table.column as alias)', () =>
   deleteQuery.returning('my_table.col_164b7896ec8e770207febe0812c5f052 as foo'),
-).types([300, 'instantiations'])
+).types([304, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returning(column as alias)', () =>
   deleteQuery.returning('col_164b7896ec8e770207febe0812c5f052 as foo'),
-).types([300, 'instantiations'])
+).types([304, 'instantiations'])
 
 bench('kysely.deleteFrom(table)..returningAll()', () =>
   deleteQuery.returningAll(),
-).types([87, 'instantiations'])
+).types([91, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(column)', () =>
   deleteQueryAny.returning('col_164b7896ec8e770207febe0812c5f052'),
-).types([234, 'instantiations'])
+).types([238, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(table.column)', () =>
   deleteQueryAny.returning('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([234, 'instantiations'])
+).types([238, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returning(table.column as alias)', () =>
   deleteQueryAny.returning(
     'my_table.col_164b7896ec8e770207febe0812c5f052 as foo',
   ),
-).types([234, 'instantiations'])
+).types([238, 'instantiations'])
 
 bench('kyselyAny.deleteFrom(table)..returningAll()', () =>
   deleteQueryAny.returningAll(),
-).types([87, 'instantiations'])
+).types([91, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -1,0 +1,165 @@
+import { bench } from '@ark/attest'
+import type {
+  DeleteQueryBuilder,
+  ExpressionBuilder,
+  Generated,
+  Kysely,
+  MergeQueryBuilder,
+  Nullable,
+  SelectQueryBuilder,
+  Transaction,
+  UpdateQueryBuilder,
+  WheneableMergeQueryBuilder,
+} from '../../dist/index.js'
+
+// These benchmarks cover the scenarios in `test/typings/test-d/generic.test-d.ts`.
+// They all relate two different instantiations of the same builder type, which
+// TypeScript can only do by comparing them structurally, member by member. That
+// makes them by far the most expensive type-level operations Kysely users hit,
+// so they're worth guarding against regressions.
+//
+// Every builder whose methods return a *computed* builder type recurses this way,
+// so each one gets a case here. Watch the ratio between TypeScript versions too,
+// not just the absolute numbers: these comparisons are only bounded by the
+// compiler's internal recursion limit unless the computed return types converge,
+// and that limit is not the same across versions.
+
+type A = { a: number }
+type B = { b: string }
+type C = { c: boolean }
+
+type Parent = { id: Generated<string> }
+type Person = { id: Generated<string>; parent_id: string }
+type Pet = { owner_id: string; name: string }
+
+declare const wideSelectQueryBuilder: SelectQueryBuilder<
+  { a: A; b: B },
+  'a' | 'b',
+  { a: number }
+>
+declare function acceptsNarrowSelectQueryBuilder(
+  qb: SelectQueryBuilder<{ a: A }, 'a', unknown>,
+): void
+
+declare const wideExpressionBuilder: ExpressionBuilder<
+  { a: A; b: B },
+  'a' | 'b'
+>
+declare function acceptsNarrowExpressionBuilder(
+  eb: ExpressionBuilder<{ a: A }, 'a'>,
+): void
+
+declare const threeTableExpressionBuilder: ExpressionBuilder<
+  { a: A; b: B; c: C },
+  'a' | 'b' | 'c'
+>
+declare function acceptsTwoTableExpressionBuilder(
+  eb: ExpressionBuilder<{ a: A; b: B; c: C }, 'b' | 'c'>,
+): void
+
+declare const kysely: Kysely<{ person: Person; parent: Parent; pet: Pet }>
+
+// The other builders that compute their result types from their arguments. Their
+// `DeleteResult`/`UpdateResult` handling means widening `DB` isn't assignable the
+// way it is for `SelectQueryBuilder`, so these narrow `TB` and widen `O` instead.
+declare const wideDeleteQueryBuilder: DeleteQueryBuilder<
+  { a: A; b: B },
+  'a' | 'b',
+  { a: number }
+>
+declare function acceptsNarrowDeleteQueryBuilder(
+  qb: DeleteQueryBuilder<{ a: A; b: B }, 'a', unknown>,
+): void
+
+declare const wideUpdateQueryBuilder: UpdateQueryBuilder<
+  { a: A; b: B },
+  'a',
+  'a' | 'b',
+  { a: number }
+>
+declare function acceptsNarrowUpdateQueryBuilder(
+  qb: UpdateQueryBuilder<{ a: A; b: B }, 'a', 'a', unknown>,
+): void
+
+declare const wideMergeQueryBuilder: WheneableMergeQueryBuilder<
+  { a: A; b: B },
+  'a',
+  'a' | 'b',
+  { a: number }
+>
+declare function acceptsNarrowMergeQueryBuilder(
+  qb: WheneableMergeQueryBuilder<{ a: A; b: B }, 'a', 'a', unknown>,
+): void
+
+// Handing a transaction to a function that takes a `Kysely` is one of the most
+// common things users do, and it is not cheap: `Transaction` and `Kysely` are
+// different generic types, so the compiler compares them member by member, and
+// `$extendTables`/`$omitTables`/`$pickTables` each return a handle over a
+// transformed `DB`, which makes that comparison recurse.
+declare const transaction: Transaction<{ a: A; b: B }>
+declare function acceptsKysely(db: Kysely<{ a: A; b: B }>): void
+
+// `MergeQueryBuilder.using()` returns a computed type, the same shape that makes
+// the join result types expensive.
+declare const wideMergeInto: MergeQueryBuilder<
+  { a: A; b: B },
+  'a' | 'b',
+  { a: number }
+>
+declare function acceptsNarrowMergeInto(
+  qb: MergeQueryBuilder<{ a: A; b: B }, 'a', unknown>,
+): void
+
+declare function selectParentId(
+  eb: ExpressionBuilder<
+    {
+      parent: Nullable<Pick<Parent, 'id'>>
+      petJoin: Nullable<Pick<Pet, 'owner_id'>>
+    },
+    'parent' | 'petJoin'
+  >,
+): readonly ['parent.id']
+
+console.log('generic.bench.ts:\n')
+
+bench.baseline(() => {})
+
+bench('SelectQueryBuilder assignable to narrower SelectQueryBuilder', () => {
+  return acceptsNarrowSelectQueryBuilder(wideSelectQueryBuilder)
+}).types([45134, 'instantiations'])
+
+bench('ExpressionBuilder assignable to narrower ExpressionBuilder', () => {
+  return acceptsNarrowExpressionBuilder(wideExpressionBuilder)
+}).types([55494, 'instantiations'])
+
+bench('ExpressionBuilder passed to function expecting fewer tables', () => {
+  return acceptsTwoTableExpressionBuilder(threeTableExpressionBuilder)
+}).types([55545, 'instantiations'])
+
+bench('select(genericSelectHelper) on a left joined query', () => {
+  return kysely
+    .selectFrom('parent')
+    .leftJoin('person as personJoin', 'personJoin.parent_id', 'parent.id')
+    .leftJoin('pet as petJoin', 'petJoin.owner_id', 'personJoin.id')
+    .select(selectParentId)
+}).types([57871, 'instantiations'])
+
+bench('DeleteQueryBuilder assignable to narrower DeleteQueryBuilder', () => {
+  return acceptsNarrowDeleteQueryBuilder(wideDeleteQueryBuilder)
+}).types([10920, 'instantiations'])
+
+bench('UpdateQueryBuilder assignable to narrower UpdateQueryBuilder', () => {
+  return acceptsNarrowUpdateQueryBuilder(wideUpdateQueryBuilder)
+}).types([91178, 'instantiations'])
+
+bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
+  return acceptsNarrowMergeQueryBuilder(wideMergeQueryBuilder)
+}).types([7573, 'instantiations'])
+
+bench('Transaction assignable to Kysely', () => {
+  return acceptsKysely(transaction)
+}).types([162352, 'instantiations'])
+
+bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
+  return acceptsNarrowMergeInto(wideMergeInto)
+}).types([22733, 'instantiations'])

--- a/test/ts-benchmarks/group-by.bench.ts
+++ b/test/ts-benchmarks/group-by.bench.ts
@@ -17,42 +17,42 @@ bench.baseline(() => {
 
 bench('kysely..groupBy(column)', () =>
   query.groupBy('col_164b7896ec8e770207febe0812c5f052'),
-).types([182, 'instantiations'])
+).types([190, 'instantiations'])
 
 bench('kysely..groupBy(~column)', () =>
   // @ts-expect-error
   query.groupBy('col_164b7896ec8e770207febe0812c5f052_'),
-).types([211, 'instantiations'])
+).types([223, 'instantiations'])
 
 bench('kysely..groupBy(table.column)', () =>
   query.groupBy('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([182, 'instantiations'])
+).types([190, 'instantiations'])
 
 bench('kysely..groupBy(~table.column)', () =>
   // @ts-expect-error
   query.groupBy('my_table.col_164b7896ec8e770207febe0812c5f052_'),
-).types([211, 'instantiations'])
+).types([223, 'instantiations'])
 
 bench('kysely..groupBy(sql)', () =>
   query.groupBy(sql`col_164b7896ec8e770207febe0812c5f052`),
-).types([224, 'instantiations'])
+).types([236, 'instantiations'])
 
 bench('kysely..groupBy(eb => ref)', () =>
   query.groupBy((eb) => eb.ref('col_164b7896ec8e770207febe0812c5f052')),
-).types([958, 'instantiations'])
+).types([974, 'instantiations'])
 
 bench('kysely..groupBy(column).groupBy(column)', () =>
   query
     .groupBy('col_164b7896ec8e770207febe0812c5f052')
     .groupBy('col_1d726898491fbca9a8dac855d2be1be8'),
-).types([186, 'instantiations'])
+).types([194, 'instantiations'])
 
 bench('kysely..groupBy([column, column])', () =>
   query.groupBy([
     'col_164b7896ec8e770207febe0812c5f052',
     'col_6f7a0a5f582c69dd4c6be0a819e862cb',
   ]),
-).types([213, 'instantiations'])
+).types([225, 'instantiations'])
 
 bench('kysely..groupBy([column, ~column])', () =>
   query.groupBy([
@@ -60,33 +60,33 @@ bench('kysely..groupBy([column, ~column])', () =>
     // @ts-expect-error
     'col_6f7a0a5f582c69dd4c6be0a819e862cb_',
   ]),
-).types([255, 'instantiations'])
+).types([267, 'instantiations'])
 
 //
 
 bench('kyselyAny..groupBy(column)', () =>
   queryAny.groupBy('col_164b7896ec8e770207febe0812c5f052'),
-).types([182, 'instantiations'])
+).types([190, 'instantiations'])
 
 bench('kyselyAny..groupBy(~column)', () =>
   queryAny.groupBy('col_164b7896ec8e770207febe0812c5f052_'),
-).types([182, 'instantiations'])
+).types([190, 'instantiations'])
 
 bench('kyselyAny..groupBy(table.column)', () =>
   queryAny.groupBy('my_table.col_164b7896ec8e770207febe0812c5f052'),
-).types([182, 'instantiations'])
+).types([190, 'instantiations'])
 
 bench('kyselyAny..groupBy(sql)', () =>
   queryAny.groupBy(sql`col_164b7896ec8e770207febe0812c5f052`),
-).types([224, 'instantiations'])
+).types([236, 'instantiations'])
 
 bench('kyselyAny..groupBy(eb => ref)', () =>
   queryAny.groupBy((eb) => eb.ref('col_164b7896ec8e770207febe0812c5f052')),
-).types([635, 'instantiations'])
+).types([651, 'instantiations'])
 
 bench('kyselyAny..groupBy([column, column])', () =>
   queryAny.groupBy([
     'col_164b7896ec8e770207febe0812c5f052',
     'col_6f7a0a5f582c69dd4c6be0a819e862cb',
   ]),
-).types([213, 'instantiations'])
+).types([225, 'instantiations'])

--- a/test/ts-benchmarks/having.bench.ts
+++ b/test/ts-benchmarks/having.bench.ts
@@ -17,25 +17,25 @@ bench.baseline(() => {
 
 bench('kysely..having(column, op, value)', () =>
   query.having('col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([2186, 'instantiations'])
+).types([2210, 'instantiations'])
 
 bench('kysely..having(~column, op, value)', () =>
   // @ts-expect-error
   query.having('col_1d726898491fbca9a8dac855d2be1be8_', '=', 123),
-).types([3437, 'instantiations'])
+).types([3461, 'instantiations'])
 
 bench('kysely..having(table.column, op, value)', () =>
   query.having('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([2189, 'instantiations'])
+).types([2213, 'instantiations'])
 
 bench('kysely..having(~table.column, op, value)', () =>
   // @ts-expect-error
   query.having('my_table_.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([3437, 'instantiations'])
+).types([3461, 'instantiations'])
 
 bench('kysely..having(column, is, null)', () =>
   query.having('col_6f5e1903664b084bf6197f2b86849d5e', 'is', null),
-).types([2192, 'instantiations'])
+).types([2216, 'instantiations'])
 
 bench('kysely..having(column, op, select)', () =>
   query.having(
@@ -46,11 +46,11 @@ bench('kysely..having(column, op, select)', () =>
       .select('t2.col_1d726898491fbca9a8dac855d2be1be8')
       .limit(1),
   ),
-).types([3290, 'instantiations'])
+).types([3329, 'instantiations'])
 
 bench('kysely..having(eb => eb(...))', () =>
   query.having((eb) => eb('col_1d726898491fbca9a8dac855d2be1be8', '=', 123)),
-).types([2775, 'instantiations'])
+).types([2799, 'instantiations'])
 
 bench('kysely..having(eb => eb.and([...]))', () =>
   query.having((eb) =>
@@ -59,11 +59,11 @@ bench('kysely..having(eb => eb.and([...]))', () =>
       eb('col_4d742b2f247bec99b41a60acbebc149a', '=', 456),
     ]),
   ),
-).types([2870, 'instantiations'])
+).types([2894, 'instantiations'])
 
 bench('kysely..having(sql`...`)', () =>
   query.having(sql<boolean>`col = 'foo'`),
-).types([37, 'instantiations'])
+).types([45, 'instantiations'])
 
 bench('kysely..havingRef(column, op, column)', () =>
   query.havingRef(
@@ -71,7 +71,7 @@ bench('kysely..havingRef(column, op, column)', () =>
     '=',
     'col_4d742b2f247bec99b41a60acbebc149a',
   ),
-).types([134, 'instantiations'])
+).types([142, 'instantiations'])
 
 bench('kysely..havingRef(~column, op, column)', () =>
   query.havingRef(
@@ -80,29 +80,29 @@ bench('kysely..havingRef(~column, op, column)', () =>
     '=',
     'col_4d742b2f247bec99b41a60acbebc149a',
   ),
-).types([143, 'instantiations'])
+).types([155, 'instantiations'])
 
 //
 
 bench('kyselyAny..having(column, op, value)', () =>
   queryAny.having('col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([683, 'instantiations'])
+).types([707, 'instantiations'])
 
 bench('kyselyAny..having(~column, op, value)', () =>
   queryAny.having('col_1d726898491fbca9a8dac855d2be1be8_', '=', 123),
-).types([683, 'instantiations'])
+).types([707, 'instantiations'])
 
 bench('kyselyAny..having(table.column, op, value)', () =>
   queryAny.having('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([669, 'instantiations'])
+).types([693, 'instantiations'])
 
 bench('kyselyAny..having(eb => eb(...))', () =>
   queryAny.having((eb) => eb('col_1d726898491fbca9a8dac855d2be1be8', '=', 123)),
-).types([955, 'instantiations'])
+).types([979, 'instantiations'])
 
 bench('kyselyAny..having(sql`...`)', () =>
   queryAny.having(sql<boolean>`col = 'foo'`),
-).types([37, 'instantiations'])
+).types([45, 'instantiations'])
 
 bench('kyselyAny..havingRef(column, op, column)', () =>
   queryAny.havingRef(
@@ -110,4 +110,4 @@ bench('kyselyAny..havingRef(column, op, column)', () =>
     '=',
     'col_4d742b2f247bec99b41a60acbebc149a',
   ),
-).types([134, 'instantiations'])
+).types([142, 'instantiations'])

--- a/test/ts-benchmarks/inner-join.bench.ts
+++ b/test/ts-benchmarks/inner-join.bench.ts
@@ -21,7 +21,7 @@ bench('kysely..innerJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6275, 'instantiations'])
+).types([6538, 'instantiations'])
 
 bench('kysely..innerJoin(~table, k1, k2)', () =>
   query.innerJoin(
@@ -30,7 +30,7 @@ bench('kysely..innerJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([31508, 'instantiations'])
+).types([21845, 'instantiations'])
 
 bench('kysely..innerJoin(table, ~k1, k2)', () =>
   query.innerJoin(
@@ -39,7 +39,7 @@ bench('kysely..innerJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6823, 'instantiations'])
+).types([7086, 'instantiations'])
 
 bench('kysely..innerJoin(table, k1, ~k2)', () =>
   query.innerJoin(
@@ -48,7 +48,7 @@ bench('kysely..innerJoin(table, k1, ~k2)', () =>
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([6826, 'instantiations'])
+).types([7089, 'instantiations'])
 
 bench('kysely..innerJoin(table as alias, k1, k2)', () =>
   query.innerJoin(
@@ -56,7 +56,7 @@ bench('kysely..innerJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6271, 'instantiations'])
+).types([6534, 'instantiations'])
 
 bench('kysely..innerJoin(table, cb)', () =>
   query.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -66,7 +66,7 @@ bench('kysely..innerJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([3077, 'instantiations'])
+).types([2246, 'instantiations'])
 
 bench('kysely..innerJoin(table, cb with ~column)', () =>
   query.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -77,7 +77,7 @@ bench('kysely..innerJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([3129, 'instantiations'])
+).types([2302, 'instantiations'])
 
 //
 
@@ -87,7 +87,7 @@ bench('kyselyAny..innerJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([867, 'instantiations'])
+).types([883, 'instantiations'])
 
 bench('kyselyAny..innerJoin(~table, k1, k2)', () =>
   queryAny.innerJoin(
@@ -95,7 +95,7 @@ bench('kyselyAny..innerJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([867, 'instantiations'])
+).types([883, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, ~k1, k2)', () =>
   queryAny.innerJoin(
@@ -103,7 +103,7 @@ bench('kyselyAny..innerJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([867, 'instantiations'])
+).types([883, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, k1, ~k2)', () =>
   queryAny.innerJoin(
@@ -111,7 +111,7 @@ bench('kyselyAny..innerJoin(table, k1, ~k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([867, 'instantiations'])
+).types([883, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table as alias, k1, k2)', () =>
   queryAny.innerJoin(
@@ -119,7 +119,7 @@ bench('kyselyAny..innerJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([865, 'instantiations'])
+).types([881, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, cb)', () =>
   queryAny.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -129,7 +129,7 @@ bench('kyselyAny..innerJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2577, 'instantiations'])
+).types([1499, 'instantiations'])
 
 bench('kyselyAny..innerJoin(table, cb with ~column)', () =>
   queryAny.innerJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -139,4 +139,4 @@ bench('kyselyAny..innerJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2577, 'instantiations'])
+).types([1499, 'instantiations'])

--- a/test/ts-benchmarks/left-join.bench.ts
+++ b/test/ts-benchmarks/left-join.bench.ts
@@ -21,7 +21,7 @@ bench('kysely..leftJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6283, 'instantiations'])
+).types([6546, 'instantiations'])
 
 bench('kysely..leftJoin(~table, k1, k2)', () =>
   query.leftJoin(
@@ -30,7 +30,7 @@ bench('kysely..leftJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([33476, 'instantiations'])
+).types([21845, 'instantiations'])
 
 bench('kysely..leftJoin(table, ~k1, k2)', () =>
   query.leftJoin(
@@ -39,7 +39,7 @@ bench('kysely..leftJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6831, 'instantiations'])
+).types([7094, 'instantiations'])
 
 bench('kysely..leftJoin(table, k1, ~k2)', () =>
   query.leftJoin(
@@ -48,7 +48,7 @@ bench('kysely..leftJoin(table, k1, ~k2)', () =>
     // @ts-expect-error
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([6834, 'instantiations'])
+).types([7097, 'instantiations'])
 
 bench('kysely..leftJoin(table as alias, k1, k2)', () =>
   query.leftJoin(
@@ -56,7 +56,7 @@ bench('kysely..leftJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([6271, 'instantiations'])
+).types([6534, 'instantiations'])
 
 bench('kysely..leftJoin(table, cb)', () =>
   query.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -66,7 +66,7 @@ bench('kysely..leftJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([3085, 'instantiations'])
+).types([2254, 'instantiations'])
 
 bench('kysely..leftJoin(table, cb with ~column)', () =>
   query.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -77,7 +77,7 @@ bench('kysely..leftJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([3137, 'instantiations'])
+).types([2310, 'instantiations'])
 
 //
 
@@ -87,7 +87,7 @@ bench('kyselyAny..leftJoin(table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([875, 'instantiations'])
+).types([891, 'instantiations'])
 
 bench('kyselyAny..leftJoin(~table, k1, k2)', () =>
   queryAny.leftJoin(
@@ -95,7 +95,7 @@ bench('kyselyAny..leftJoin(~table, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([875, 'instantiations'])
+).types([891, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, ~k1, k2)', () =>
   queryAny.leftJoin(
@@ -103,7 +103,7 @@ bench('kyselyAny..leftJoin(table, ~k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052_',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([875, 'instantiations'])
+).types([891, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, k1, ~k2)', () =>
   queryAny.leftJoin(
@@ -111,7 +111,7 @@ bench('kyselyAny..leftJoin(table, k1, ~k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4_',
   ),
-).types([875, 'instantiations'])
+).types([891, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table as alias, k1, k2)', () =>
   queryAny.leftJoin(
@@ -119,7 +119,7 @@ bench('kyselyAny..leftJoin(table as alias, k1, k2)', () =>
     'my_table.col_164b7896ec8e770207febe0812c5f052',
     't2.col_454ff479a3b5a9ef082d9be9ac02a6f4',
   ),
-).types([865, 'instantiations'])
+).types([881, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, cb)', () =>
   queryAny.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -129,7 +129,7 @@ bench('kyselyAny..leftJoin(table, cb)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2585, 'instantiations'])
+).types([1507, 'instantiations'])
 
 bench('kyselyAny..leftJoin(table, cb with ~column)', () =>
   queryAny.leftJoin('table_000a8a0cb7f265a624c851d3e7f8b946', (join) =>
@@ -139,4 +139,4 @@ bench('kyselyAny..leftJoin(table, cb with ~column)', () =>
       'table_000a8a0cb7f265a624c851d3e7f8b946.col_454ff479a3b5a9ef082d9be9ac02a6f4',
     ),
   ),
-).types([2585, 'instantiations'])
+).types([1507, 'instantiations'])

--- a/test/ts-benchmarks/order-by.bench.ts
+++ b/test/ts-benchmarks/order-by.bench.ts
@@ -28,45 +28,45 @@ bench.baseline(() => {
 
 bench('kysely..orderBy(column)', () =>
   query.orderBy('col_164b7896ec8e770207febe0812c5f052'),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kysely..orderBy(~column)', () =>
   // @ts-expect-error
   query.orderBy('col_164b7896ec8e770207febe0812c5f052_'),
-).types([189, 'instantiations'])
+).types([201, 'instantiations'])
 
 bench('kysely..orderBy(O)', () => query.orderBy('e862ca')).types([
-  69,
+  77,
   'instantiations',
 ])
 
 bench('kysely..orderBy(column, asc)', () =>
   query.orderBy('col_164b7896ec8e770207febe0812c5f052', 'asc'),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kysely..orderBy(~column, asc)', () =>
   // @ts-expect-error
   query.orderBy('col_164b7896ec8e770207febe0812c5f052_', 'asc'),
-).types([113, 'instantiations'])
+).types([125, 'instantiations'])
 
 bench('kysely..orderBy(column, ~asc)', () =>
   // @ts-expect-error
   query.orderBy('col_164b7896ec8e770207febe0812c5f052', 'asc_'),
-).types([103, 'instantiations'])
+).types([111, 'instantiations'])
 
 bench('kysely..orderBy(column, desc)', () =>
   query.orderBy('col_164b7896ec8e770207febe0812c5f052', 'desc'),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kysely..orderBy(column, ob)', async () =>
   query.orderBy('col_164b7896ec8e770207febe0812c5f052', (ob) =>
     ob.asc().nullsLast(),
   ),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kysely..orderBy(sql)', () =>
   query.orderBy(sql`col_164b7896ec8e770207febe0812c5f052 asc nulls first`),
-).types([94, 'instantiations'])
+).types([106, 'instantiations'])
 
 bench('kysely..orderBy(select)', () =>
   query.orderBy(
@@ -77,7 +77,7 @@ bench('kysely..orderBy(select)', () =>
       )
       .limit(1),
   ),
-).types([525, 'instantiations'])
+).types([556, 'instantiations'])
 
 bench('kysely..orderBy(eb => select)', () =>
   query.orderBy((eb) =>
@@ -88,48 +88,48 @@ bench('kysely..orderBy(eb => select)', () =>
       )
       .limit(1),
   ),
-).types([674, 'instantiations'])
+).types([713, 'instantiations'])
 
 bench('deprecated - kysely..orderBy(column desc)', () =>
   query.orderBy('col_164b7896ec8e770207febe0812c5f052 desc'),
-).types([170, 'instantiations'])
+).types([182, 'instantiations'])
 
 bench('deprecated - kysely..orderBy([column])', () =>
   query.orderBy(['col_164b7896ec8e770207febe0812c5f052']),
-).types([152, 'instantiations'])
+).types([164, 'instantiations'])
 
 bench('kysely..orderBy(column).orderBy(column)', () =>
   query
     .orderBy('col_164b7896ec8e770207febe0812c5f052')
     .orderBy('col_1d726898491fbca9a8dac855d2be1be8'),
-).types([75, 'instantiations'])
+).types([83, 'instantiations'])
 
 bench('deprecated - kysely..orderBy([column, column])', () =>
   query.orderBy([
     'col_164b7896ec8e770207febe0812c5f052',
     'col_6f7a0a5f582c69dd4c6be0a819e862cb',
   ]),
-).types([152, 'instantiations'])
+).types([164, 'instantiations'])
 
 bench('kysely..orderBy(column).orderBy(column, desc)', () =>
   query
     .orderBy('col_1d726898491fbca9a8dac855d2be1be8')
     .orderBy('col_164b7896ec8e770207febe0812c5f052', 'desc'),
-).types([75, 'instantiations'])
+).types([83, 'instantiations'])
 
 bench('deprecated - kysely..orderBy([column, column desc])', () =>
   query.orderBy([
     'col_6f7a0a5f582c69dd4c6be0a819e862cb',
     'col_164b7896ec8e770207febe0812c5f052 desc',
   ]),
-).types([152, 'instantiations'])
+).types([164, 'instantiations'])
 
 bench('kysely..orderBy(column).orderBy(column).orderBy(column)', () =>
   query
     .orderBy('col_164b7896ec8e770207febe0812c5f052')
     .orderBy('col_1d726898491fbca9a8dac855d2be1be8')
     .orderBy('col_af4e225b70a9bbd83cc3bc0e7ef24cfa'),
-).types([81, 'instantiations'])
+).types([89, 'instantiations'])
 
 bench('deprecated - kysely..orderBy([column, column, column])', () =>
   query.orderBy([
@@ -137,49 +137,49 @@ bench('deprecated - kysely..orderBy([column, column, column])', () =>
     'col_6f7a0a5f582c69dd4c6be0a819e862cb',
     'col_af4e225b70a9bbd83cc3bc0e7ef24cfa',
   ]),
-).types([152, 'instantiations'])
+).types([164, 'instantiations'])
 
 //
 
 bench('kyselyAny..orderBy(column)', () =>
   queryAny.orderBy('col_164b7896ec8e770207febe0812c5f052'),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kyselyAny..orderBy(~column)', () =>
   queryAny.orderBy('col_164b7896ec8e770207febe0812c5f052_'),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kyselyAny..orderBy(O)', () => queryAny.orderBy('e862ca')).types([
-  69,
+  77,
   'instantiations',
 ])
 
 bench('kyselyAny..orderBy(column, asc)', () =>
   queryAny.orderBy('col_164b7896ec8e770207febe0812c5f052', 'asc'),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kyselyAny..orderBy(~column, asc)', () =>
   queryAny.orderBy('col_164b7896ec8e770207febe0812c5f052_', 'asc'),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kyselyAny..orderBy(column, ~asc)', () =>
   // @ts-expect-error
   queryAny.orderBy('col_164b7896ec8e770207febe0812c5f052', 'asc_'),
-).types([103, 'instantiations'])
+).types([111, 'instantiations'])
 
 bench('kyselyAny..orderBy(column, desc)', () =>
   queryAny.orderBy('col_164b7896ec8e770207febe0812c5f052', 'desc'),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kyselyAny..orderBy(column, ob)', async () =>
   queryAny.orderBy('col_164b7896ec8e770207febe0812c5f052', (ob) =>
     ob.asc().nullsLast(),
   ),
-).types([69, 'instantiations'])
+).types([77, 'instantiations'])
 
 bench('kyselyAny..orderBy(sql)', () =>
   queryAny.orderBy(sql`col_164b7896ec8e770207febe0812c5f052 asc nulls first`),
-).types([94, 'instantiations'])
+).types([106, 'instantiations'])
 
 bench('kyselyAny..orderBy(select)', () =>
   queryAny.orderBy(
@@ -190,7 +190,7 @@ bench('kyselyAny..orderBy(select)', () =>
       )
       .limit(1),
   ),
-).types([267, 'instantiations'])
+).types([298, 'instantiations'])
 
 bench('kyselyAny..orderBy(eb => select)', () =>
   queryAny.orderBy((eb) =>
@@ -199,4 +199,4 @@ bench('kyselyAny..orderBy(eb => select)', () =>
       .select('col_164b7896ec8e770207febe0812c5f052')
       .limit(1),
   ),
-).types([356, 'instantiations'])
+).types([395, 'instantiations'])

--- a/test/ts-benchmarks/where.bench.ts
+++ b/test/ts-benchmarks/where.bench.ts
@@ -17,25 +17,25 @@ bench.baseline(() => {
 
 bench('kysely..where(column, op, value)', () =>
   query.where('col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([2186, 'instantiations'])
+).types([2210, 'instantiations'])
 
 bench('kysely..where(~column, op, value)', () =>
   // @ts-expect-error
   query.where('col_1d726898491fbca9a8dac855d2be1be8_', '=', 123),
-).types([3437, 'instantiations'])
+).types([3461, 'instantiations'])
 
 bench('kysely..where(table.column, op, value)', () =>
   query.where('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([2189, 'instantiations'])
+).types([2213, 'instantiations'])
 
 bench('kysely..where(~table.column, op, value)', () =>
   // @ts-expect-error
   query.where('my_table_.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([3437, 'instantiations'])
+).types([3461, 'instantiations'])
 
 bench('kysely..where(column, is, null)', () =>
   query.where('col_6f5e1903664b084bf6197f2b86849d5e', 'is', null),
-).types([2192, 'instantiations'])
+).types([2216, 'instantiations'])
 
 bench('kysely..where(column, op, select)', () =>
   query.where(
@@ -46,11 +46,11 @@ bench('kysely..where(column, op, select)', () =>
       .select('t2.col_1d726898491fbca9a8dac855d2be1be8')
       .limit(1),
   ),
-).types([3290, 'instantiations'])
+).types([3329, 'instantiations'])
 
 bench('kysely..where(eb => eb(...))', () =>
   query.where((eb) => eb('col_1d726898491fbca9a8dac855d2be1be8', '=', 123)),
-).types([2775, 'instantiations'])
+).types([2799, 'instantiations'])
 
 bench('kysely..where(eb => eb.and([...]))', () =>
   query.where((eb) =>
@@ -59,11 +59,11 @@ bench('kysely..where(eb => eb.and([...]))', () =>
       eb('col_4d742b2f247bec99b41a60acbebc149a', '=', 456),
     ]),
   ),
-).types([2870, 'instantiations'])
+).types([2894, 'instantiations'])
 
 bench('kysely..where(sql`...`)', () =>
   query.where(sql<boolean>`col = 'foo'`),
-).types([37, 'instantiations'])
+).types([45, 'instantiations'])
 
 bench('kysely..whereRef(column, op, column)', () =>
   query.whereRef(
@@ -71,7 +71,7 @@ bench('kysely..whereRef(column, op, column)', () =>
     '=',
     'col_4d742b2f247bec99b41a60acbebc149a',
   ),
-).types([134, 'instantiations'])
+).types([142, 'instantiations'])
 
 bench('kysely..whereRef(~column, op, column)', () =>
   query.whereRef(
@@ -80,29 +80,29 @@ bench('kysely..whereRef(~column, op, column)', () =>
     '=',
     'col_4d742b2f247bec99b41a60acbebc149a',
   ),
-).types([143, 'instantiations'])
+).types([155, 'instantiations'])
 
 //
 
 bench('kyselyAny..where(column, op, value)', () =>
   queryAny.where('col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([683, 'instantiations'])
+).types([707, 'instantiations'])
 
 bench('kyselyAny..where(~column, op, value)', () =>
   queryAny.where('col_1d726898491fbca9a8dac855d2be1be8_', '=', 123),
-).types([683, 'instantiations'])
+).types([707, 'instantiations'])
 
 bench('kyselyAny..where(table.column, op, value)', () =>
   queryAny.where('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 123),
-).types([669, 'instantiations'])
+).types([693, 'instantiations'])
 
 bench('kyselyAny..where(eb => eb(...))', () =>
   queryAny.where((eb) => eb('col_1d726898491fbca9a8dac855d2be1be8', '=', 123)),
-).types([955, 'instantiations'])
+).types([979, 'instantiations'])
 
 bench('kyselyAny..where(sql`...`)', () =>
   queryAny.where(sql<boolean>`col = 'foo'`),
-).types([37, 'instantiations'])
+).types([45, 'instantiations'])
 
 bench('kyselyAny..whereRef(column, op, column)', () =>
   queryAny.whereRef(
@@ -110,4 +110,4 @@ bench('kyselyAny..whereRef(column, op, column)', () =>
     '=',
     'col_4d742b2f247bec99b41a60acbebc149a',
   ),
-).types([134, 'instantiations'])
+).types([142, 'instantiations'])

--- a/test/ts-benchmarks/with.bench.ts
+++ b/test/ts-benchmarks/with.bench.ts
@@ -19,11 +19,11 @@ bench('kysely.with(cte, qc => qc.insertInto(table))', () => {
 
 bench('kysely.with(cte, qc => qc.updateTable(table))', () => {
   return kysely.with('cte', (qc) => qc.updateTable('my_table').returningAll())
-}).types([23981, 'instantiations'])
+}).types([23938, 'instantiations'])
 
 bench('kysely.with(cte, qc => qc.deleteFrom(table))', () => {
   return kysely.with('cte', (qc) => qc.deleteFrom('my_table').returningAll())
-}).types([20717, 'instantiations'])
+}).types([11503, 'instantiations'])
 
 bench('kyselyAny.with(cte, qc => qc.selectFrom(table))', () => {
   return kyselyAny.with('cte', (qc) => qc.selectFrom('my_table').selectAll())
@@ -37,11 +37,11 @@ bench('kyselyAny.with(cte, qc => qc.updateTable(table))', () => {
   return kyselyAny.with('cte', (qc) =>
     qc.updateTable('my_table').returningAll(),
   )
-}).types([23771, 'instantiations'])
+}).types([23728, 'instantiations'])
 
 bench('kyselyAny.with(cte, qc => qc.deleteFrom(table))', () => {
   return kyselyAny.with('cte', (qc) => qc.deleteFrom('my_table').returningAll())
-}).types([20507, 'instantiations'])
+}).types([11299, 'instantiations'])
 
 bench('kysely.with(cte, () => selectQuery)', () => {
   return kysely.with('cte', () => kysely.selectFrom('my_table').selectAll())
@@ -53,11 +53,11 @@ bench('kysely.with(cte, () => insertQuery)', () => {
 
 bench('kysely.with(cte, () => updateQuery)', () => {
   return kysely.with('cte', () => kysely.updateTable('my_table').returningAll())
-}).types([23969, 'instantiations'])
+}).types([23926, 'instantiations'])
 
 bench('kysely.with(cte, () => deleteQuery)', () => {
   return kysely.with('cte', () => kysely.deleteFrom('my_table').returningAll())
-}).types([20705, 'instantiations'])
+}).types([11491, 'instantiations'])
 
 bench('kyselyAny.with(cte, () => selectQuery)', () => {
   return kyselyAny.with('cte', () =>
@@ -75,13 +75,13 @@ bench('kyselyAny.with(cte, () => updateQuery)', () => {
   return kyselyAny.with('cte', () =>
     kyselyAny.updateTable('my_table').returningAll(),
   )
-}).types([23759, 'instantiations'])
+}).types([23716, 'instantiations'])
 
 bench('kyselyAny.with(cte, () => deleteQuery)', () => {
   return kyselyAny.with('cte', () =>
     kyselyAny.deleteFrom('my_table').returningAll(),
   )
-}).types([20495, 'instantiations'])
+}).types([11287, 'instantiations'])
 
 bench('kysely.with(cte, selectQuery)', () => {
   return kysely.with('cte', kysely.selectFrom('my_table').selectAll())
@@ -93,11 +93,11 @@ bench('kysely.with(cte, insertQuery)', () => {
 
 bench('kysely.with(cte, updateQuery)', () => {
   return kysely.with('cte', kysely.updateTable('my_table').returningAll())
-}).types([24013, 'instantiations'])
+}).types([23970, 'instantiations'])
 
 bench('kysely.with(cte, deleteQuery)', () => {
   return kysely.with('cte', kysely.deleteFrom('my_table').returningAll())
-}).types([20750, 'instantiations'])
+}).types([11536, 'instantiations'])
 
 bench('kyselyAny.with(cte, selectQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.selectFrom('my_table').selectAll())
@@ -109,8 +109,8 @@ bench('kyselyAny.with(cte, insertQuery)', () => {
 
 bench('kyselyAny.with(cte, updateQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.updateTable('my_table').returningAll())
-}).types([23803, 'instantiations'])
+}).types([23760, 'instantiations'])
 
 bench('kyselyAny.with(cte, deleteQuery)', () => {
   return kyselyAny.with('cte', kyselyAny.deleteFrom('my_table').returningAll())
-}).types([20540, 'instantiations'])
+}).types([11332, 'instantiations'])

--- a/test/typings/test-d/generic.test-d.ts
+++ b/test/typings/test-d/generic.test-d.ts
@@ -11,7 +11,35 @@ import type {
 import { expectAssignable, expectType } from 'tsd'
 import type { Database, Movie, Person } from '../shared.js'
 
-// TODO: type-checking this is crazy slow. Figure out the cause.
+// The tests below relate two different instantiations of the same builder type.
+// TypeScript can't derive variance for `SelectQueryBuilder` or `ExpressionBuilder`
+// (both mention their `DB`/`TB` parameters under `keyof` and in conditional types),
+// so it has to compare them structurally, member by member. That makes these the
+// most expensive type-level operations in the library, so two rules keep them in
+// check - breaking either one is easy to do by accident and expensive:
+//
+//   1. A method that accepts a `DB`/`TB`-parameterized expression type must keep it
+//      behind a generic type parameter (`limit<VE extends ValueExpression<...>>(v: VE)`,
+//      not `limit(v: ValueExpression<...>)`). Otherwise the comparison expands the
+//      whole expression union, which pulls in `ExpressionBuilder`, which pulls in
+//      `SelectQueryBuilder` again.
+//
+//   2. A method whose result type is computed from the arguments must converge when
+//      asked what it returns for an *unknown* argument, because that is what the
+//      compiler computes while comparing two builders. If it instead expands into a
+//      union of builders, the comparison recurses until the compiler's internal
+//      limit - and that limit is not the same across TypeScript versions. The join
+//      result types guard against this with `TableExpression<DB, TB> extends TE`, and
+//      `UpdateQueryBuilder.$if`/`DeleteQueryBuilder.$if` with `unknown extends O2`.
+//
+// Note that such a guard is only worth adding where it *replaces* a conditional that
+// would otherwise expand into a union of builders. Adding one to a result type that is
+// already a single type makes things dramatically worse, because the guard is itself a
+// conditional - it was measured at 15x on `Kysely.$extendTables` and friends. Not every
+// expensive comparison is worth guarding either: the guard has a fixed cost of its own,
+// so it only pays where the recursion actually blows up.
+//
+// See `test/ts-benchmarks/generic.bench.ts`.
 function testSelectQueryBuilderExtends() {
   type A = { a: number }
   type B = { b: string }
@@ -25,7 +53,6 @@ function testSelectQueryBuilderExtends() {
   expectAssignable<T1>(t2)
 }
 
-// TODO: type-checking this is crazy slow. Figure out the cause.
 function testExpressionBuilderExtends() {
   type A = { a: number }
   type B = { b: string }
@@ -39,7 +66,6 @@ function testExpressionBuilderExtends() {
   expectAssignable<T1>(t2)
 }
 
-// TODO: type-checking this is crazy slow. Figure out the cause.
 function testExpressionBuilderExtendsFuncArg() {
   type A = { a: number }
   type B = { b: string }
@@ -56,7 +82,6 @@ function testExpressionBuilderExtendsFuncArg() {
   test(t2)
 }
 
-// TODO: type-checking this is crazy slow. Figure out the cause.
 async function testGenericSelectHelper() {
   type Parent = { id: Generated<string> }
   type Person = { id: Generated<string>; parent_id: string }


### PR DESCRIPTION
This issue has existed a long time and I haven't been able to figure out how to fix it. We had a bunch of type tests with a TODO comment about insane slowness. Those cases are now fixed. Mostly thanks to Opus 5.

This fix makes the benchmark linked in the typescript issue https://github.com/microsoft/typescript-go/issues/4579 ~100x faster on ts7. The pathological cases got about 50% faster on TS5/6 as well.

Results for https://github.com/XiNiHa/kysely-tsgo-slower/blob/main/src/index.ts:

| compiler | instantiations before | instantiations after | change | check time before | check time after | change | total time before | total time after |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| TS 5.9.2 | 599,095 | 83,325 | **−86%** | 0.51s | 0.22s | −57% | 0.95s | 0.67s |
| TS 6.0.3 | 601,143 | 93,113 | **−85%** | 0.52s | 0.25s | −52% | 0.68s | 0.48s |
| TS 7.0.2 | 9,795,115 | 94,536 | **−99.0%** | 2.794s | 0.056s | **−98%** | 2.81s | 0.073s |

See #1947 (maybe this closes it?)