### PR TITLE
chore(site): drop self-narrating captions, make proof arrows a standing cue

### DIFF
--- a/site/src/components/DemoVideo.module.css
+++ b/site/src/components/DemoVideo.module.css
@@ -28,11 +28,3 @@
   width: 106.67%;
 }
 
-.caption {
-  color: var(--kl-mut, #9b9b9b);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 12px;
-  letter-spacing: 0.04em;
-  margin-top: 12px;
-  text-align: center;
-}

--- a/site/src/components/DemoVideo.tsx
+++ b/site/src/components/DemoVideo.tsx
@@ -68,9 +68,6 @@ export function DemoVideo() {
           </video>
         )}
       </div>
-      <figcaption className={styles.caption}>
-        real footage: schema-aware autocompletion and inline docs
-      </figcaption>
     </figure>
   )
 }

--- a/site/src/components/SectionQuotes/styles.module.css
+++ b/site/src/components/SectionQuotes/styles.module.css
@@ -83,15 +83,16 @@
   transition: border-color 0.15s ease;
 }
 
+/* Every card links to the source; the corner arrow is the standing cue,
+   faint until intent (same convention as the proof wall). */
 .quoteContainer::after {
-  color: var(--kl-acc);
+  color: var(--kl-faint);
   content: '↗';
   font-size: 11px;
-  opacity: 0;
   position: absolute;
   right: 6px;
   top: 4px;
-  transition: opacity 0.15s ease;
+  transition: color 0.15s ease;
 }
 
 .quoteContainer:hover {
@@ -100,7 +101,7 @@
 }
 
 .quoteContainer:hover::after {
-  opacity: 1;
+  color: var(--kl-acc);
 }
 
 .quoteInnerContainer {

--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -359,26 +359,20 @@ a.stat:hover .statValue {
   text-decoration: none;
 }
 
+/* Every cell links to proof; the corner arrow is the standing cue, faint
+   until intent. */
 .productionNames a:not(.productionCTA)::after {
-  color: var(--kl-acc);
+  color: var(--kl-faint);
   content: '↗';
   font-size: 10px;
-  opacity: 0;
   position: absolute;
   right: 4px;
   top: 2px;
-  transition: opacity 0.15s ease;
+  transition: color 0.15s ease;
 }
 
 .productionNames a:hover::after {
-  opacity: 1;
-}
-
-.productionFootnote {
-  color: var(--kl-faint);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 11px;
-  letter-spacing: 0.04em;
+  color: var(--kl-acc);
 }
 
 .productionNames a.productionCTA {
@@ -476,15 +470,6 @@ a.stat:hover .statValue {
 .editorCode :global(.kl-squiggle) {
   text-decoration: underline wavy var(--kl-err) 1.5px;
   text-underline-offset: 4px;
-}
-
-.editorCaption {
-  color: var(--kl-mut);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 12px;
-  letter-spacing: 0.04em;
-  margin-top: 12px;
-  text-align: center;
 }
 
 .errPanel {

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -366,9 +366,6 @@ function SectionProduction() {
             </span>
           </React.Fragment>
         ))}
-        <span className={styles.productionFootnote}>
-          every logo links to proof
-        </span>
       </div>
     </section>
   )
@@ -410,9 +407,6 @@ function SectionCompiler() {
               <span>{'\'ReferenceExpression<DB, "person">\''}</span>.{' '}
               <span>ts(2345)</span>
             </div>
-          </div>
-          <div className={styles.editorCaption}>
-            actual TypeScript compiler output
           </div>
         </div>
       </div>
@@ -457,7 +451,6 @@ function SectionComposition() {
               }
             </div>
           </div>
-          <div className={styles.editorCaption}>inferred type, verbatim</div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## What

- Removes the three captions under landing figures — "actual TypeScript compiler output", "inferred type, verbatim", and "real footage: schema-aware autocompletion and inline docs" — plus their orphaned CSS. The figures carry their own evidence (real `ts(2345)` output, a real inferred type, a real recording); narrating it reads as authored commentary.
- Replaces the proof wall's "every logo links to proof" footnote with a visual cue on the cells themselves: the corner ↗ (previously hover-only, so effectively invisible) is now always present at the faint token, igniting to the accent on hover. Thirty-five quiet repetitions read as a convention without a sentence saying so. The "+ add your team" CTA stays arrow-free.
- Extends the same standing-arrow convention to the quote cards, which previously had the identical hover-only pattern.

Kept deliberately: the "IN PRODUCTION AT" / "BUILT INTO" group labels (structural, they carry the production-vs-integration distinction) and the stat labels.

## Verification

Checked in-browser on production builds, both themes: figures end cleanly at their panels, arrows render faint across both wall groups and all 109 quote cards, hover ignites per-cell, zero caption elements left in the DOM. Quote card resting color verified equal to the faint token, hover rule to the accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)