### PR TITLE
remove recursive type checks from Kysely and subtypes

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -94,7 +94,33 @@ Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose')
  *    in the database and values must be interfaces that describe the rows in those
  *    tables. See the examples above.
  */
-export class Kysely<DB>
+// Why `in out DB` here and on the other generic types in this file:
+//
+// To relate two *different* instantiations of the same generic type - say
+// `Kysely<DB1>` to `Kysely<DB2>` - TypeScript first needs the variance of each
+// type parameter. Nothing declared it, so the compiler measured it: it
+// instantiates the type twice with synthetic marker types and relates the two
+// results structurally, member by member.
+//
+// That measurement was the expensive part, and it didn't terminate on its own.
+// Members like `$extendTables` return the same type over a *recomputed* `DB`, so
+// comparing them starts the whole comparison again one level down, against a `DB`
+// the compiler hasn't seen before and so can't match against a pair already in
+// progress. It only stopped at the compiler's internal recursion limit - and that
+// limit isn't the same across versions, which is why this cost ~5x more on
+// TypeScript 7 than on 6. Relating two `Kysely` types was ~12k type
+// instantiations on TS6 and ~56k on TS7; it is now 2 on both.
+//
+// An explicit annotation skips the measurement entirely: the compiler just uses
+// the declared variance. `in out` (invariant) is the strictest option and the
+// only sound one here - TypeScript rejects `out DB` with TS2636, because
+// `selectFrom` and friends take `keyof DB`.
+//
+// This is not a technique the query builders can borrow. They deliberately let a
+// wider builder stand in for a narrower one, which is bivariance, and bivariance
+// can't be spelled as an annotation. See `test/typings/test-d/generic.test-d.ts`
+// for what keeps those in check instead.
+export class Kysely<in out DB>
   extends QueryCreator<DB>
   implements QueryExecutorProvider, AsyncDisposable
 {
@@ -665,7 +691,7 @@ export type Transaction<DB> = TransactionMethods<DB> & Kysely<DB>
  * return another transaction rather than a plain `Kysely` instance, and the
  * ones a transaction doesn't support.
  */
-export interface TransactionMethods<DB> {
+export interface TransactionMethods<in out DB> {
   /**
    * Always `true` for a transaction.
    *
@@ -901,7 +927,7 @@ export interface KyselyConfig {
   readonly log?: LogConfig
 }
 
-export class ConnectionBuilder<DB> {
+export class ConnectionBuilder<in out DB> {
   readonly #props: ConnectionBuilderProps
 
   constructor(props: ConnectionBuilderProps) {
@@ -929,7 +955,7 @@ export class ConnectionBuilder<DB> {
 
 interface ConnectionBuilderProps extends KyselyProps {}
 
-export class TransactionBuilder<DB> {
+export class TransactionBuilder<in out DB> {
   readonly #props: TransactionBuilderProps
 
   constructor(props: TransactionBuilderProps) {
@@ -996,7 +1022,7 @@ interface TransactionBuilderProps extends KyselyProps {
   readonly isolationLevel?: IsolationLevel
 }
 
-export class ControlledTransactionBuilder<DB> {
+export class ControlledTransactionBuilder<in out DB> {
   readonly #props: TransactionBuilderProps
 
   constructor(props: TransactionBuilderProps) {
@@ -1062,7 +1088,10 @@ export type ControlledTransaction<
  * @typeParam S - The names of the savepoints that are currently open, in the
  *    order they were created.
  */
-export interface ControlledTransactionMethods<DB, S extends string[] = []> {
+export interface ControlledTransactionMethods<
+  in out DB,
+  S extends string[] = [],
+> {
   readonly isCommitted: boolean
 
   readonly isRolledBack: boolean

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -94,22 +94,6 @@ Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose')
  *    in the database and values must be interfaces that describe the rows in those
  *    tables. See the examples above.
  */
-// Why `in out DB` here and on the other generic types in this file:
-//
-// To relate two *different* instantiations of the same generic type - say
-// `Kysely<DB1>` to `Kysely<DB2>` - TypeScript first needs the variance of each
-// type parameter. Nothing declared it, so the compiler measured it: it
-// instantiates the type twice with synthetic marker types and relates the two
-// results structurally, member by member.
-//
-// That measurement was the expensive part, and it didn't terminate on its own.
-// Members like `$extendTables` return the same type over a *recomputed* `DB`, so
-// comparing them starts the whole comparison again one level down, against a `DB`
-// the compiler hasn't seen before and so can't match against a pair already in
-// progress. It only stopped at the compiler's internal recursion limit - and that
-// limit isn't the same across versions, which is why this cost ~5x more on
-// TypeScript 7 than on 6. Relating two `Kysely` types was ~12k type
-// instantiations on TS6 and ~56k on TS7; it is now 2 on both.
 //
 // An explicit annotation skips the measurement entirely: the compiler just uses
 // the declared variance. `in out` (invariant) is the strictest option and the

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -94,16 +94,6 @@ Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose')
  *    in the database and values must be interfaces that describe the rows in those
  *    tables. See the examples above.
  */
-//
-// An explicit annotation skips the measurement entirely: the compiler just uses
-// the declared variance. `in out` (invariant) is the strictest option and the
-// only sound one here - TypeScript rejects `out DB` with TS2636, because
-// `selectFrom` and friends take `keyof DB`.
-//
-// This is not a technique the query builders can borrow. They deliberately let a
-// wider builder stand in for a narrower one, which is bivariance, and bivariance
-// can't be spelled as an annotation. See `test/typings/test-d/generic.test-d.ts`
-// for what keeps those in check instead.
 export class Kysely<in out DB>
   extends QueryCreator<DB>
   implements QueryExecutorProvider, AsyncDisposable

--- a/src/readonly/readonly-kysely.ts
+++ b/src/readonly/readonly-kysely.ts
@@ -4,9 +4,11 @@ import type {
   ConnectionBuilder,
   ControlledTransaction,
   ControlledTransactionBuilder,
+  ControlledTransactionMethods,
   Kysely,
   Transaction,
   TransactionBuilder,
+  TransactionMethods,
 } from '../kysely.js'
 import type {
   ReleaseSavepoint,
@@ -58,7 +60,10 @@ import type { ReadonlyQueryCreator } from './readonly-query-creator.js'
  * db.deleteFrom('person') // typescript compiler error!
  * ```
  */
-export interface ReadonlyKysely<DB>
+// `DB` is `in out` on this and the other read-only types below for the same
+// reason it is on `Kysely`. See the comment above the `Kysely` class in
+// `src/kysely.ts`.
+export interface ReadonlyKysely<in out DB>
   extends
     ReadonlyQueryCreator<DB>,
     Pick<
@@ -156,7 +161,7 @@ export interface ReadonlyKysely<DB>
 /**
  * Similar to {@link ConnectionBuilder} but read-only.
  */
-export interface ReadonlyConnectionBuilder<DB> extends Omit<
+export interface ReadonlyConnectionBuilder<in out DB> extends Omit<
   ConnectionBuilder<DB>,
   'execute'
 > {
@@ -172,7 +177,7 @@ export interface ReadonlyConnectionBuilder<DB> extends Omit<
 /**
  * Similar to {@link TransactionBuilder} but read-only.
  */
-export interface ReadonlyTransactionBuilder<DB> {
+export interface ReadonlyTransactionBuilder<in out DB> {
   /**
    * Similar to {@link TransactionBuilder.execute} but read-only.
    */
@@ -193,36 +198,58 @@ export interface ReadonlyTransactionBuilder<DB> {
 
 /**
  * Similar to {@link Transaction} but read-only.
+ *
+ * Like {@link Transaction}, this is an intersection of
+ * {@link ReadonlyTransactionMethods} and {@link ReadonlyKysely} rather than an
+ * interface that repeats their members, for type check performance reasons.
+ *
+ * Spelling it this way is what makes a `ReadonlyTransaction` usable where a
+ * {@link ReadonlyKysely} is expected: the compiler finds the very same
+ * `ReadonlyKysely<DB>` among the intersection's members and stops there. As an
+ * interface of its own it had to relate the two structurally, and the members
+ * that return themselves over a recomputed `DB` - `$extendTables` and friends -
+ * made that recurse until the compiler gave up. That cost 1.3M type
+ * instantiations on TypeScript 7, five times what it cost on 6.
  */
-export interface ReadonlyTransaction<DB>
-  extends
-    Pick<
-      ReadonlyKysely<DB>,
-      | 'case'
-      | 'deleteFrom'
-      | 'dynamic'
-      | 'executeQuery'
-      | 'fn'
-      | 'getExecutor'
-      | 'insertInto'
-      | 'introspection'
-      | 'mergeInto'
-      | 'replaceInto'
-      | 'schema'
-      | 'selectFrom'
-      | 'selectNoFrom'
-      | 'updateTable'
-      | 'with'
-      | 'withRecursive'
-    >,
-    Pick<
-      Transaction<DB>,
-      | 'connection'
-      | 'destroy'
-      | 'isTransaction'
-      | 'startTransaction'
-      | 'transaction'
-    > {
+export type ReadonlyTransaction<DB> = ReadonlyTransactionMethods<DB> &
+  ReadonlyKysely<DB>
+
+/**
+ * The methods a {@link ReadonlyTransaction} has on top of the
+ * {@link ReadonlyKysely} ones.
+ *
+ * Similar to {@link TransactionMethods} but read-only.
+ */
+export interface ReadonlyTransactionMethods<in out DB> {
+  /**
+   * Always `true` for a transaction.
+   *
+   * The type is `true` instead of `boolean` to make `ReadonlyKysely<DB>`
+   * unassignable to `ReadonlyTransaction<DB>` while allowing assignment the
+   * other way around.
+   */
+  readonly isTransaction: true
+
+  /**
+   * @deprecated calling the transaction method for a Transaction is not supported
+   */
+  transaction(): never
+
+  /**
+   * @deprecated calling the controlled transaction method for a Transaction is not supported
+   */
+  startTransaction(): never
+
+  /**
+   * @deprecated calling the connection method for a Transaction is not supported
+   */
+  connection(): never
+
+  /**
+   * @deprecated calling the destroy method for a Transaction is not supported
+   */
+  destroy(): never
+
   /**
    * Similar to {@link Transaction.withoutPlugins} but read-only.
    */
@@ -272,7 +299,7 @@ export interface ReadonlyTransaction<DB>
 /**
  * Similar to {@link ControlledTransactionBuilder} but read-only.
  */
-export interface ReadonlyControlledTransactionBuilder<DB> {
+export interface ReadonlyControlledTransactionBuilder<in out DB> {
   /**
    * Similar to {@link ControlledTransactionBuilder.execute} but read-only.
    */
@@ -295,14 +322,31 @@ export interface ReadonlyControlledTransactionBuilder<DB> {
 
 /**
  * Similar to {@link ControlledTransaction} but read-only.
+ *
+ * Like {@link ReadonlyTransaction}, this is an intersection rather than an
+ * interface of its own, for the type check performance reasons described there.
  */
-export interface ReadonlyControlledTransaction<DB, S extends string[] = []>
-  extends
-    ReadonlyTransaction<DB>,
-    Pick<
-      ControlledTransaction<DB, S>,
-      'commit' | 'isCommitted' | 'isRolledBack' | 'rollback'
-    > {
+export type ReadonlyControlledTransaction<
+  DB,
+  S extends string[] = [],
+> = ReadonlyControlledTransactionMethods<DB, S> & ReadonlyTransaction<DB>
+
+/**
+ * The methods a {@link ReadonlyControlledTransaction} has on top of the
+ * {@link ReadonlyTransaction} ones.
+ *
+ * Similar to {@link ControlledTransactionMethods} but read-only.
+ *
+ * @typeParam S - The names of the savepoints that are currently open, in the
+ *    order they were created.
+ */
+export interface ReadonlyControlledTransactionMethods<
+  in out DB,
+  S extends string[] = [],
+> extends Pick<
+  ControlledTransactionMethods<DB, S>,
+  'commit' | 'isCommitted' | 'isRolledBack' | 'rollback'
+> {
   /**
    * Similar to {@link ControlledTransaction.releaseSavepoint} but read-only.
    */

--- a/src/readonly/readonly-kysely.ts
+++ b/src/readonly/readonly-kysely.ts
@@ -60,9 +60,6 @@ import type { ReadonlyQueryCreator } from './readonly-query-creator.js'
  * db.deleteFrom('person') // typescript compiler error!
  * ```
  */
-// `DB` is `in out` on this and the other read-only types below for the same
-// reason it is on `Kysely`. See the comment above the `Kysely` class in
-// `src/kysely.ts`.
 export interface ReadonlyKysely<in out DB>
   extends
     ReadonlyQueryCreator<DB>,

--- a/src/readonly/readonly-kysely.ts
+++ b/src/readonly/readonly-kysely.ts
@@ -199,14 +199,6 @@ export interface ReadonlyTransactionBuilder<in out DB> {
  * Like {@link Transaction}, this is an intersection of
  * {@link ReadonlyTransactionMethods} and {@link ReadonlyKysely} rather than an
  * interface that repeats their members, for type check performance reasons.
- *
- * Spelling it this way is what makes a `ReadonlyTransaction` usable where a
- * {@link ReadonlyKysely} is expected: the compiler finds the very same
- * `ReadonlyKysely<DB>` among the intersection's members and stops there. As an
- * interface of its own it had to relate the two structurally, and the members
- * that return themselves over a recomputed `DB` - `$extendTables` and friends -
- * made that recurse until the compiler gave up. That cost 1.3M type
- * instantiations on TypeScript 7, five times what it cost on 6.
  */
 export type ReadonlyTransaction<DB> = ReadonlyTransactionMethods<DB> &
   ReadonlyKysely<DB>

--- a/src/readonly/readonly-query-creator.ts
+++ b/src/readonly/readonly-query-creator.ts
@@ -10,8 +10,6 @@ import type {
 /**
  * Similar to {@link QueryCreator} but read-only.
  */
-// `DB` is `in out` for the same reason it is on `Kysely`. See the comment above
-// the `Kysely` class in `src/kysely.ts`.
 export interface ReadonlyQueryCreator<in out DB> extends Pick<
   QueryCreator<DB>,
   'selectFrom' | 'selectNoFrom'

--- a/src/readonly/readonly-query-creator.ts
+++ b/src/readonly/readonly-query-creator.ts
@@ -10,7 +10,9 @@ import type {
 /**
  * Similar to {@link QueryCreator} but read-only.
  */
-export interface ReadonlyQueryCreator<DB> extends Pick<
+// `DB` is `in out` for the same reason it is on `Kysely`. See the comment above
+// the `Kysely` class in `src/kysely.ts`.
+export interface ReadonlyQueryCreator<in out DB> extends Pick<
   QueryCreator<DB>,
   'selectFrom' | 'selectNoFrom'
 > {

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -192,9 +192,6 @@ bench('ControlledTransaction assignable to Transaction', () => {
   return acceptsTransaction(controlledTransaction)
 }).types([136150, 'instantiations'])
 
-// The read-only mirror of the four cases above. It has the same shape for the
-// same reason, and had the same problem: before `ReadonlyTransaction` became an
-// intersection, the second of these cost 1.3M instantiations on TypeScript 7.
 bench('ReadonlyKysely assignable to ReadonlyKysely', () => {
   return acceptsReadonlyKysely(readonlyKysely)
 }).types([26, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -188,10 +188,6 @@ bench('ControlledTransaction assignable to Kysely', () => {
   return acceptsKysely(controlledTransaction)
 }).types([64, 'instantiations'])
 
-// Still the expensive one: a `ControlledTransaction` and a `Transaction` share
-// members whose return types are these same two intersections, so the compiler
-// has to walk both in full. It doesn't recurse without bound - the count barely
-// moves between TypeScript versions - it's just a lot of members.
 bench('ControlledTransaction assignable to Transaction', () => {
   return acceptsTransaction(controlledTransaction)
 }).types([136150, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -12,6 +12,11 @@ import type {
   UpdateQueryBuilder,
   WheneableMergeQueryBuilder,
 } from '../../dist/index.js'
+import type {
+  ReadonlyControlledTransaction,
+  ReadonlyKysely,
+  ReadonlyTransaction,
+} from '../../dist/readonly/index.js'
 
 // These benchmarks cover the scenarios in `test/typings/test-d/generic.test-d.ts`.
 // They all relate two different instantiations of the same builder type, which
@@ -120,6 +125,17 @@ declare function acceptsKysely(db: Kysely<{ a: A; b: B }>): void
 declare const controlledTransaction: ControlledTransaction<{ a: A; b: B }>
 declare function acceptsTransaction(trx: Transaction<{ a: A; b: B }>): void
 
+declare const readonlyKysely: ReadonlyKysely<{ a: A; b: B }>
+declare const readonlyTransaction: ReadonlyTransaction<{ a: A; b: B }>
+declare const readonlyControlledTransaction: ReadonlyControlledTransaction<{
+  a: A
+  b: B
+}>
+declare function acceptsReadonlyKysely(db: ReadonlyKysely<{ a: A; b: B }>): void
+declare function acceptsReadonlyTransaction(
+  trx: ReadonlyTransaction<{ a: A; b: B }>,
+): void
+
 console.log('generic.bench.ts:\n')
 
 bench.baseline(() => {})
@@ -162,16 +178,39 @@ bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
 
 bench('Kysely assignable to Kysely', () => {
   return acceptsKysely(plainKysely)
-}).types([11784, 'instantiations'])
+}).types([2, 'instantiations'])
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([11832, 'instantiations'])
+}).types([50, 'instantiations'])
 
 bench('ControlledTransaction assignable to Kysely', () => {
   return acceptsKysely(controlledTransaction)
-}).types([11846, 'instantiations'])
+}).types([64, 'instantiations'])
 
+// Still the expensive one: a `ControlledTransaction` and a `Transaction` share
+// members whose return types are these same two intersections, so the compiler
+// has to walk both in full. It doesn't recurse without bound - the count barely
+// moves between TypeScript versions - it's just a lot of members.
 bench('ControlledTransaction assignable to Transaction', () => {
   return acceptsTransaction(controlledTransaction)
-}).types([330097, 'instantiations'])
+}).types([136150, 'instantiations'])
+
+// The read-only mirror of the four cases above. It has the same shape for the
+// same reason, and had the same problem: before `ReadonlyTransaction` became an
+// intersection, the second of these cost 1.3M instantiations on TypeScript 7.
+bench('ReadonlyKysely assignable to ReadonlyKysely', () => {
+  return acceptsReadonlyKysely(readonlyKysely)
+}).types([26, 'instantiations'])
+
+bench('ReadonlyTransaction assignable to ReadonlyKysely', () => {
+  return acceptsReadonlyKysely(readonlyTransaction)
+}).types([101, 'instantiations'])
+
+bench('ReadonlyControlledTransaction assignable to ReadonlyKysely', () => {
+  return acceptsReadonlyKysely(readonlyControlledTransaction)
+}).types([131, 'instantiations'])
+
+bench('ReadonlyControlledTransaction assignable to ReadonlyTransaction', () => {
+  return acceptsReadonlyTransaction(readonlyControlledTransaction)
+}).types([74677, 'instantiations'])

--- a/test/typings/test-d/generic.test-d.ts
+++ b/test/typings/test-d/generic.test-d.ts
@@ -1,4 +1,5 @@
 import type {
+  ControlledTransaction,
   Kysely,
   ExpressionBuilder,
   SelectQueryBuilder,
@@ -6,17 +7,22 @@ import type {
   Nullable,
   Selectable,
   SelectType,
+  Transaction,
 } from '../index.js'
 
-import { expectAssignable, expectType } from 'tsd'
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
 import type { Database, Movie, Person } from '../shared.js'
 
 // The tests below relate two different instantiations of the same builder type.
-// TypeScript can't derive variance for `SelectQueryBuilder` or `ExpressionBuilder`
-// (both mention their `DB`/`TB` parameters under `keyof` and in conditional types),
-// so it has to compare them structurally, member by member. That makes these the
-// most expensive type-level operations in the library, so two rules keep them in
-// check - breaking either one is easy to do by accident and expensive:
+//
+// To do that, TypeScript first needs the variance of each type parameter. Nothing
+// declares it, so the compiler measures it: it instantiates the type twice with
+// synthetic marker types and relates the two results structurally, member by
+// member. For these builders that measurement comes back "unreliable" - they
+// mention their `DB`/`TB` parameters under `keyof` and in conditional types - so
+// every comparison then *also* falls back to the same structural walk. That makes
+// these the most expensive type-level operations in the library, and three rules
+// keep them in check. Breaking any of them is easy to do by accident, and expensive:
 //
 //   1. A method that accepts a `DB`/`TB`-parameterized expression type must keep it
 //      behind a generic type parameter (`limit<VE extends ValueExpression<...>>(v: VE)`,
@@ -32,7 +38,14 @@ import type { Database, Movie, Person } from '../shared.js'
 //      result types guard against this with `TableExpression<DB, TB> extends TE`, and
 //      `UpdateQueryBuilder.$if`/`DeleteQueryBuilder.$if` with `unknown extends O2`.
 //
-// Note that such a guard is only worth adding where it *replaces* a conditional that
+//   3. A type that is only ever related at a single `DB` should declare its variance
+//      instead, with an `in out` annotation. That skips the measurement entirely, and
+//      with it the recursion - it is what makes relating two `Kysely` types free. This
+//      is only available to types that don't need the structural fallback: the query
+//      builders let a wider builder stand in for a narrower one (the first tests
+//      below), which is bivariance, and bivariance can't be spelled as an annotation.
+//
+// Note that a rule 2 guard is only worth adding where it *replaces* a conditional that
 // would otherwise expand into a union of builders. Adding one to a result type that is
 // already a single type makes things dramatically worse, because the guard is itself a
 // conditional - it was measured at 15x on `Kysely.$extendTables` and friends. Not every
@@ -80,6 +93,39 @@ function testExpressionBuilderExtendsFuncArg() {
 
   const t2 = {} as T2
   test(t2)
+}
+
+// `Kysely` and the transaction types declare `DB` as `in out` (rule 3 above).
+function testKyselyAssignability() {
+  type A = { a: number }
+  type B = { b: string }
+
+  // Written out a second time on purpose: an identical *type* short-circuits the
+  // whole comparison, so it wouldn't test anything. Two separately written but
+  // mutually assignable databases is the case that has to go through variance.
+  const db = {} as Kysely<{ a: A; b: B }>
+  const trx = {} as Transaction<{ a: A; b: B }>
+  const controlled = {} as ControlledTransaction<{ a: A; b: B }>
+
+  expectAssignable<Kysely<{ a: { a: number }; b: { b: string } }>>(db)
+
+  // A transaction can stand in for a `Kysely`, but not the other way around.
+  expectAssignable<Kysely<{ a: A; b: B }>>(trx)
+  expectAssignable<Kysely<{ a: A; b: B }>>(controlled)
+  expectAssignable<Transaction<{ a: A; b: B }>>(controlled)
+  expectNotAssignable<Transaction<{ a: A; b: B }>>(db)
+
+  // A `Kysely` over a *different* database is not interchangeable, in either
+  // direction. Use `$omitTables`/`$pickTables`/`$extendTables` to change it.
+  //
+  // Both of these used to be allowed, but only because the compiler didn't trust
+  // the variance it had measured and fell back to comparing the two structurally,
+  // where the methods match bivariantly. It was never a variance the library could
+  // have declared - TypeScript rejects `out DB` on `Kysely` with TS2636 - and the
+  // second one is unsound: it hands you a `Kysely` typed with a table the
+  // underlying database doesn't have.
+  expectNotAssignable<Kysely<{ a: A }>>(db)
+  expectNotAssignable<Kysely<{ a: A; b: B }>>({} as Kysely<{ a: A }>)
 }
 
 async function testGenericSelectHelper() {

--- a/test/typings/test-d/readonly.test-d.ts
+++ b/test/typings/test-d/readonly.test-d.ts
@@ -2,6 +2,7 @@ import {
   expectAssignable,
   expectDeprecated,
   expectError,
+  expectNotAssignable,
   expectNotDeprecated,
   expectType,
 } from 'tsd'
@@ -25,6 +26,7 @@ import {
   type ReadonlyQueryResult,
   type ReadonlyTransaction,
   type ReadonlyTransactionBuilder,
+  type ReadonlyTransactionMethods,
   type Selectable,
   SelectQueryNode,
   type Transaction,
@@ -336,7 +338,7 @@ async function testReadonlyTransaction(
   expectType<typeof tx.case>(rtx.case)
   expectNotDeprecated(rtx.case)
 
-  expectType<typeof tx.connection>(rtx.connection)
+  expectType<Disabled<'connection'>>(rtx.connection)
   expectDeprecated(rtx.connection)
 
   expectType<NotAllowed>(rtx.deleteFrom)
@@ -384,10 +386,10 @@ async function testReadonlyTransaction(
   expectType<typeof tx.selectNoFrom>(rtx.selectNoFrom)
   expectNotDeprecated(rtx.selectNoFrom)
 
-  expectType<typeof tx.startTransaction>(rtx.startTransaction)
+  expectType<Disabled<'startTransaction'>>(rtx.startTransaction)
   expectDeprecated(rtx.startTransaction)
 
-  expectType<typeof tx.transaction>(rtx.transaction)
+  expectType<Disabled<'transaction'>>(rtx.transaction)
   expectDeprecated(rtx.transaction)
 
   expectType<NotAllowed>(rtx.updateTable)
@@ -410,6 +412,25 @@ async function testReadonlyTransaction(
 
   expectType<typeof rtx>(rtx.withoutPlugins())
   expectNotDeprecated(rtx.withoutPlugins)
+}
+
+// `ReadonlyTransaction` and `ReadonlyControlledTransaction` are intersections
+// that contain a `ReadonlyKysely<DB>`, which is what lets the compiler relate
+// them to one without walking either type. These are the assignments that shape
+// buys, so they're worth pinning.
+function testReadonlyTransactionAssignability(
+  rdb: ReadonlyKysely<Database>,
+  rtx: ReadonlyTransaction<Database>,
+  rctx: ReadonlyControlledTransaction<Database>,
+) {
+  expectAssignable<ReadonlyKysely<Database>>(rtx)
+  expectAssignable<ReadonlyKysely<Database>>(rctx)
+  expectAssignable<ReadonlyTransaction<Database>>(rctx)
+
+  // `isTransaction` is `true` rather than `boolean` to keep this one direction
+  // only - a plain read-only Kysely is not a transaction.
+  expectNotAssignable<ReadonlyTransaction<Database>>(rdb)
+  expectNotAssignable<ReadonlyControlledTransaction<Database>>(rtx)
 }
 
 async function testReadonlyControlledTransaction(
@@ -456,7 +477,7 @@ async function testReadonlyControlledTransaction(
   expectType<typeof tx.commit>(rtx.commit)
   expectNotDeprecated(rtx.commit)
 
-  expectType<typeof tx.connection>(rtx.connection)
+  expectType<Disabled<'connection'>>(rtx.connection)
   expectDeprecated(rtx.connection)
 
   expectType<NotAllowed>(rtx.deleteFrom)
@@ -552,10 +573,10 @@ async function testReadonlyControlledTransaction(
   expectType<typeof tx.selectNoFrom>(rtx.selectNoFrom)
   expectNotDeprecated(rtx.selectNoFrom)
 
-  expectType<typeof tx.startTransaction>(rtx.startTransaction)
+  expectType<Disabled<'startTransaction'>>(rtx.startTransaction)
   expectDeprecated(rtx.startTransaction)
 
-  expectType<typeof tx.transaction>(rtx.transaction)
+  expectType<Disabled<'transaction'>>(rtx.transaction)
   expectDeprecated(rtx.transaction)
 
   expectType<NotAllowed>(rtx.updateTable)
@@ -588,6 +609,15 @@ type DatabaseOf<K> = K extends Kysely<infer DB> ? DB : never
 
 type SavepointsOf<T> =
   T extends ControlledTransactionMethods<any, infer S> ? S : never
+
+// The members a transaction doesn't support are an overload set, because
+// `ReadonlyTransaction` is an intersection: the `never` overload from
+// `ReadonlyTransactionMethods` comes first and is the one calls resolve to, and
+// the one `ReadonlyKysely` declares follows it.
+type Disabled<
+  K extends keyof ReadonlyTransactionMethods<Database> &
+    keyof ReadonlyKysely<Database>,
+> = ReadonlyTransactionMethods<Database>[K] & ReadonlyKysely<Database>[K]
 
 declare function keyof<T>(thing: T): keyof T & string
 


### PR DESCRIPTION
Remove `Kysely` assignment type check recursion. This one comes with a rather big caveat, that we might not want:

```ts
let k1: Kysely<{ a: A, b: B }>
let k2: Kysely<{ a: A }>
k2 = k1 // This no longer works!
```

Opus says it only worked so far because typescript gave up with the infinite recursion. If it was able to follow it through, the result would've been an error:

> On the assignability change you approved: Kysely<{a,b}> ↔ Kysely<{a}> no longer compiles in either direction. Worth knowing why it used to: the compiler didn't trust the variance it measured and fell back to a structural comparison, where methods match bivariantly. It was never a variance the library could have declared — I confirmed TypeScript rejects out DB with TS2636 because selectFrom takes keyof DB. Users who relied on it need $pickTables/$omitTables.

So do we want to keep that feature, which only works because typescript gives up over infinite recursion (assuming Opus is right)?

This is on top of #1962