### PR TITLE
Speed up SelectQueryBuilder.if type checking

### DIFF
--- a/src/query-builder/select-query-builder.ts
+++ b/src/query-builder/select-query-builder.ts
@@ -1847,7 +1847,7 @@ export interface SelectQueryBuilder<DB, TB extends keyof DB, O>
    */
   $if<O2>(
     condition: boolean,
-    func: (qb: this) => SelectQueryBuilder<any, any, O & O2>,
+    func: (qb: this) => SelectQueryBuilderExpression<O & O2>,
   ): SelectQueryBuilder<DB, TB, O & Partial<Omit<O2, keyof O>>>
 
   /**
@@ -2589,10 +2589,10 @@ class SelectQueryBuilderImpl<
 
   $if<O2>(
     condition: boolean,
-    func: (qb: this) => SelectQueryBuilder<any, any, O & O2>,
+    func: (qb: this) => SelectQueryBuilderExpression<O & O2>,
   ): SelectQueryBuilder<DB, TB, O & Partial<Omit<O2, keyof O>>> {
     if (condition) {
-      return func(this)
+      return func(this) as any
     }
 
     return new SelectQueryBuilderImpl({

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -4,6 +4,7 @@ import type {
   DeleteQueryBuilder,
   ExpressionBuilder,
   Generated,
+  InsertQueryBuilder,
   Kysely,
   MergeQueryBuilder,
   Nullable,
@@ -75,6 +76,15 @@ declare const wideDeleteQueryBuilder: DeleteQueryBuilder<
 >
 declare function acceptsNarrowDeleteQueryBuilder(
   qb: DeleteQueryBuilder<{ a: A; b: B }, 'a', unknown>,
+): void
+
+declare const wideInsertQueryBuilder: InsertQueryBuilder<
+  { a: A; b: B },
+  'a',
+  { a: number }
+>
+declare function acceptsNarrowInsertQueryBuilder(
+  qb: InsertQueryBuilder<{ a: A; b: B }, 'a', unknown>,
 ): void
 
 declare const wideUpdateQueryBuilder: UpdateQueryBuilder<
@@ -163,6 +173,10 @@ bench('select(genericSelectHelper) on a left joined query', () => {
 bench('DeleteQueryBuilder assignable to narrower DeleteQueryBuilder', () => {
   return acceptsNarrowDeleteQueryBuilder(wideDeleteQueryBuilder)
 }).types([10919, 'instantiations'])
+
+bench('InsertQueryBuilder assignable to narrower InsertQueryBuilder', () => {
+  return acceptsNarrowInsertQueryBuilder(wideInsertQueryBuilder)
+}).types([2614, 'instantiations'])
 
 bench('UpdateQueryBuilder assignable to narrower UpdateQueryBuilder', () => {
   return acceptsNarrowUpdateQueryBuilder(wideUpdateQueryBuilder)

--- a/test/ts-benchmarks/if.bench.ts
+++ b/test/ts-benchmarks/if.bench.ts
@@ -1,0 +1,102 @@
+import { bench } from '@ark/attest'
+import type { DB } from '../typings/test-d/huge-db.test-d.js'
+import type { Kysely } from '../../dist/index.js'
+
+// `$if` is how conditional filters, optional selections and optional joins get
+// built in application code, so it tends to appear in every non-trivial query.
+//
+// Each of these numbers includes the one-time cost of relating two
+// instantiations of the builder under test, because that is what a `$if` call
+// site makes the compiler do: it has to match the callback's return type
+// against the builder type in the signature. Keep the callback return types
+// pointed at the smallest interface that still identifies the builder - see the
+// comment on `SelectQueryBuilder.$if`.
+
+declare const kysely: Kysely<DB>
+declare const condition: boolean
+
+console.log('if.bench.ts:\n')
+
+bench.baseline(() => {})
+
+bench('kysely..select..$if(qb => qb.select(column))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$if(condition, (qb) =>
+      qb.select('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+}).types([7027, 'instantiations'])
+
+bench('kysely..select..$if(qb => qb.where(...))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$if(condition, (qb) =>
+      qb.where('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 1),
+    )
+}).types([3509, 'instantiations'])
+
+bench('kysely..select..$if(qb => qb.innerJoin(...))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$if(condition, (qb) =>
+      qb.innerJoin(
+        'table_0b5ac72e03509e06683edcba4b3887ab',
+        'table_0b5ac72e03509e06683edcba4b3887ab.id',
+        'my_table.id',
+      ),
+    )
+}).types([8742, 'instantiations'])
+
+bench('kysely..select..$if x3', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$if(condition, (qb) =>
+      qb.where('my_table.col_1d726898491fbca9a8dac855d2be1be8', '=', 1),
+    )
+    .$if(condition, (qb) =>
+      qb.select('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+    .$if(condition, (qb) =>
+      qb.select('my_table.col_4f84013a8b5e4c2b7529058c8fafcaa8'),
+    )
+}).types([10196, 'instantiations'])
+
+bench('kysely..update..$if(qb => qb.returning(column))', () => {
+  return kysely
+    .updateTable('my_table')
+    .set('my_table.col_2e66a5c7e24d1d066230f368ce8b094e', 'x')
+    .returning('my_table.id')
+    .$if(condition, (qb) =>
+      qb.returning('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+}).types([27600, 'instantiations'])
+
+bench('kysely..delete..$if(qb => qb.returning(column))', () => {
+  return kysely
+    .deleteFrom('my_table')
+    .returning('my_table.id')
+    .$if(condition, (qb) =>
+      qb.returning('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+}).types([12710, 'instantiations'])
+
+bench('kysely..insert..$if(qb => qb.returning(column))', () => {
+  return kysely
+    .insertInto('my_table')
+    .defaultValues()
+    .returning('my_table.id')
+    .$if(condition, (qb) =>
+      qb.returning('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+    )
+}).types([4083, 'instantiations'])
+
+bench('kysely..$call(qb => qb.select(column))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select('my_table.id')
+    .$call((qb) => qb.select('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'))
+}).types([968, 'instantiations'])

--- a/test/ts-benchmarks/insert-values.bench.ts
+++ b/test/ts-benchmarks/insert-values.bench.ts
@@ -1,0 +1,125 @@
+import { bench } from '@ark/attest'
+import type { DB } from '../typings/test-d/huge-db.test-d.js'
+import type { Kysely } from '../../dist/index.js'
+
+// `insert-into.bench.ts` only covers picking the table. These cover the parts
+// that carry data - the values themselves, upserts and `set` - which is where a
+// row type gets matched against the table's insertable columns. Bulk inserts
+// are worth watching in particular: the cost should stay flat in the number of
+// rows, since every row is checked against the same type.
+
+declare const kysely: Kysely<DB>
+declare const kyselyAny: Kysely<any>
+
+const row = {
+  col_1d726898491fbca9a8dac855d2be1be8: 1,
+  col_2e66a5c7e24d1d066230f368ce8b094e: 'a',
+  col_2f76db193eac6ad0f152563313673ac9: new Date(),
+  col_4f84013a8b5e4c2b7529058c8fafcaa8: 'b',
+  col_d2508118d0d39e198d1129d87d692d59: new Date(),
+  col_454ff479a3b5a9ef082d9be9ac02a6f4: 'c',
+  col_3917508388f24a50271f7088b657123c: 'd',
+}
+
+declare const rows: (typeof row)[]
+
+console.log('insert-values.bench.ts:\n')
+
+bench.baseline(() => {
+  return kysely.insertInto('my_table')
+})
+
+bench('kysely.insertInto(table).values(row)', () => {
+  return kysely.insertInto('my_table').values(row)
+}).types([1038, 'instantiations'])
+
+bench('kysely.insertInto(table).values(~row)', () => {
+  // @ts-expect-error
+  return kysely.insertInto('my_table').values({ ...row, no_such_column: 1 })
+}).types([1171, 'instantiations'])
+
+bench('kysely.insertInto(table).values([row])', () => {
+  return kysely.insertInto('my_table').values([row])
+}).types([1047, 'instantiations'])
+
+bench('kysely.insertInto(table).values([row x5])', () => {
+  return kysely.insertInto('my_table').values([row, row, row, row, row])
+}).types([1047, 'instantiations'])
+
+bench('kysely.insertInto(table).values([row x10])', () => {
+  return kysely
+    .insertInto('my_table')
+    .values([row, row, row, row, row, row, row, row, row, row])
+}).types([1047, 'instantiations'])
+
+bench('kysely.insertInto(table).values(row[])', () => {
+  return kysely.insertInto('my_table').values(rows)
+}).types([1045, 'instantiations'])
+
+bench('kysely.insertInto(table).values(eb => row)', () => {
+  return kysely.insertInto('my_table').values((eb) => ({
+    ...row,
+    col_1d726898491fbca9a8dac855d2be1be8: eb
+      .selectFrom('my_table as t2')
+      .select('t2.col_1d726898491fbca9a8dac855d2be1be8')
+      .limit(1),
+  }))
+}).types([2522, 'instantiations'])
+
+bench('kysely..onConflict(oc => oc.column(column).doNothing())', () => {
+  return kysely
+    .insertInto('my_table')
+    .values(row)
+    .onConflict((oc) =>
+      oc.column('col_1d726898491fbca9a8dac855d2be1be8').doNothing(),
+    )
+}).types([1102, 'instantiations'])
+
+bench('kysely..onConflict(oc => oc.column(column).doUpdateSet(row))', () => {
+  return kysely
+    .insertInto('my_table')
+    .values(row)
+    .onConflict((oc) =>
+      oc.column('col_1d726898491fbca9a8dac855d2be1be8').doUpdateSet(row),
+    )
+}).types([2131, 'instantiations'])
+
+bench('kysely..onConflict(oc => oc..doUpdateSet(eb => excluded ref))', () => {
+  return kysely
+    .insertInto('my_table')
+    .values(row)
+    .onConflict((oc) =>
+      oc.column('col_1d726898491fbca9a8dac855d2be1be8').doUpdateSet({
+        col_2e66a5c7e24d1d066230f368ce8b094e: (eb) =>
+          eb.ref('excluded.col_2e66a5c7e24d1d066230f368ce8b094e'),
+      }),
+    )
+}).types([4458, 'instantiations'])
+
+bench('kysely.updateTable(table).set(row)', () => {
+  return kysely.updateTable('my_table').set(row)
+}).types([848, 'instantiations'])
+
+bench('kysely.updateTable(table).set(column, value)', () => {
+  return kysely
+    .updateTable('my_table')
+    .set('my_table.col_2e66a5c7e24d1d066230f368ce8b094e', 'x')
+}).types([3078, 'instantiations'])
+
+bench('kysely.updateTable(table).set(eb => row)', () => {
+  return kysely.updateTable('my_table').set((eb) => ({
+    col_1d726898491fbca9a8dac855d2be1be8: eb(
+      'col_1d726898491fbca9a8dac855d2be1be8',
+      '+',
+      1,
+    ),
+  }))
+}).types([3520, 'instantiations'])
+
+bench('kyselyAny.insertInto(table).values(row)', () => {
+  return kyselyAny.insertInto('my_table').values(row)
+}).types([421, 'instantiations'])
+
+bench('kyselyAny.updateTable(table).set(row)', () => {
+  return kyselyAny.updateTable('my_table').set(row)
+}).types([333, 'instantiations'])

--- a/test/ts-benchmarks/json-helpers.bench.ts
+++ b/test/ts-benchmarks/json-helpers.bench.ts
@@ -1,0 +1,141 @@
+import { bench } from '@ark/attest'
+import type { DB } from '../typings/test-d/huge-db.test-d.js'
+import type { Kysely } from '../../dist/index.js'
+import {
+  jsonArrayFrom,
+  jsonBuildObject,
+  jsonObjectFrom,
+} from '../../dist/helpers/postgres.js'
+
+// Kysely has no relations, so `jsonArrayFrom` / `jsonObjectFrom` are how
+// applications load nested data. They show up once per relation, and queries
+// routinely nest them two or three deep, which makes them one of the most
+// repeated type-level operations in a real codebase.
+
+declare const kysely: Kysely<DB>
+
+console.log('json-helpers.bench.ts:\n')
+
+bench.baseline(() => {
+  return kysely.selectFrom('my_table')
+})
+
+bench('jsonArrayFrom(subquery.select(column))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select((eb) => [
+      'my_table.id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('table_0b5ac72e03509e06683edcba4b3887ab')
+          .select('table_0b5ac72e03509e06683edcba4b3887ab.id')
+          .whereRef(
+            'table_0b5ac72e03509e06683edcba4b3887ab.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rels'),
+    ])
+}).types([1622, 'instantiations'])
+
+bench('jsonArrayFrom(subquery.selectAll(table))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select((eb) => [
+      'my_table.id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('table_0b5ac72e03509e06683edcba4b3887ab')
+          .selectAll('table_0b5ac72e03509e06683edcba4b3887ab')
+          .whereRef(
+            'table_0b5ac72e03509e06683edcba4b3887ab.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rels'),
+    ])
+}).types([2070, 'instantiations'])
+
+bench('jsonObjectFrom(subquery.select(column))', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select((eb) => [
+      'my_table.id',
+      jsonObjectFrom(
+        eb
+          .selectFrom('table_1474a7e0348b1ca363ee4a2a5dc4a1ec')
+          .select('table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id')
+          .whereRef(
+            'table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rel'),
+    ])
+}).types([1526, 'instantiations'])
+
+bench('jsonArrayFrom + jsonObjectFrom in one select', () => {
+  return kysely
+    .selectFrom('my_table')
+    .select((eb) => [
+      'my_table.id',
+      jsonArrayFrom(
+        eb
+          .selectFrom('table_0b5ac72e03509e06683edcba4b3887ab')
+          .select('table_0b5ac72e03509e06683edcba4b3887ab.id')
+          .whereRef(
+            'table_0b5ac72e03509e06683edcba4b3887ab.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rels'),
+      jsonObjectFrom(
+        eb
+          .selectFrom('table_1474a7e0348b1ca363ee4a2a5dc4a1ec')
+          .select('table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id')
+          .whereRef(
+            'table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id',
+            '=',
+            'my_table.id',
+          ),
+      ).as('rel'),
+    ])
+}).types([2688, 'instantiations'])
+
+bench('jsonArrayFrom nested two deep', () => {
+  return kysely.selectFrom('my_table').select((eb) => [
+    'my_table.id',
+    jsonArrayFrom(
+      eb
+        .selectFrom('table_0b5ac72e03509e06683edcba4b3887ab')
+        .select((eb2) => [
+          'table_0b5ac72e03509e06683edcba4b3887ab.id',
+          jsonArrayFrom(
+            eb2
+              .selectFrom('table_1474a7e0348b1ca363ee4a2a5dc4a1ec')
+              .select('table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id')
+              .whereRef(
+                'table_1474a7e0348b1ca363ee4a2a5dc4a1ec.id',
+                '=',
+                'table_0b5ac72e03509e06683edcba4b3887ab.id',
+              ),
+          ).as('inner'),
+        ])
+        .whereRef(
+          'table_0b5ac72e03509e06683edcba4b3887ab.id',
+          '=',
+          'my_table.id',
+        ),
+    ).as('rels'),
+  ])
+}).types([2662, 'instantiations'])
+
+bench('jsonBuildObject(refs)', () => {
+  return kysely.selectFrom('my_table').select((eb) => [
+    'my_table.id',
+    jsonBuildObject({
+      a: eb.ref('my_table.col_2e66a5c7e24d1d066230f368ce8b094e'),
+      b: eb.ref('my_table.col_4f84013a8b5e4c2b7529058c8fafcaa8'),
+    }).as('obj'),
+  ])
+}).types([1578, 'instantiations'])

--- a/test/typings/test-d/if.test-d.ts
+++ b/test/typings/test-d/if.test-d.ts
@@ -5,7 +5,7 @@ import type {
   DeleteResult,
 } from '../index.js'
 import type { Database } from '../shared.js'
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 
 async function testIfInSelect(db: Kysely<Database>) {
   const condition = Math.random() < 0.5
@@ -60,6 +60,43 @@ async function testIfInSelect(db: Kysely<Database>) {
     .execute()
 
   expectType<{ species: 'dog' | 'cat'; person_age?: number | null }>(r5)
+}
+
+// The callback's return type is declared as `SelectQueryBuilderExpression` for
+// type-checking performance, so pin down that it still only accepts a select
+// query builder.
+function testIfInSelectCallbackReturnType(db: Kysely<Database>) {
+  const condition = Math.random() < 0.5
+
+  expectError(db.selectFrom('pet').select('species').$if(condition, () => 42))
+
+  expectError(
+    db
+      .selectFrom('pet')
+      .select('species')
+      .$if(condition, () => {}),
+  )
+
+  expectError(
+    db
+      .selectFrom('pet')
+      .select('species')
+      .$if(condition, () =>
+        db.insertInto('person').values({
+          first_name: 'Foo',
+          last_name: 'Bar',
+          gender: 'other',
+          age: 0,
+        }),
+      ),
+  )
+
+  expectError(
+    db
+      .selectFrom('pet')
+      .select('species')
+      .$if(condition, (qb) => qb.select('no_such_column')),
+  )
 }
 
 async function testIfInInsert(db: Kysely<Database>) {


### PR DESCRIPTION
Significantly speed up SelectQueryBuilder.if type checking.

It had kinda stupid types, that required a full SelectQueryBuilder comparison for each $if.

This PR also adds type benchmarks for various commonly used kysely queries.

This is on top of https://github.com/kysely-org/kysely/pull/1962.