### PR TITLE
Speed up if function type check

### DIFF
--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -94,7 +94,33 @@ Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose')
  *    in the database and values must be interfaces that describe the rows in those
  *    tables. See the examples above.
  */
-export class Kysely<DB>
+// Why `in out DB` here and on the other generic types in this file:
+//
+// To relate two *different* instantiations of the same generic type - say
+// `Kysely<DB1>` to `Kysely<DB2>` - TypeScript first needs the variance of each
+// type parameter. Nothing declared it, so the compiler measured it: it
+// instantiates the type twice with synthetic marker types and relates the two
+// results structurally, member by member.
+//
+// That measurement was the expensive part, and it didn't terminate on its own.
+// Members like `$extendTables` return the same type over a *recomputed* `DB`, so
+// comparing them starts the whole comparison again one level down, against a `DB`
+// the compiler hasn't seen before and so can't match against a pair already in
+// progress. It only stopped at the compiler's internal recursion limit - and that
+// limit isn't the same across versions, which is why this cost ~5x more on
+// TypeScript 7 than on 6. Relating two `Kysely` types was ~12k type
+// instantiations on TS6 and ~56k on TS7; it is now 2 on both.
+//
+// An explicit annotation skips the measurement entirely: the compiler just uses
+// the declared variance. `in out` (invariant) is the strictest option and the
+// only sound one here - TypeScript rejects `out DB` with TS2636, because
+// `selectFrom` and friends take `keyof DB`.
+//
+// This is not a technique the query builders can borrow. They deliberately let a
+// wider builder stand in for a narrower one, which is bivariance, and bivariance
+// can't be spelled as an annotation. See `test/typings/test-d/generic.test-d.ts`
+// for what keeps those in check instead.
+export class Kysely<in out DB>
   extends QueryCreator<DB>
   implements QueryExecutorProvider, AsyncDisposable
 {
@@ -665,7 +691,7 @@ export type Transaction<DB> = TransactionMethods<DB> & Kysely<DB>
  * return another transaction rather than a plain `Kysely` instance, and the
  * ones a transaction doesn't support.
  */
-export interface TransactionMethods<DB> {
+export interface TransactionMethods<in out DB> {
   /**
    * Always `true` for a transaction.
    *
@@ -901,7 +927,7 @@ export interface KyselyConfig {
   readonly log?: LogConfig
 }
 
-export class ConnectionBuilder<DB> {
+export class ConnectionBuilder<in out DB> {
   readonly #props: ConnectionBuilderProps
 
   constructor(props: ConnectionBuilderProps) {
@@ -929,7 +955,7 @@ export class ConnectionBuilder<DB> {
 
 interface ConnectionBuilderProps extends KyselyProps {}
 
-export class TransactionBuilder<DB> {
+export class TransactionBuilder<in out DB> {
   readonly #props: TransactionBuilderProps
 
   constructor(props: TransactionBuilderProps) {
@@ -996,7 +1022,7 @@ interface TransactionBuilderProps extends KyselyProps {
   readonly isolationLevel?: IsolationLevel
 }
 
-export class ControlledTransactionBuilder<DB> {
+export class ControlledTransactionBuilder<in out DB> {
   readonly #props: TransactionBuilderProps
 
   constructor(props: TransactionBuilderProps) {
@@ -1062,7 +1088,10 @@ export type ControlledTransaction<
  * @typeParam S - The names of the savepoints that are currently open, in the
  *    order they were created.
  */
-export interface ControlledTransactionMethods<DB, S extends string[] = []> {
+export interface ControlledTransactionMethods<
+  in out DB,
+  S extends string[] = [],
+> {
   readonly isCommitted: boolean
 
   readonly isRolledBack: boolean

--- a/src/kysely.ts
+++ b/src/kysely.ts
@@ -642,7 +642,113 @@ export class Kysely<DB>
   }
 }
 
-export class Transaction<DB> extends Kysely<DB> {
+/**
+ * A {@link Kysely} instance that runs all its queries inside a transaction.
+ *
+ * You get one from {@link Kysely.transaction} or {@link Kysely.startTransaction}.
+ *
+ * A `Transaction<DB>` can be used anywhere a `Kysely<DB>` is expected. The
+ * opposite is not true - a plain `Kysely` instance is not a transaction.
+ *
+ * This is an intersection of {@link TransactionMethods} and {@link Kysely}
+ * rather than a subclass of `Kysely` for type check performance reasons.
+ *
+ * `Transaction` is still a class at runtime, so `db instanceof Transaction`
+ * works.
+ */
+export type Transaction<DB> = TransactionMethods<DB> & Kysely<DB>
+
+/**
+ * The methods a {@link Transaction} has on top of the {@link Kysely} ones.
+ *
+ * These are the members that make a transaction a transaction: the ones that
+ * return another transaction rather than a plain `Kysely` instance, and the
+ * ones a transaction doesn't support.
+ */
+export interface TransactionMethods<DB> {
+  /**
+   * Always `true` for a transaction.
+   *
+   * The type is `true` instead of `boolean` to make `Kysely<DB>` unassignable
+   * to `Transaction<DB>` while allowing assignment the other way around.
+   */
+  readonly isTransaction: true
+
+  /**
+   * @deprecated calling the transaction method for a Transaction is not supported
+   */
+  transaction(): never
+
+  /**
+   * @deprecated calling the controlled transaction method for a Transaction is not supported
+   */
+  startTransaction(): never
+
+  /**
+   * @deprecated calling the connection method for a Transaction is not supported
+   */
+  connection(): never
+
+  /**
+   * @deprecated calling the destroy method for a Transaction is not supported
+   */
+  destroy(): never
+
+  /**
+   * Similar to {@link Kysely.withPlugin} but returns the transaction.
+   */
+  withPlugin(plugin: KyselyPlugin): Transaction<DB>
+
+  /**
+   * Similar to {@link Kysely.withoutPlugins} but returns the transaction.
+   */
+  withoutPlugins(): Transaction<DB>
+
+  /**
+   * Similar to {@link Kysely.withSchema} but returns the transaction.
+   */
+  withSchema(schema: string): Transaction<DB>
+
+  /**
+   * Similar to {@link Kysely.withTables} but returns the transaction.
+   *
+   * @deprecated use {@link $extendTables} instead.
+   */
+  withTables<T extends Record<string, Record<string, any>>>(): Transaction<
+    DrainOuterGeneric<DB & T>
+  >
+
+  /**
+   * Similar to {@link Kysely.$extendTables} but returns the transaction.
+   */
+  $extendTables<T extends Record<string, Record<string, any>>>(): Transaction<
+    DrainOuterGeneric<DB & T>
+  >
+
+  /**
+   * Similar to {@link Kysely.$omitTables} but returns the transaction.
+   */
+  $omitTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Omit<DB, T> : DB
+  >
+
+  /**
+   * Similar to {@link Kysely.$pickTables} but returns the transaction.
+   */
+  $pickTables<T extends keyof DB>(): Transaction<
+    DB extends object ? Pick<DB, T> : DB
+  >
+}
+
+/**
+ * The static side of the {@link Transaction} class.
+ */
+export interface TransactionConstructor {
+  new <DB>(props: KyselyProps): Transaction<DB>
+  readonly prototype: Transaction<any>
+}
+
+class TransactionImpl<DB> extends Kysely<DB> implements TransactionMethods<DB> {
   readonly #props: KyselyProps
 
   constructor(props: KyselyProps) {
@@ -650,74 +756,50 @@ export class Transaction<DB> extends Kysely<DB> {
     this.#props = props
   }
 
-  // The return type is `true` instead of `boolean` to make Kysely<DB>
-  // unassignable to Transaction<DB> while allowing assignment the
-  // other way around.
   override get isTransaction(): true {
     return true
   }
 
-  /**
-   * @deprecated calling the transaction method for a Transaction is not supported
-   */
   override transaction(): never {
     throw new Error(
       'calling the transaction method for a Transaction is not supported',
     )
   }
 
-  /**
-   * @deprecated calling the controlled transaction method for a Transaction is not supported
-   */
   override startTransaction(): never {
     throw new Error(
       'calling the controlled transaction method for a Transaction is not supported',
     )
   }
 
-  /**
-   * @deprecated calling the connection method for a Transaction is not supported
-   */
   override connection(): never {
     throw new Error(
       'calling the connection method for a Transaction is not supported',
     )
   }
 
-  /**
-   * @deprecated calling the destroy method for a Transaction is not supported
-   */
   override destroy(): never {
     throw new Error(
       'calling the destroy method for a Transaction is not supported',
     )
   }
 
-  /**
-   * Similar to {@link Kysely.withPlugin} but returns the transaction.
-   */
   override withPlugin(plugin: KyselyPlugin): Transaction<DB> {
-    return new Transaction({
+    return new TransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withPlugin(plugin),
     })
   }
 
-  /**
-   * Similar to {@link Kysely.withoutPlugins} but returns the transaction.
-   */
   override withoutPlugins(): Transaction<DB> {
-    return new Transaction({
+    return new TransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withoutPlugins(),
     })
   }
 
-  /**
-   * Similar to {@link Kysely.withSchema} but returns the transaction.
-   */
   override withSchema(schema: string): Transaction<DB> {
-    return new Transaction({
+    return new TransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withPluginAtFront(
         new WithSchemaPlugin(schema),
@@ -725,44 +807,32 @@ export class Transaction<DB> extends Kysely<DB> {
     })
   }
 
-  /**
-   * Similar to {@link Kysely.withTables} but returns the transaction.
-   *
-   * @deprecated use {@link $extendTables} instead.
-   */
   override withTables<
     T extends Record<string, Record<string, any>>,
   >(): Transaction<DrainOuterGeneric<DB & T>> {
-    return new Transaction({ ...this.#props })
+    return new TransactionImpl({ ...this.#props })
   }
 
-  /**
-   * Similar to {@link Kysely.$extendTables} but returns the transaction.
-   */
   override $extendTables<
     T extends Record<string, Record<string, any>>,
   >(): Transaction<DrainOuterGeneric<DB & T>> {
-    return new Transaction({ ...this.#props })
+    return new TransactionImpl({ ...this.#props })
   }
 
-  /**
-   * Similar to {@link Kysely.$omitTables} but returns the transaction.
-   */
   override $omitTables<T extends keyof DB>(): Transaction<
     DB extends object ? Omit<DB, T> : DB
   > {
-    return new Transaction({ ...this.#props })
+    return new TransactionImpl({ ...this.#props })
   }
 
-  /**
-   * Similar to {@link Kysely.$pickTables} but returns the transaction.
-   */
   override $pickTables<T extends keyof DB>(): Transaction<
     DB extends object ? Pick<DB, T> : DB
   > {
-    return new Transaction({ ...this.#props })
+    return new TransactionImpl({ ...this.#props })
   }
 }
+
+export const Transaction: TransactionConstructor = TransactionImpl
 
 export interface KyselyProps {
   readonly config: KyselyConfig
@@ -969,40 +1039,33 @@ export class ControlledTransactionBuilder<DB> {
   }
 }
 
-export class ControlledTransaction<
+/**
+ * A {@link Transaction} you commit and roll back yourself.
+ *
+ * You get one from {@link Kysely.startTransaction}. Once it is committed or
+ * rolled back it can't be used anymore - all queries will throw an error.
+ *
+ * Like {@link Transaction}, this is an intersection instead of a subclass for
+ * type check performance reasons.
+ *
+ * It is still a class at runtime so `trx instanceof ControlledTransaction` works.
+ */
+export type ControlledTransaction<
   DB,
   S extends string[] = [],
-> extends Transaction<DB> {
-  readonly #props: ControlledTransactionProps
-  readonly #compileQuery: QueryCompiler['compileQuery']
-  readonly #state: ControlledTransctionState
+> = ControlledTransactionMethods<DB, S> & Transaction<DB>
 
-  constructor(props: ControlledTransactionProps) {
-    const state = { isCommitted: false, isRolledBack: false }
-    props = {
-      ...props,
-      executor: new NotCommittedOrRolledBackAssertingExecutor(
-        props.executor,
-        state,
-      ),
-    }
-    const { connection, ...transactionProps } = props
-    super(transactionProps)
+/**
+ * The methods a {@link ControlledTransaction} has on top of the
+ * {@link Transaction} ones.
+ *
+ * @typeParam S - The names of the savepoints that are currently open, in the
+ *    order they were created.
+ */
+export interface ControlledTransactionMethods<DB, S extends string[] = []> {
+  readonly isCommitted: boolean
 
-    this.#props = freeze(props)
-    this.#state = state
-
-    const queryId = createQueryId()
-    this.#compileQuery = (node) => props.executor.compileQuery(node, queryId)
-  }
-
-  get isCommitted(): boolean {
-    return this.#state.isCommitted
-  }
-
-  get isRolledBack(): boolean {
-    return this.#state.isRolledBack
-  }
+  readonly isRolledBack: boolean
 
   /**
    * Commits the transaction.
@@ -1028,17 +1091,7 @@ export class ControlledTransaction<
    * async function doSomething(kysely: Kysely<Database>) {}
    * ```
    */
-  commit(): Command<void> {
-    assertNotCommittedOrRolledBack(this.#state)
-
-    return new Command(async (): Promise<void> => {
-      await this.#props.driver.commitTransaction(
-        this.#props.connection.connection,
-      )
-      this.#state.isCommitted = true
-      this.#props.connection.release()
-    })
-  }
+  commit(): Command<void>
 
   /**
    * Rolls back the transaction.
@@ -1064,17 +1117,7 @@ export class ControlledTransaction<
    * async function doSomething(kysely: Kysely<Database>) {}
    * ```
    */
-  rollback(): Command<void> {
-    assertNotCommittedOrRolledBack(this.#state)
-
-    return new Command(async (): Promise<void> => {
-      await this.#props.driver.rollbackTransaction(
-        this.#props.connection.connection,
-      )
-      this.#state.isRolledBack = true
-      this.#props.connection.release()
-    })
-  }
+  rollback(): Command<void>
 
   /**
    * Creates a savepoint with a given name.
@@ -1107,21 +1150,7 @@ export class ControlledTransaction<
    */
   savepoint<SN extends string>(
     savepointName: SN extends S ? never : SN,
-  ): Command<ControlledTransaction<DB, [...S, SN]>> {
-    assertNotCommittedOrRolledBack(this.#state)
-
-    return new Command(
-      async (): Promise<ControlledTransaction<DB, [...S, SN]>> => {
-        await this.#props.driver.savepoint?.(
-          this.#props.connection.connection,
-          savepointName,
-          this.#compileQuery,
-        )
-
-        return new ControlledTransaction({ ...this.#props })
-      },
-    )
-  }
+  ): Command<ControlledTransaction<DB, [...S, SN]>>
 
   /**
    * Rolls back to a savepoint with a given name.
@@ -1157,23 +1186,7 @@ export class ControlledTransaction<
     savepointName: SN,
   ): RollbackToSavepoint<S, SN> extends string[]
     ? Command<ControlledTransaction<DB, RollbackToSavepoint<S, SN>>>
-    : never {
-    assertNotCommittedOrRolledBack(this.#state)
-
-    return new Command(
-      async (): Promise<
-        ControlledTransaction<DB, RollbackToSavepoint<S, SN>>
-      > => {
-        await this.#props.driver.rollbackToSavepoint?.(
-          this.#props.connection.connection,
-          savepointName,
-          this.#compileQuery,
-        )
-
-        return new ControlledTransaction({ ...this.#props })
-      },
-    ) as never
-  }
+    : never
 
   /**
    * Releases a savepoint with a given name.
@@ -1214,6 +1227,149 @@ export class ControlledTransaction<
     savepointName: SN,
   ): ReleaseSavepoint<S, SN> extends string[]
     ? Command<ControlledTransaction<DB, ReleaseSavepoint<S, SN>>>
+    : never
+
+  withPlugin(plugin: KyselyPlugin): ControlledTransaction<DB, S>
+
+  withoutPlugins(): ControlledTransaction<DB, S>
+
+  withSchema(schema: string): ControlledTransaction<DB, S>
+
+  withTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  $extendTables<
+    T extends Record<string, Record<string, any>>,
+  >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S>
+
+  $omitTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Omit<DB, T> : DB,
+    S
+  >
+
+  $pickTables<T extends keyof DB>(): ControlledTransaction<
+    DB extends object ? Pick<DB, T> : DB,
+    S
+  >
+}
+
+/**
+ * The static side of the {@link ControlledTransaction} class.
+ */
+export interface ControlledTransactionConstructor {
+  new <DB, S extends string[] = []>(
+    props: ControlledTransactionProps,
+  ): ControlledTransaction<DB, S>
+  readonly prototype: ControlledTransaction<any, any>
+}
+
+class ControlledTransactionImpl<DB, S extends string[] = []>
+  extends TransactionImpl<DB>
+  implements ControlledTransactionMethods<DB, S>
+{
+  readonly #props: ControlledTransactionProps
+  readonly #compileQuery: QueryCompiler['compileQuery']
+  readonly #state: ControlledTransctionState
+
+  constructor(props: ControlledTransactionProps) {
+    const state = { isCommitted: false, isRolledBack: false }
+    props = {
+      ...props,
+      executor: new NotCommittedOrRolledBackAssertingExecutor(
+        props.executor,
+        state,
+      ),
+    }
+    const { connection, ...transactionProps } = props
+    super(transactionProps)
+
+    this.#props = freeze(props)
+    this.#state = state
+
+    const queryId = createQueryId()
+    this.#compileQuery = (node) => props.executor.compileQuery(node, queryId)
+  }
+
+  get isCommitted(): boolean {
+    return this.#state.isCommitted
+  }
+
+  get isRolledBack(): boolean {
+    return this.#state.isRolledBack
+  }
+
+  commit(): Command<void> {
+    assertNotCommittedOrRolledBack(this.#state)
+
+    return new Command(async (): Promise<void> => {
+      await this.#props.driver.commitTransaction(
+        this.#props.connection.connection,
+      )
+      this.#state.isCommitted = true
+      this.#props.connection.release()
+    })
+  }
+
+  rollback(): Command<void> {
+    assertNotCommittedOrRolledBack(this.#state)
+
+    return new Command(async (): Promise<void> => {
+      await this.#props.driver.rollbackTransaction(
+        this.#props.connection.connection,
+      )
+      this.#state.isRolledBack = true
+      this.#props.connection.release()
+    })
+  }
+
+  savepoint<SN extends string>(
+    savepointName: SN extends S ? never : SN,
+  ): Command<ControlledTransaction<DB, [...S, SN]>> {
+    assertNotCommittedOrRolledBack(this.#state)
+
+    return new Command(
+      async (): Promise<ControlledTransaction<DB, [...S, SN]>> => {
+        await this.#props.driver.savepoint?.(
+          this.#props.connection.connection,
+          savepointName,
+          this.#compileQuery,
+        )
+
+        // The savepoint name juggling in `rollbackToSavepoint` and
+        // `releaseSavepoint` doesn't survive being related to itself with `S`
+        // instantiated as `[...S, SN]`.
+        return new ControlledTransactionImpl({ ...this.#props }) as never
+      },
+    )
+  }
+
+  rollbackToSavepoint<SN extends S[number]>(
+    savepointName: SN,
+  ): RollbackToSavepoint<S, SN> extends string[]
+    ? Command<ControlledTransaction<DB, RollbackToSavepoint<S, SN>>>
+    : never {
+    assertNotCommittedOrRolledBack(this.#state)
+
+    return new Command(
+      async (): Promise<
+        ControlledTransaction<DB, RollbackToSavepoint<S, SN>>
+      > => {
+        await this.#props.driver.rollbackToSavepoint?.(
+          this.#props.connection.connection,
+          savepointName,
+          this.#compileQuery,
+        )
+
+        return new ControlledTransactionImpl({ ...this.#props })
+      },
+    ) as never
+  }
+
+  releaseSavepoint<SN extends S[number]>(
+    savepointName: SN,
+  ): ReleaseSavepoint<S, SN> extends string[]
+    ? Command<ControlledTransaction<DB, ReleaseSavepoint<S, SN>>>
     : never {
     assertNotCommittedOrRolledBack(this.#state)
 
@@ -1225,27 +1381,27 @@ export class ControlledTransaction<
           this.#compileQuery,
         )
 
-        return new ControlledTransaction({ ...this.#props })
+        return new ControlledTransactionImpl({ ...this.#props })
       },
     ) as never
   }
 
   override withPlugin(plugin: KyselyPlugin): ControlledTransaction<DB, S> {
-    return new ControlledTransaction({
+    return new ControlledTransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withPlugin(plugin),
     })
   }
 
   override withoutPlugins(): ControlledTransaction<DB, S> {
-    return new ControlledTransaction({
+    return new ControlledTransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withoutPlugins(),
     })
   }
 
   override withSchema(schema: string): ControlledTransaction<DB, S> {
-    return new ControlledTransaction({
+    return new ControlledTransactionImpl({
       ...this.#props,
       executor: this.#props.executor.withPluginAtFront(
         new WithSchemaPlugin(schema),
@@ -1256,29 +1412,32 @@ export class ControlledTransaction<
   override withTables<
     T extends Record<string, Record<string, any>>,
   >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
-    return new ControlledTransaction({ ...this.#props })
+    return new ControlledTransactionImpl({ ...this.#props })
   }
 
   override $extendTables<
     T extends Record<string, Record<string, any>>,
   >(): ControlledTransaction<DrainOuterGeneric<DB & T>, S> {
-    return new ControlledTransaction({ ...this.#props })
+    return new ControlledTransactionImpl({ ...this.#props })
   }
 
   override $omitTables<T extends keyof DB>(): ControlledTransaction<
     DB extends object ? Omit<DB, T> : DB,
     S
   > {
-    return new ControlledTransaction({ ...this.#props })
+    return new ControlledTransactionImpl({ ...this.#props })
   }
 
   override $pickTables<T extends keyof DB>(): ControlledTransaction<
     DB extends object ? Pick<DB, T> : DB,
     S
   > {
-    return new ControlledTransaction({ ...this.#props })
+    return new ControlledTransactionImpl({ ...this.#props })
   }
 }
+
+export const ControlledTransaction: ControlledTransactionConstructor =
+  ControlledTransactionImpl
 
 interface ControlledTransctionState {
   isCommitted: boolean

--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1847,7 +1847,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   $if<O2>(
     condition: boolean,
-    func: (qb: this) => SelectQueryBuilder<any, any, O & O2>,
+    func: (qb: this) => SelectQueryBuilderExpression<O & O2>,
   ): SelectQueryBuilder<DB, TB, O & Partial<Omit<O2, keyof O>>>
 
   /**
@@ -2589,10 +2589,10 @@ class SelectQueryBuilderImpl<
 
   $if<O2>(
     condition: boolean,
-    func: (qb: this) => SelectQueryBuilder<any, any, O & O2>,
+    func: (qb: this) => SelectQueryBuilderExpression<O & O2>,
   ): SelectQueryBuilder<DB, TB, O & Partial<Omit<O2, keyof O>>> {
     if (condition) {
-      return func(this)
+      return func(this) as any
     }
 
     return new SelectQueryBuilderImpl({

--- a/src/readonly/readonly-kysely.ts
+++ b/src/readonly/readonly-kysely.ts
@@ -4,9 +4,11 @@ import type {
   ConnectionBuilder,
   ControlledTransaction,
   ControlledTransactionBuilder,
+  ControlledTransactionMethods,
   Kysely,
   Transaction,
   TransactionBuilder,
+  TransactionMethods,
 } from '../kysely.js'
 import type {
   ReleaseSavepoint,
@@ -58,7 +60,10 @@ import type { ReadonlyQueryCreator } from './readonly-query-creator.js'
  * db.deleteFrom('person') // typescript compiler error!
  * ```
  */
-export interface ReadonlyKysely<DB>
+// `DB` is `in out` on this and the other read-only types below for the same
+// reason it is on `Kysely`. See the comment above the `Kysely` class in
+// `src/kysely.ts`.
+export interface ReadonlyKysely<in out DB>
   extends
     ReadonlyQueryCreator<DB>,
     Pick<
@@ -156,7 +161,7 @@ export interface ReadonlyKysely<DB>
 /**
  * Similar to {@link ConnectionBuilder} but read-only.
  */
-export interface ReadonlyConnectionBuilder<DB> extends Omit<
+export interface ReadonlyConnectionBuilder<in out DB> extends Omit<
   ConnectionBuilder<DB>,
   'execute'
 > {
@@ -172,7 +177,7 @@ export interface ReadonlyConnectionBuilder<DB> extends Omit<
 /**
  * Similar to {@link TransactionBuilder} but read-only.
  */
-export interface ReadonlyTransactionBuilder<DB> {
+export interface ReadonlyTransactionBuilder<in out DB> {
   /**
    * Similar to {@link TransactionBuilder.execute} but read-only.
    */
@@ -193,36 +198,58 @@ export interface ReadonlyTransactionBuilder<DB> {
 
 /**
  * Similar to {@link Transaction} but read-only.
+ *
+ * Like {@link Transaction}, this is an intersection of
+ * {@link ReadonlyTransactionMethods} and {@link ReadonlyKysely} rather than an
+ * interface that repeats their members, for type check performance reasons.
+ *
+ * Spelling it this way is what makes a `ReadonlyTransaction` usable where a
+ * {@link ReadonlyKysely} is expected: the compiler finds the very same
+ * `ReadonlyKysely<DB>` among the intersection's members and stops there. As an
+ * interface of its own it had to relate the two structurally, and the members
+ * that return themselves over a recomputed `DB` - `$extendTables` and friends -
+ * made that recurse until the compiler gave up. That cost 1.3M type
+ * instantiations on TypeScript 7, five times what it cost on 6.
  */
-export interface ReadonlyTransaction<DB>
-  extends
-    Pick<
-      ReadonlyKysely<DB>,
-      | 'case'
-      | 'deleteFrom'
-      | 'dynamic'
-      | 'executeQuery'
-      | 'fn'
-      | 'getExecutor'
-      | 'insertInto'
-      | 'introspection'
-      | 'mergeInto'
-      | 'replaceInto'
-      | 'schema'
-      | 'selectFrom'
-      | 'selectNoFrom'
-      | 'updateTable'
-      | 'with'
-      | 'withRecursive'
-    >,
-    Pick<
-      Transaction<DB>,
-      | 'connection'
-      | 'destroy'
-      | 'isTransaction'
-      | 'startTransaction'
-      | 'transaction'
-    > {
+export type ReadonlyTransaction<DB> = ReadonlyTransactionMethods<DB> &
+  ReadonlyKysely<DB>
+
+/**
+ * The methods a {@link ReadonlyTransaction} has on top of the
+ * {@link ReadonlyKysely} ones.
+ *
+ * Similar to {@link TransactionMethods} but read-only.
+ */
+export interface ReadonlyTransactionMethods<in out DB> {
+  /**
+   * Always `true` for a transaction.
+   *
+   * The type is `true` instead of `boolean` to make `ReadonlyKysely<DB>`
+   * unassignable to `ReadonlyTransaction<DB>` while allowing assignment the
+   * other way around.
+   */
+  readonly isTransaction: true
+
+  /**
+   * @deprecated calling the transaction method for a Transaction is not supported
+   */
+  transaction(): never
+
+  /**
+   * @deprecated calling the controlled transaction method for a Transaction is not supported
+   */
+  startTransaction(): never
+
+  /**
+   * @deprecated calling the connection method for a Transaction is not supported
+   */
+  connection(): never
+
+  /**
+   * @deprecated calling the destroy method for a Transaction is not supported
+   */
+  destroy(): never
+
   /**
    * Similar to {@link Transaction.withoutPlugins} but read-only.
    */
@@ -272,7 +299,7 @@ export interface ReadonlyTransaction<DB>
 /**
  * Similar to {@link ControlledTransactionBuilder} but read-only.
  */
-export interface ReadonlyControlledTransactionBuilder<DB> {
+export interface ReadonlyControlledTransactionBuilder<in out DB> {
   /**
    * Similar to {@link ControlledTransactionBuilder.execute} but read-only.
    */
@@ -295,14 +322,31 @@ export interface ReadonlyControlledTransactionBuilder<DB> {
 
 /**
  * Similar to {@link ControlledTransaction} but read-only.
+ *
+ * Like {@link ReadonlyTransaction}, this is an intersection rather than an
+ * interface of its own, for the type check performance reasons described there.
  */
-export interface ReadonlyControlledTransaction<DB, S extends string[] = []>
-  extends
-    ReadonlyTransaction<DB>,
-    Pick<
-      ControlledTransaction<DB, S>,
-      'commit' | 'isCommitted' | 'isRolledBack' | 'rollback'
-    > {
+export type ReadonlyControlledTransaction<
+  DB,
+  S extends string[] = [],
+> = ReadonlyControlledTransactionMethods<DB, S> & ReadonlyTransaction<DB>
+
+/**
+ * The methods a {@link ReadonlyControlledTransaction} has on top of the
+ * {@link ReadonlyTransaction} ones.
+ *
+ * Similar to {@link ControlledTransactionMethods} but read-only.
+ *
+ * @typeParam S - The names of the savepoints that are currently open, in the
+ *    order they were created.
+ */
+export interface ReadonlyControlledTransactionMethods<
+  in out DB,
+  S extends string[] = [],
+> extends Pick<
+  ControlledTransactionMethods<DB, S>,
+  'commit' | 'isCommitted' | 'isRolledBack' | 'rollback'
+> {
   /**
    * Similar to {@link ControlledTransaction.releaseSavepoint} but read-only.
    */

--- a/src/readonly/readonly-query-creator.ts
+++ b/src/readonly/readonly-query-creator.ts
@@ -10,7 +10,9 @@ import type {
 /**
  * Similar to {@link QueryCreator} but read-only.
  */
-export interface ReadonlyQueryCreator<DB> extends Pick<
+// `DB` is `in out` for the same reason it is on `Kysely`. See the comment above
+// the `Kysely` class in `src/kysely.ts`.
+export interface ReadonlyQueryCreator<in out DB> extends Pick<
   QueryCreator<DB>,
   'selectFrom' | 'selectNoFrom'
 > {

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -1,5 +1,6 @@
 import { bench } from '@ark/attest'
 import type {
+  ControlledTransaction,
   DeleteQueryBuilder,
   ExpressionBuilder,
   Generated,
@@ -91,14 +92,6 @@ declare function acceptsNarrowMergeQueryBuilder(
   qb: WheneableMergeQueryBuilder<{ a: A; b: B }, 'a', 'a', unknown>,
 ): void
 
-// Handing a transaction to a function that takes a `Kysely` is one of the most
-// common things users do, and it is not cheap: `Transaction` and `Kysely` are
-// different generic types, so the compiler compares them member by member, and
-// `$extendTables`/`$omitTables`/`$pickTables` each return a handle over a
-// transformed `DB`, which makes that comparison recurse.
-declare const transaction: Transaction<{ a: A; b: B }>
-declare function acceptsKysely(db: Kysely<{ a: A; b: B }>): void
-
 // `MergeQueryBuilder.using()` returns a computed type, the same shape that makes
 // the join result types expensive.
 declare const wideMergeInto: MergeQueryBuilder<
@@ -119,6 +112,13 @@ declare function selectParentId(
     'parent' | 'petJoin'
   >,
 ): readonly ['parent.id']
+
+declare const plainKysely: Kysely<{ a: A; b: B }>
+declare const transaction: Transaction<{ a: A; b: B }>
+declare function acceptsKysely(db: Kysely<{ a: A; b: B }>): void
+
+declare const controlledTransaction: ControlledTransaction<{ a: A; b: B }>
+declare function acceptsTransaction(trx: Transaction<{ a: A; b: B }>): void
 
 console.log('generic.bench.ts:\n')
 
@@ -146,7 +146,7 @@ bench('select(genericSelectHelper) on a left joined query', () => {
 
 bench('DeleteQueryBuilder assignable to narrower DeleteQueryBuilder', () => {
   return acceptsNarrowDeleteQueryBuilder(wideDeleteQueryBuilder)
-}).types([10920, 'instantiations'])
+}).types([10919, 'instantiations'])
 
 bench('UpdateQueryBuilder assignable to narrower UpdateQueryBuilder', () => {
   return acceptsNarrowUpdateQueryBuilder(wideUpdateQueryBuilder)
@@ -156,10 +156,22 @@ bench('WheneableMergeQueryBuilder assignable to a narrower one', () => {
   return acceptsNarrowMergeQueryBuilder(wideMergeQueryBuilder)
 }).types([7573, 'instantiations'])
 
-bench('Transaction assignable to Kysely', () => {
-  return acceptsKysely(transaction)
-}).types([162352, 'instantiations'])
-
 bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
   return acceptsNarrowMergeInto(wideMergeInto)
 }).types([22733, 'instantiations'])
+
+bench('Kysely assignable to Kysely', () => {
+  return acceptsKysely(plainKysely)
+}).types([11784, 'instantiations'])
+
+bench('Transaction assignable to Kysely', () => {
+  return acceptsKysely(transaction)
+}).types([11832, 'instantiations'])
+
+bench('ControlledTransaction assignable to Kysely', () => {
+  return acceptsKysely(controlledTransaction)
+}).types([11846, 'instantiations'])
+
+bench('ControlledTransaction assignable to Transaction', () => {
+  return acceptsTransaction(controlledTransaction)
+}).types([330097, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -12,6 +12,11 @@ import type {
   UpdateQueryBuilder,
   WheneableMergeQueryBuilder,
 } from '../../dist/index.js'
+import type {
+  ReadonlyControlledTransaction,
+  ReadonlyKysely,
+  ReadonlyTransaction,
+} from '../../dist/readonly/index.js'
 
 // These benchmarks cover the scenarios in `test/typings/test-d/generic.test-d.ts`.
 // They all relate two different instantiations of the same builder type, which
@@ -120,6 +125,17 @@ declare function acceptsKysely(db: Kysely<{ a: A; b: B }>): void
 declare const controlledTransaction: ControlledTransaction<{ a: A; b: B }>
 declare function acceptsTransaction(trx: Transaction<{ a: A; b: B }>): void
 
+declare const readonlyKysely: ReadonlyKysely<{ a: A; b: B }>
+declare const readonlyTransaction: ReadonlyTransaction<{ a: A; b: B }>
+declare const readonlyControlledTransaction: ReadonlyControlledTransaction<{
+  a: A
+  b: B
+}>
+declare function acceptsReadonlyKysely(db: ReadonlyKysely<{ a: A; b: B }>): void
+declare function acceptsReadonlyTransaction(
+  trx: ReadonlyTransaction<{ a: A; b: B }>,
+): void
+
 console.log('generic.bench.ts:\n')
 
 bench.baseline(() => {})
@@ -162,16 +178,39 @@ bench('MergeQueryBuilder assignable to narrower MergeQueryBuilder', () => {
 
 bench('Kysely assignable to Kysely', () => {
   return acceptsKysely(plainKysely)
-}).types([11784, 'instantiations'])
+}).types([2, 'instantiations'])
 
 bench('Transaction assignable to Kysely', () => {
   return acceptsKysely(transaction)
-}).types([11832, 'instantiations'])
+}).types([50, 'instantiations'])
 
 bench('ControlledTransaction assignable to Kysely', () => {
   return acceptsKysely(controlledTransaction)
-}).types([11846, 'instantiations'])
+}).types([64, 'instantiations'])
 
+// Still the expensive one: a `ControlledTransaction` and a `Transaction` share
+// members whose return types are these same two intersections, so the compiler
+// has to walk both in full. It doesn't recurse without bound - the count barely
+// moves between TypeScript versions - it's just a lot of members.
 bench('ControlledTransaction assignable to Transaction', () => {
   return acceptsTransaction(controlledTransaction)
-}).types([330097, 'instantiations'])
+}).types([136150, 'instantiations'])
+
+// The read-only mirror of the four cases above. It has the same shape for the
+// same reason, and had the same problem: before `ReadonlyTransaction` became an
+// intersection, the second of these cost 1.3M instantiations on TypeScript 7.
+bench('ReadonlyKysely assignable to ReadonlyKysely', () => {
+  return acceptsReadonlyKysely(readonlyKysely)
+}).types([26, 'instantiations'])
+
+bench('ReadonlyTransaction assignable to ReadonlyKysely', () => {
+  return acceptsReadonlyKysely(readonlyTransaction)
+}).types([101, 'instantiations'])
+
+bench('ReadonlyControlledTransaction assignable to ReadonlyKysely', () => {
+  return acceptsReadonlyKysely(readonlyControlledTransaction)
+}).types([131, 'instantiations'])
+
+bench('ReadonlyControlledTransaction assignable to ReadonlyTransaction', () => {
+  return acceptsReadonlyTransaction(readonlyControlledTransaction)
+}).types([74677, 'instantiations'])

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -4,6 +4,7 @@ import type {
   DeleteQueryBuilder,
   ExpressionBuilder,
   Generated,
+  InsertQueryBuilder,
   Kysely,
   MergeQueryBuilder,
   Nullable,
@@ -75,6 +76,15 @@ declare const wideDeleteQueryBuilder: DeleteQueryBuilder<
 >
 declare function acceptsNarrowDeleteQueryBuilder(
   qb: DeleteQueryBuilder<{ a: A; b: B }, 'a', unknown>,
+): void
+
+declare const wideInsertQueryBuilder: InsertQueryBuilder<
+  { a: A; b: B },
+  'a',
+  { a: number }
+>
+declare function acceptsNarrowInsertQueryBuilder(
+  qb: InsertQueryBuilder<{ a: A; b: B }, 'a', unknown>,
 ): void
 
 declare const wideUpdateQueryBuilder: UpdateQueryBuilder<
@@ -163,6 +173,10 @@ bench('select(genericSelectHelper) on a left joined query', () => {
 bench('DeleteQueryBuilder assignable to narrower DeleteQueryBuilder', () => {
   return acceptsNarrowDeleteQueryBuilder(wideDeleteQueryBuilder)
 }).types([10919, 'instantiations'])
+
+bench('InsertQueryBuilder assignable to narrower InsertQueryBuilder', () => {
+  return acceptsNarrowInsertQueryBuilder(wideInsertQueryBuilder)
+}).types([2614, 'instantiations'])
 
 bench('UpdateQueryBuilder assignable to narrower UpdateQueryBuilder', () => {
   return acceptsNarrowUpdateQueryBuilder(wideUpdateQueryBuilder)

--- a/test/ts-benchmarks/if.bench.ts
+++ b/test/ts-benchmarks/if.bench.ts
@@ -1,0 +1,102 @@
+import { bench } from '@ark/attest'
+import type { DB } from '../typings/test-d/huge-db.test-d.js'
+import type { Kysely } from '../../dist/index.js'
+
+// `$if` is how conditional filters, optional selections and optional joins get
+// built in application code, so it tends to appear in every non-trivial query.
+//
+// Each of these numbers includes the one-time cost of relating two
+// instantiations of the builder under test, because that is what a `$if` call
+// site makes the compiler do: it has to match the callback's return type
+// against the builder type in the signature. Keep the callback return types
+// pointed at the smallest interface that still identifies the builder - see the
+// comment on `SelectQueryBuilder.$if`.
+
+declare const kysely: Kysely<DB>
+declare const condition: boolean
+
+console.log('if.bench.ts:\n')
+
+bench.baseline(() => {})
+
+bench('kysely..select..$if(qb => qb.select(column))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$if(condition, (qb) =>
+      qb.select('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+}).types([7027, 'instantiations'])
+
+bench('kysely..select..$if(qb => qb.where(...))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$if(condition, (qb) =>
+      qb.where('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 1),
+    )
+}).types([3509, 'instantiations'])
+
+bench('kysely..select..$if(qb => qb.innerJoin(...))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$if(condition, (qb) =>
+      qb.innerJoin(
+        'table_0b5ac72e03509e06683edcba4b3887ab',
+        'table_0b5ac72e03509e06683edcba4b3887ab.id',
+        'my_table.id',
+      ),
+    )
+}).types([8742, 'instantiations'])
+
+bench('kysely..select..$if x3', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$if(condition, (qb) =>
+      qb.where('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 1),
+    )
+    .$if(condition, (qb) =>
+      qb.select('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+    .$if(condition, (qb) =>
+      qb.select('my_table.col_4f84013a8b5e4c2b7529058c8fafcaa8'),
+    )
+}).types([10196, 'instantiations'])
+
+bench('kysely..update..$if(qb => qb.returning(column))', () => {
+  return kysely
+    .updateTable('my_table')
+    .set('my_table.col_2e66a5c7e24d1d066230f368ce8b094e', 'x')
+    .returning('my_table.id')
+    .$if(condition, (qb) =>
+      qb.returning('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+}).types([27600, 'instantiations'])
+
+bench('kysely..delete..$if(qb => qb.returning(column))', () => {
+  return kysely
+    .deleteFrom('my_table')
+    .returning('my_table.id')
+    .$if(condition, (qb) =>
+      qb.returning('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+}).types([12710, 'instantiations'])
+
+bench('kysely..insert..$if(qb => qb.returning(column))', () => {
+  return kysely
+    .insertInto('my_table')
+    .defaultValues()
+    .returning('my_table.id')
+    .$if(condition, (qb) =>
+      qb.returning('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+}).types([4083, 'instantiations'])
+
+bench('kysely..$call(qb => qb.select(column))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$call((qb) => qb.select('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'))
+}).types([968, 'instantiations'])

--- a/test/ts-benchmarks/insert-values.bench.ts
+++ b/test/ts-benchmarks/insert-values.bench.ts
@@ -1,0 +1,125 @@
+import { bench } from '@ark/attest'
+import type { DB } from '../typings/test-d/huge-db.test-d.js'
+import type { Kysely } from '../../dist/index.js'
+
+// `insert-into.bench.ts` only covers picking the table. These cover the parts
+// that carry data - the values themselves, upserts and `set` - which is where a
+// row type gets matched against the table's insertable columns. Bulk inserts
+// are worth watching in particular: the cost should stay flat in the number of
+// rows, since every row is checked against the same type.
+
+declare const kysely: Kysely<DB>
+declare const kyselyAny: Kysely<any>
+
+const row = {
+  col_1d726898491fbca9a8dac855d2be1be8: 1,
+  col_2e66a5c7e24d1d066230f368ce8b094e: 'a',
+  col_2f76db193eac6ad0f152563313673ac9: new Date(),
+  col_4f84013a8b5e4c2b7529058c8fafcaa8: 'b',
+  col_d2508118d0d39e198d1129d87d692d59: new Date(),
+  col_454ff479a3b5a9ef082d9be9ac02a6f4: 'c',
+  col_3917508388f24a50271f7088b657123c: 'd',
+}
+
+declare const rows: (typeof row)[]
+
+console.log('insert-values.bench.ts:\n')
+
+bench.baseline(() => {
+  return kysely.insertInto('my_table')
+})
+
+bench('kysely.insertInto(table).values(row)', () => {
+  return kysely.insertInto('my_table').values(row)
+}).types([1038, 'instantiations'])
+
+bench('kysely.insertInto(table).values(~row)', () => {
+  // @ts-expect-error
+  return kysely.insertInto('my_table').values({ ...row, no_such_column: 1 })
+}).types([1171, 'instantiations'])
+
+bench('kysely.insertInto(table).values([row])', () => {
+  return kysely.insertInto('my_table').values([row])
+}).types([1047, 'instantiations'])
+
+bench('kysely.insertInto(table).values([row x5])', () => {
+  return kysely.insertInto('my_table').values([row, row, row, row, row])
+}).types([1047, 'instantiations'])
+
+bench('kysely.insertInto(table).values([row x10])', () => {
+  return kysely
+    .insertInto('my_table')
+    .values([row, row, row, row, row, row, row, row, row, row])
+}).types([1047, 'instantiations'])
+
+bench('kysely.insertInto(table).values(row[])', () => {
+  return kysely.insertInto('my_table').values(rows)
+}).types([1045, 'instantiations'])
+
+bench('kysely.insertInto(table).values(eb => row)', () => {
+  return kysely.insertInto('my_table').values((eb) => ({
+    ...row,
+    col_1d726898491fbca9a8dac855d2be1be8: eb
+      .selectFrom('my_table as t2')
+      .select('t2.col_1d726898491fbca9a8dac855d2be1be8')
+      .limit(1),
+  }))
+}).types([2522, 'instantiations'])
+
+bench('kysely..onConflict(oc => oc.column(column).doNothing())', () => {
+  return kysely
+    .insertInto('my_table')
+    .values(row)
+    .onConflict((oc) =>
+      oc.column('col_1d726898491fbca9a8dac855d2be1be8').doNothing(),
+    )
+}).types([1102, 'instantiations'])
+
+bench('kysely..onConflict(oc => oc.column(column).doUpdateSet(row))', () => {
+  return kysely
+    .insertInto('my_table')
+    .values(row)
+    .onConflict((oc) =>
+      oc.column('col_1d726898491fbca9a8dac855d2be1be8').doUpdateSet(row),
+    )
+}).types([2131, 'instantiations'])
+
+bench('kysely..onConflict(oc => oc..doUpdateSet(eb => excluded ref))', () => {
+  return kysely
+    .insertInto('my_table')
+    .values(row)
+    .onConflict((oc) =>
+      oc.column('col_1d726898491fbca9a8dac855d2be1be8').doUpdateSet({
+        col_2e66a5c7e24d1d066230f368ce8b094e: (eb) =>
+          eb.ref('excluded.col_2e66a5c7e24d1d066230f368ce8b094e'),
+      }),
+    )
+}).types([4458, 'instantiations'])
+
+bench('kysely.updateTable(table).set(row)', () => {
+  return kysely.updateTable('my_table').set(row)
+}).types([848, 'instantiations'])
+
+bench('kysely.updateTable(table).set(column, value)', () => {
+  return kysely
+    .updateTable('my_table')
+    .set('my_table.col_2e66a5c7e24d1d066230f368ce8b094e', 'x')
+}).types([3078, 'instantiations'])
+
+bench('kysely.updateTable(table).set(eb => row)', () => {
+  return kysely.updateTable('my_table').set((eb) => ({
+    col_1d726898491fbca9a8dac855d2be1be8: eb(
+      'col_1d726898491fbca9a8dac855d2be1be8',
+      '+',
+      1,
+    ),
+  }))
+}).types([3520, 'instantiations'])
+
+bench('kyselyAny.insertInto(table).values(row)', () => {
+  return kyselyAny.insertInto('my_table').values(row)
+}).types([421, 'instantiations'])
+
+bench('kyselyAny.updateTable(table).set(row)', () => {
+  return kyselyAny.updateTable('my_table').set(row)
+}).types([333, 'instantiations'])

--- a/test/ts-benchmarks/json-helpers.bench.ts
+++ b/test/ts-benchmarks/json-helpers.bench.ts
@@ -1,0 +1,141 @@
+import { bench } from '@ark/attest'
+import type { DB } from '../typings/test-d/huge-db.test-d.js'
+import type { Kysely } from '../../dist/index.js'
+import {
+  jsonArrayFrom,
+  jsonBuildObject,
+  jsonObjectFrom,
+} from '../../dist/helpers/postgres.js'
+
+// Kysely has no relations, so `jsonArrayFrom` / `jsonObjectFrom` are how
+// applications load nested data. They show up once per relation, and queries
+// routinely nest them two or three deep, which makes them one of the most
+// repeated type-level operations in a real codebase.
+
+declare const kysely: Kysely<DB>
+
+console.log('json-helpers.bench.ts:\n')
+
+bench.baseline(() => {
+  return kysely.selectFrom('my_table')
+})
+
+bench('jsonArrayFrom(subquery.select(column))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select((eb) => [
+      'my_table.id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('table_0b5ac72e03509e06683edcba4b3887ab')
+          .select('table_0b5ac72e03509e06683edcba4b3887ab.id')
+          .whereRef(
+            'table_0b5ac72e03509e06683edcba4b3887ab.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rels'),
+    ])
+}).types([1622, 'instantiations'])
+
+bench('jsonArrayFrom(subquery.selectAll(table))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select((eb) => [
+      'my_table.id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('table_0b5ac72e03509e06683edcba4b3887ab')
+          .selectAll('table_0b5ac72e03509e06683edcba4b3887ab')
+          .whereRef(
+            'table_0b5ac72e03509e06683edcba4b3887ab.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rels'),
+    ])
+}).types([2070, 'instantiations'])
+
+bench('jsonObjectFrom(subquery.select(column))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select((eb) => [
+      'my_table.id',
+      jsonObjectFrom(
+        eb
+          .selectFrom('table_1474a7e0348b1ca363ee4a2a5dc4a1ec')
+          .select('table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id')
+          .whereRef(
+            'table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rel'),
+    ])
+}).types([1526, 'instantiations'])
+
+bench('jsonArrayFrom + jsonObjectFrom in one select', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select((eb) => [
+      'my_table.id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('table_0b5ac72e03509e06683edcba4b3887ab')
+          .select('table_0b5ac72e03509e06683edcba4b3887ab.id')
+          .whereRef(
+            'table_0b5ac72e03509e06683edcba4b3887ab.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rels'),
+      jsonObjectFrom(
+        eb
+          .selectFrom('table_1474a7e0348b1ca363ee4a2a5dc4a1ec')
+          .select('table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id')
+          .whereRef(
+            'table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rel'),
+    ])
+}).types([2688, 'instantiations'])
+
+bench('jsonArrayFrom nested two deep', () => {
+  return kysely.selectFrom('my_table').select((eb) => [
+    'my_table.id',
+    jsonArrayFrom(
+      eb
+        .selectFrom('table_0b5ac72e03509e06683edcba4b3887ab')
+        .select((eb2) => [
+          'table_0b5ac72e03509e06683edcba4b3887ab.id',
+          jsonArrayFrom(
+            eb2
+              .selectFrom('table_1474a7e0348b1ca363ee4a2a5dc4a1ec')
+              .select('table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id')
+              .whereRef(
+                'table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id',
+                '=',
+                'table_0b5ac72e03509e06683edcba4b3887ab.id',
+              ),
+          ).as('inner'),
+        ])
+        .whereRef(
+          'table_0b5ac72e03509e06683edcba4b3887ab.id',
+          '=',
+          'my_table.id',
+        ),
+    ).as('rels'),
+  ])
+}).types([2662, 'instantiations'])
+
+bench('jsonBuildObject(refs)', () => {
+  return kysely.selectFrom('my_table').select((eb) => [
+    'my_table.id',
+    jsonBuildObject({
+      a: eb.ref('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+      b: eb.ref('my_table.col_4f84013a8b5e4c2b7529058c8fafcaa8'),
+    }).as('obj'),
+  ])
+}).types([1578, 'instantiations'])

--- a/test/typings/test-d/generic.test-d.ts
+++ b/test/typings/test-d/generic.test-d.ts
@@ -1,4 +1,5 @@
 import type {
+  ControlledTransaction,
   Kysely,
   ExpressionBuilder,
   SelectQueryBuilder,
@@ -6,17 +7,22 @@ import type {
   Nullable,
   Selectable,
   SelectType,
+  Transaction,
 } from '../index.js'
 
-import { expectAssignable, expectType } from 'tsd'
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
 import type { Database, Movie, Person } from '../shared.js'
 
 // The tests below relate two different instantiations of the same builder type.
-// TypeScript can't derive variance for `SelectQueryBuilder` or `ExpressionBuilder`
-// (both mention their `DB`/`TB` parameters under `keyof` and in conditional types),
-// so it has to compare them structurally, member by member. That makes these the
-// most expensive type-level operations in the library, so two rules keep them in
-// check - breaking either one is easy to do by accident and expensive:
+//
+// To do that, TypeScript first needs the variance of each type parameter. Nothing
+// declares it, so the compiler measures it: it instantiates the type twice with
+// synthetic marker types and relates the two results structurally, member by
+// member. For these builders that measurement comes back "unreliable" - they
+// mention their `DB`/`TB` parameters under `keyof` and in conditional types - so
+// every comparison then *also* falls back to the same structural walk. That makes
+// these the most expensive type-level operations in the library, and three rules
+// keep them in check. Breaking any of them is easy to do by accident, and expensive:
 //
 //   1. A method that accepts a `DB`/`TB`-parameterized expression type must keep it
 //      behind a generic type parameter (`limit<VE extends ValueExpression<...>>(v: VE)`,
@@ -32,7 +38,14 @@ import type { Database, Movie, Person } from '../shared.js'
 //      result types guard against this with `TableExpression<DB, TB> extends TE`, and
 //      `UpdateQueryBuilder.$if`/`DeleteQueryBuilder.$if` with `unknown extends O2`.
 //
-// Note that such a guard is only worth adding where it *replaces* a conditional that
+//   3. A type that is only ever related at a single `DB` should declare its variance
+//      instead, with an `in out` annotation. That skips the measurement entirely, and
+//      with it the recursion - it is what makes relating two `Kysely` types free. This
+//      is only available to types that don't need the structural fallback: the query
+//      builders let a wider builder stand in for a narrower one (the first tests
+//      below), which is bivariance, and bivariance can't be spelled as an annotation.
+//
+// Note that a rule 2 guard is only worth adding where it *replaces* a conditional that
 // would otherwise expand into a union of builders. Adding one to a result type that is
 // already a single type makes things dramatically worse, because the guard is itself a
 // conditional - it was measured at 15x on `Kysely.$extendTables` and friends. Not every
@@ -80,6 +93,39 @@ function testExpressionBuilderExtendsFuncArg() {
 
   const t2 = {} as T2
   test(t2)
+}
+
+// `Kysely` and the transaction types declare `DB` as `in out` (rule 3 above).
+function testKyselyAssignability() {
+  type A = { a: number }
+  type B = { b: string }
+
+  // Written out a second time on purpose: an identical *type* short-circuits the
+  // whole comparison, so it wouldn't test anything. Two separately written but
+  // mutually assignable databases is the case that has to go through variance.
+  const db = {} as Kysely<{ a: A; b: B }>
+  const trx = {} as Transaction<{ a: A; b: B }>
+  const controlled = {} as ControlledTransaction<{ a: A; b: B }>
+
+  expectAssignable<Kysely<{ a: { a: number }; b: { b: string } }>>(db)
+
+  // A transaction can stand in for a `Kysely`, but not the other way around.
+  expectAssignable<Kysely<{ a: A; b: B }>>(trx)
+  expectAssignable<Kysely<{ a: A; b: B }>>(controlled)
+  expectAssignable<Transaction<{ a: A; b: B }>>(controlled)
+  expectNotAssignable<Transaction<{ a: A; b: B }>>(db)
+
+  // A `Kysely` over a *different* database is not interchangeable, in either
+  // direction. Use `$omitTables`/`$pickTables`/`$extendTables` to change it.
+  //
+  // Both of these used to be allowed, but only because the compiler didn't trust
+  // the variance it had measured and fell back to comparing the two structurally,
+  // where the methods match bivariantly. It was never a variance the library could
+  // have declared - TypeScript rejects `out DB` on `Kysely` with TS2636 - and the
+  // second one is unsound: it hands you a `Kysely` typed with a table the
+  // underlying database doesn't have.
+  expectNotAssignable<Kysely<{ a: A }>>(db)
+  expectNotAssignable<Kysely<{ a: A; b: B }>>({} as Kysely<{ a: A }>)
 }
 
 async function testGenericSelectHelper() {

--- a/test/typings/test-d/if.test-d.ts
+++ b/test/typings/test-d/if.test-d.ts
@@ -5,7 +5,7 @@ import type {
   DeleteResult,
 } from '../index.js'
 import type { Database } from '../shared.js'
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 
 async function testIfInSelect(db: Kysely<Database>) {
   const condition = Math.random() < 0.5
@@ -60,6 +60,43 @@ async function testIfInSelect(db: Kysely<Database>) {
     .execute()
 
   expectType<{ species: 'dog' | 'cat'; person_age?: number | null }>(r5)
+}
+
+// The callback's return type is declared as `SelectQueryBuilderExpression` for
+// type-checking performance, so pin down that it still only accepts a select
+// query builder.
+function testIfInSelectCallbackReturnType(db: Kysely<Database>) {
+  const condition = Math.random() < 0.5
+
+  expectError(db.selectFrom('pet').select('species').$if(condition, () => 42))
+
+  expectError(
+    db
+      .selectFrom('pet')
+      .select('species')
+      .$if(condition, () => {}),
+  )
+
+  expectError(
+    db
+      .selectFrom('pet')
+      .select('species')
+      .$if(condition, () =>
+        db.insertInto('person').values({
+          first_name: 'Foo',
+          last_name: 'Bar',
+          gender: 'other',
+          age: 0,
+        }),
+      ),
+  )
+
+  expectError(
+    db
+      .selectFrom('pet')
+      .select('species')
+      .$if(condition, (qb) => qb.select('no_such_column')),
+  )
 }
 
 async function testIfInInsert(db: Kysely<Database>) {

--- a/test/typings/test-d/readonly.test-d.ts
+++ b/test/typings/test-d/readonly.test-d.ts
@@ -2,6 +2,7 @@ import {
   expectAssignable,
   expectDeprecated,
   expectError,
+  expectNotAssignable,
   expectNotDeprecated,
   expectType,
 } from 'tsd'
@@ -25,6 +26,7 @@ import {
   type ReadonlyQueryResult,
   type ReadonlyTransaction,
   type ReadonlyTransactionBuilder,
+  type ReadonlyTransactionMethods,
   type Selectable,
   SelectQueryNode,
   type Transaction,
@@ -336,7 +338,7 @@ async function testReadonlyTransaction(
   expectType<typeof tx.case>(rtx.case)
   expectNotDeprecated(rtx.case)
 
-  expectType<typeof tx.connection>(rtx.connection)
+  expectType<Disabled<'connection'>>(rtx.connection)
   expectDeprecated(rtx.connection)
 
   expectType<NotAllowed>(rtx.deleteFrom)
@@ -384,10 +386,10 @@ async function testReadonlyTransaction(
   expectType<typeof tx.selectNoFrom>(rtx.selectNoFrom)
   expectNotDeprecated(rtx.selectNoFrom)
 
-  expectType<typeof tx.startTransaction>(rtx.startTransaction)
+  expectType<Disabled<'startTransaction'>>(rtx.startTransaction)
   expectDeprecated(rtx.startTransaction)
 
-  expectType<typeof tx.transaction>(rtx.transaction)
+  expectType<Disabled<'transaction'>>(rtx.transaction)
   expectDeprecated(rtx.transaction)
 
   expectType<NotAllowed>(rtx.updateTable)
@@ -410,6 +412,25 @@ async function testReadonlyTransaction(
 
   expectType<typeof rtx>(rtx.withoutPlugins())
   expectNotDeprecated(rtx.withoutPlugins)
+}
+
+// `ReadonlyTransaction` and `ReadonlyControlledTransaction` are intersections
+// that contain a `ReadonlyKysely<DB>`, which is what lets the compiler relate
+// them to one without walking either type. These are the assignments that shape
+// buys, so they're worth pinning.
+function testReadonlyTransactionAssignability(
+  rdb: ReadonlyKysely<Database>,
+  rtx: ReadonlyTransaction<Database>,
+  rctx: ReadonlyControlledTransaction<Database>,
+) {
+  expectAssignable<ReadonlyKysely<Database>>(rtx)
+  expectAssignable<ReadonlyKysely<Database>>(rctx)
+  expectAssignable<ReadonlyTransaction<Database>>(rctx)
+
+  // `isTransaction` is `true` rather than `boolean` to keep this one direction
+  // only - a plain read-only Kysely is not a transaction.
+  expectNotAssignable<ReadonlyTransaction<Database>>(rdb)
+  expectNotAssignable<ReadonlyControlledTransaction<Database>>(rtx)
 }
 
 async function testReadonlyControlledTransaction(
@@ -456,7 +477,7 @@ async function testReadonlyControlledTransaction(
   expectType<typeof tx.commit>(rtx.commit)
   expectNotDeprecated(rtx.commit)
 
-  expectType<typeof tx.connection>(rtx.connection)
+  expectType<Disabled<'connection'>>(rtx.connection)
   expectDeprecated(rtx.connection)
 
   expectType<NotAllowed>(rtx.deleteFrom)
@@ -552,10 +573,10 @@ async function testReadonlyControlledTransaction(
   expectType<typeof tx.selectNoFrom>(rtx.selectNoFrom)
   expectNotDeprecated(rtx.selectNoFrom)
 
-  expectType<typeof tx.startTransaction>(rtx.startTransaction)
+  expectType<Disabled<'startTransaction'>>(rtx.startTransaction)
   expectDeprecated(rtx.startTransaction)
 
-  expectType<typeof tx.transaction>(rtx.transaction)
+  expectType<Disabled<'transaction'>>(rtx.transaction)
   expectDeprecated(rtx.transaction)
 
   expectType<NotAllowed>(rtx.updateTable)
@@ -588,6 +609,15 @@ type DatabaseOf<K> = K extends Kysely<infer DB> ? DB : never
 
 type SavepointsOf<T> =
   T extends ControlledTransactionMethods<any, infer S> ? S : never
+
+// The members a transaction doesn't support are an overload set, because
+// `ReadonlyTransaction` is an intersection: the `never` overload from
+// `ReadonlyTransactionMethods` comes first and is the one calls resolve to, and
+// the one `ReadonlyKysely` declares follows it.
+type Disabled<
+  K extends keyof ReadonlyTransactionMethods<Database> &
+    keyof ReadonlyKysely<Database>,
+> = ReadonlyTransactionMethods<Database>[K] & ReadonlyKysely<Database>[K]
 
 declare function keyof<T>(thing: T): keyof T & string
 

--- a/test/typings/test-d/readonly.test-d.ts
+++ b/test/typings/test-d/readonly.test-d.ts
@@ -10,6 +10,7 @@ import {
   type AbortableOperationOptions,
   type ControlledTransaction,
   type ControlledTransactionBuilder,
+  type ControlledTransactionMethods,
   createQueryId,
   DeleteQueryNode,
   type InferResult,
@@ -421,14 +422,14 @@ async function testReadonlyControlledTransaction(
     | (keyof typeof tx & string)
   >(keyof(rtx))
 
+  // The table helpers only change the database, so the open savepoints are
+  // still the ones `tx` was declared with.
   expectType<
     ReadonlyControlledTransaction<
       DatabaseOf<
         ReturnType<typeof tx.$extendTables<{ moshe: { haim: true } }>>
       >,
-      SavepointsOf<
-        ReturnType<typeof tx.$extendTables<{ moshe: { haim: true } }>>
-      >
+      ['haim', 'moshe']
     >
   >(rtx.$extendTables<{ moshe: { haim: true } }>())
   expectNotDeprecated(rtx.$extendTables)
@@ -436,7 +437,7 @@ async function testReadonlyControlledTransaction(
   expectType<
     ReadonlyControlledTransaction<
       DatabaseOf<ReturnType<typeof tx.$omitTables<'person_metadata'>>>,
-      SavepointsOf<ReturnType<typeof tx.$omitTables<'person_metadata'>>>
+      ['haim', 'moshe']
     >
   >(rtx.$omitTables<'person_metadata'>())
   expectNotDeprecated(rtx.$omitTables)
@@ -444,7 +445,7 @@ async function testReadonlyControlledTransaction(
   expectType<
     ReadonlyControlledTransaction<
       DatabaseOf<ReturnType<typeof tx.$pickTables<'person_metadata'>>>,
-      SavepointsOf<ReturnType<typeof tx.$pickTables<'person_metadata'>>>
+      ['haim', 'moshe']
     >
   >(rtx.$pickTables<'person_metadata'>())
   expectNotDeprecated(rtx.$pickTables)
@@ -497,11 +498,7 @@ async function testReadonlyControlledTransaction(
 
   expectType<
     ReadonlyControlledTransaction<
-      DatabaseOf<
-        Awaited<
-          ReturnType<ReturnType<typeof tx.releaseSavepoint<'moshe'>>['execute']>
-        >
-      >,
+      Database,
       SavepointsOf<
         Awaited<
           ReturnType<ReturnType<typeof tx.releaseSavepoint<'moshe'>>['execute']>
@@ -520,13 +517,7 @@ async function testReadonlyControlledTransaction(
 
   expectType<
     ReadonlyControlledTransaction<
-      DatabaseOf<
-        Awaited<
-          ReturnType<
-            ReturnType<typeof tx.rollbackToSavepoint<'haim'>>['execute']
-          >
-        >
-      >,
+      Database,
       SavepointsOf<
         Awaited<
           ReturnType<
@@ -541,9 +532,7 @@ async function testReadonlyControlledTransaction(
 
   expectType<
     ReadonlyControlledTransaction<
-      DatabaseOf<
-        Awaited<ReturnType<ReturnType<typeof tx.savepoint<'rivka'>>['execute']>>
-      >,
+      Database,
       SavepointsOf<
         Awaited<ReturnType<ReturnType<typeof tx.savepoint<'rivka'>>['execute']>>
       >
@@ -591,14 +580,14 @@ async function testReadonlyControlledTransaction(
   expectNotDeprecated(rtx.withoutPlugins)
 }
 
-type DatabaseOf<K> = K extends
-  | Kysely<infer DB>
-  | Transaction<infer DB>
-  | ControlledTransaction<infer DB, any>
-  ? DB
-  : never
+// `Transaction` and `ControlledTransaction` are intersections, and TypeScript
+// can't infer type arguments from an intersection. Both of them contain a
+// `Kysely<DB>` to infer the database from, and the open savepoints can be
+// inferred from `ControlledTransactionMethods`.
+type DatabaseOf<K> = K extends Kysely<infer DB> ? DB : never
 
-type SavepointsOf<T> = T extends ControlledTransaction<any, infer S> ? S : never
+type SavepointsOf<T> =
+  T extends ControlledTransactionMethods<any, infer S> ? S : never
 
 declare function keyof<T>(thing: T): keyof T & string
 


### PR DESCRIPTION
Significantly speed up `SelectQueryBuilder.if` type checking.

This PR also adds type benchmarks for various commonly used kysely queries.

I tasked an LLM to go through the biggest libraries' codebases that use Kysely and identify most common patterns. According to that analysis, `$if` appears everywhere.

It had kinda stupid types, that required a full `SelectQueryBuilder` comparison for each $if.

This is on top of #1962.