### PR TITLE
fix `ControlledTransaction<infer DB, any>` inferring `DB` as `string`

### DIFF
--- a/src/parser/savepoint-parser.ts
+++ b/src/parser/savepoint-parser.ts
@@ -10,14 +10,20 @@ export type RollbackToSavepoint<
     : RollbackToSavepoint<L extends string[] ? L : never, SN>
   : never
 
+// `0 extends 1 & S` is only true when `S` is `any`. That happens in patterns
+// like `T extends ControlledTransaction<infer DB, any>`. Without this
+// short-circuit, the recursion below leaks a bogus `string` inference
+// candidate into `infer DB` through `releaseSavepoint`'s return type.
 export type ReleaseSavepoint<
   S extends string[],
   SN extends S[number],
-> = S extends [...infer L, infer R]
-  ? R extends SN
-    ? L
-    : ReleaseSavepoint<L extends string[] ? L : never, SN>
-  : never
+> = 0 extends 1 & S
+  ? string[]
+  : S extends [...infer L, infer R]
+    ? R extends SN
+      ? L
+      : ReleaseSavepoint<L extends string[] ? L : never, SN>
+    : never
 
 export function parseSavepointCommand(
   command: string,

--- a/test/ts-benchmarks/generic.bench.ts
+++ b/test/ts-benchmarks/generic.bench.ts
@@ -174,4 +174,4 @@ bench('ControlledTransaction assignable to Kysely', () => {
 
 bench('ControlledTransaction assignable to Transaction', () => {
   return acceptsTransaction(controlledTransaction)
-}).types([330097, 'instantiations'])
+}).types([155377, 'instantiations'])

--- a/test/typings/test-d/controlled-transaction.test-d.ts
+++ b/test/typings/test-d/controlled-transaction.test-d.ts
@@ -1,0 +1,75 @@
+import { expectError, expectType } from 'tsd'
+import type { Database } from '../shared.js'
+import type {
+  Command,
+  ControlledTransaction,
+  Transaction,
+} from '../index.js'
+
+async function testSavepoint(
+  tx: ControlledTransaction<Database, ['sp1', 'sp2']>,
+) {
+  // creating a savepoint appends its name to the list of open savepoints.
+  expectType<Command<ControlledTransaction<Database, ['sp1', 'sp2', 'sp3']>>>(
+    tx.savepoint('sp3'),
+  )
+}
+
+async function testRollbackToSavepoint(
+  tx: ControlledTransaction<Database, ['sp1', 'sp2']>,
+) {
+  // rolling back to a savepoint keeps it open and discards the ones created
+  // after it.
+  expectType<Command<ControlledTransaction<Database, ['sp1', 'sp2']>>>(
+    tx.rollbackToSavepoint('sp2'),
+  )
+  expectType<Command<ControlledTransaction<Database, ['sp1']>>>(
+    tx.rollbackToSavepoint('sp1'),
+  )
+
+  // only open savepoints can be rolled back to.
+  expectError(tx.rollbackToSavepoint('nope'))
+}
+
+async function testReleaseSavepoint(
+  tx: ControlledTransaction<Database, ['sp1', 'sp2']>,
+) {
+  // releasing a savepoint removes it and the ones created after it.
+  expectType<Command<ControlledTransaction<Database, ['sp1']>>>(
+    tx.releaseSavepoint('sp2'),
+  )
+  expectType<Command<ControlledTransaction<Database, []>>>(
+    tx.releaseSavepoint('sp1'),
+  )
+
+  // only open savepoints can be released.
+  expectError(tx.releaseSavepoint('nope'))
+
+  // when the savepoint list is `any`, the released list degrades to
+  // `string[]` instead of leaking bogus inference candidates. see #1967.
+  const anyTx = tx as ControlledTransaction<Database, any>
+  expectType<Command<ControlledTransaction<Database, string[]>>>(
+    anyTx.releaseSavepoint('whatever'),
+  )
+}
+
+// #1967: matching `ControlledTransaction<infer DB, any>` used to silently
+// infer `DB` as `string` because of `releaseSavepoint`'s return type.
+async function testControlledTransactionTypeArgumentInference(
+  tx: ControlledTransaction<Database, ['sp1']>,
+  trx: Transaction<Database>,
+) {
+  type DatabaseOf<T> =
+    T extends ControlledTransaction<infer DB, any> ? DB : never
+  type SavepointsOf<T> =
+    T extends ControlledTransaction<any, infer S> ? S : never
+  type BothOf<T> =
+    T extends ControlledTransaction<infer DB, infer S> ? [DB, S] : never
+  type TransactionDatabaseOf<T> =
+    T extends Transaction<infer DB> ? DB : never
+
+  expectType<Database>(null as unknown as DatabaseOf<typeof tx>)
+  expectType<['sp1']>(null as unknown as SavepointsOf<typeof tx>)
+  expectType<[Database, ['sp1']]>(null as unknown as BothOf<typeof tx>)
+  expectType<Database>(null as unknown as TransactionDatabaseOf<typeof trx>)
+}


### PR DESCRIPTION
Fixes an inference regression introduced by the `Transaction`/`ControlledTransaction` intersection rewrite in this branch, and removes the branch's one remaining perf regression while at it.

**Problem:** `T extends ControlledTransaction<infer DB, any> ? DB : never` silently infers `DB` as `string` instead of the actual database type. The bogus candidate leaks out of `releaseSavepoint`'s return type: with `S` instantiated as `any`, the `ReleaseSavepoint` utility's recursion stays a deferred conditional and poisons structural inference. `RollbackToSavepoint` is immune because its success branch returns `S` rather than the inferred tuple prefix.

**Fix:** short-circuit `ReleaseSavepoint` to `string[]` when `S` is `any` (`0 extends 1 & S` guard).

## Perf

Measured like the table in #1962: `tsc --noEmit --extendedDiagnostics` per assignability case, three runs each. "Before" is this branch's current head (808047a0), "after" adds this commit. Measured with `--skipLibCheck` and a minimal two-table fixture, so instantiation counts isolate the assignability work itself (which is why the cheap cases show tens instead of ~12k).

| Case | TS | Instantiations (before → after) | Check time (before → after) |
|---|---|---|---|
| Kysely assignable to Kysely | 5.9 | 0 → 0 | 10ms → 10ms |
| | 6.0 | 0 → 0 | 10ms → 10ms |
| | 7.0 | 0 → 0 | 1ms → 1ms |
| Transaction assignable to Kysely | 5.9 | 28 → 28 | 10ms → 10ms |
| | 6.0 | 28 → 28 | 10ms → 10ms |
| | 7.0 | 28 → 28 | 1ms → 1ms |
| ControlledTransaction assignable to Kysely | 5.9 | 43 → 43 | 10ms → 10ms |
| | 6.0 | 43 → 43 | 10ms → 10ms |
| | 7.0 | 43 → 43 | 1ms → 1ms |
| ControlledTransaction assignable to Transaction | 5.9 | 313,676 → **139,288** | ~400ms → **~220ms** |
| | 6.0 | 327,643 → **152,953** | ~430ms → **~245ms** |
| | 7.0 | 336,103 → **160,884** | ~141ms → **~68ms** |

The guard halves the `ControlledTransaction` assignable to `Transaction` case because the same deferred conditional that poisoned inference was also doing work during assignability checking. Going by the numbers in #1962, that case is now faster than master's class design (260-290ms on stable TS), so the trade-off flagged there as debatable no longer exists. The ts-benchmark baseline is updated to the new count.

## Verified

`pnpm build`, `pnpm test:typings`, ts-benchmarks (clean, one improved baseline), plus targeted probes for `<infer D, any>`, `<infer D, infer S>`, `<infer D>`, `<infer D, string[]>`, `<any, infer S>` and `ReleaseSavepoint` tuple correctness, on both TypeScript 7.0.2 and 5.4 (oldest supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
