### PR TITLE
Add missing beforeThrow calls in getInflightQueryAbortHandler

### DIFF
--- a/src/util/abort.ts
+++ b/src/util/abort.ts
@@ -61,6 +61,7 @@ export function getInflightQueryAbortHandler(
     const handler = connection.cancelQuery
 
     if (!handler) {
+      beforeThrow()
       throwUnsupportedInflightQueryAbortStrategyError(
         abortStrategy,
         connection.killSession ? 'kill session' : undefined,
@@ -74,6 +75,7 @@ export function getInflightQueryAbortHandler(
     const handler = connection.killSession
 
     if (!handler) {
+      beforeThrow()
       throwUnsupportedInflightQueryAbortStrategyError(
         abortStrategy,
         connection.cancelQuery ? 'cancel query' : undefined,


### PR DESCRIPTION
Fixes a bug where the connection would leak for a dialect that didn't support one of the abort strategies. Discovered while working on https://github.com/kysely-org/kysely-postgres-js/pull/459